### PR TITLE
Add discovery server prefix configuration

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -177,6 +177,7 @@ public class ConfigClientProperties {
 		public static final String DEFAULT_CONFIG_SERVER = "CONFIGSERVER";
 
 		private boolean enabled;
+		private String prefix;
 		private String serviceId = DEFAULT_CONFIG_SERVER;
 
 		public boolean isEnabled() {
@@ -193,6 +194,14 @@ public class ConfigClientProperties {
 
 		public void setServiceId(String serviceId) {
 			this.serviceId = serviceId;
+		}
+
+		public String getPrefix() {
+			return prefix;
+		}
+
+		public void setPrefix(String prefix) {
+			this.prefix = prefix;
 		}
 	}
 


### PR DESCRIPTION
Add prefix property to discovery config.
It is useful to fix the connexion to a prefixed config server with eureka discovery

Related to issue : https://github.com/spring-cloud/spring-cloud-netflix/issues/64
