### PR TITLE
Property to disable configuration server locator

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/bootstrap/config/PropertySourceBootstrapConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
 import org.springframework.cloud.config.client.ConfigClientProperties;
@@ -95,6 +96,7 @@ public class PropertySourceBootstrapConfiguration implements
 	}
 
 	@Configuration
+	@ConditionalOnExpression("${spring.cloud.config.server.enabled:true}")
 	protected static class PropertySourceLocatorConfiguration {
 
 		@Autowired


### PR DESCRIPTION
Introducing `spring.cloud.config.server.enabled` configuration property to disable `ConfigServicePropertySourceLocator`. In our use case we use different locator and we would like to disable this one enabled by default.
