### PR TITLE
[#13] Fix for 'Non-resolvable parent POM...'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,4 +50,19 @@
 		</dependency>
      </dependencies>
     </dependencyManagement>
+    <repositories>
+        <repository>
+            <id>repository.spring.snapshot</id>
+            <name>Spring Snapshot Repository</name>
+            <url>http://repo.spring.io/libs-snapshot-local</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>repository.spring.milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>http://repo.spring.io/libs-milestone-local</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
[#13] Fix for 'Non-resolvable parent POM: Could not find artifact org.springframework.cloud:spring-cloud-build:pom:1.0.0.BUILD-SNAPSHOT'
