### PR TITLE
[#17] Main class for spring-cloud-config-server corrected

### DIFF
--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -51,7 +51,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring-cloud.version>${project.version}</spring-cloud.version>
-		<start-class>org.springframework.cloud.config.server.Application</start-class>
+		<start-class>org.springframework.cloud.config.server.ConfigServerApplication</start-class>
 		<java.version>1.7</java.version>
 	</properties>
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerApplication.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerApplication.java
@@ -1,5 +1,6 @@
 package org.springframework.cloud.config.server;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 
@@ -7,5 +8,9 @@ import org.springframework.context.annotation.Configuration;
 @EnableAutoConfiguration
 @EnableConfigServer
 public class ConfigServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServerApplication.class, args);
+    }
 
 }


### PR DESCRIPTION
Fix for #17 'Invalid main class for spring-cloud-config-server'
