### PR TITLE
Suggestion: add a property to Config Server to allow Git to read sub directories

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/AbstractSCMEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/AbstractSCMEnvironmentRepository.java
@@ -44,6 +44,9 @@ public abstract class AbstractSCMEnvironmentRepository implements EnvironmentRep
 	protected ConfigurableEnvironment environment;
 	protected String username;
 	protected String password;
+	
+	private boolean searchAllFoldersInRoot = false;
+	
 	private String[] searchPaths = new String[0];
 
 	public AbstractSCMEnvironmentRepository(ConfigurableEnvironment environment) {
@@ -90,6 +93,14 @@ public abstract class AbstractSCMEnvironmentRepository implements EnvironmentRep
 	public File getBasedir() {
 		return basedir;
 	}
+	
+	public boolean isSearchAllFoldersInRoot() {
+		return searchAllFoldersInRoot;
+	}
+
+	public void setSearchAllFoldersInRoot(boolean searchAllFoldersInRoot) {
+		this.searchAllFoldersInRoot = searchAllFoldersInRoot;
+	}
 
 	public void setSearchPaths(String... searchPaths) {
 		this.searchPaths = searchPaths;
@@ -130,12 +141,22 @@ public abstract class AbstractSCMEnvironmentRepository implements EnvironmentRep
 	protected String[] getSearchLocations(File dir) {
 		List<String> locations = new ArrayList<String>();
 		locations.add(dir.toURI().toString());
+		
+		if (searchAllFoldersInRoot) {
+			for (File file : dir.listFiles()) {
+				if (file.isDirectory()) {
+					locations.add(file.toURI().toString());
+				}
+			}
+		}
+		
 		for (String path : searchPaths) {
 			File file = new File(getWorkingDirectory(), path);
 			if (file.isDirectory()) {
 				locations.add(file.toURI().toString());
 			}
 		}
+		
 		return locations.toArray(new String[0]);
 	}
 


### PR DESCRIPTION
Hi,

I would like to separate my Git config repo into several sub directories, one for each app so all the files are not mixed together in the root folder.

I know there is a property I can use: *spring.cloud.config.server.git.searchPaths* where I can provide a list of directories to add when loading the files.

However, I would like this to be more automatic instead of having to add another folder to *spring.cloud.config.server.git.searchPaths* every time I have a new folder for an app configuration added.

I created a sample pull request just to show the idea with one-level sub directories.
However, I think we can make this even better by recursively going into all sub directories even after first level.

Anyway, just a suggestion, since I think this can be very useful to reduce and organise configuration.

PS: I am not suggesting to merge this pull request, this is just to present the idea.

Thanks.



