### PR TITLE
Use 'trunk' as default label for Subversion repositories

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerBootstrapConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import org.springframework.util.StringUtils;
  * enabled with <code>spring.cloud.config.server.bootstrap=true</code>. This would be
  * useful, for example, if the config server were embedded in another app that wanted to
  * be configured from the same repository as all the other clients.
- * 
- * @author Dave Syer
  *
+ * @author Dave Syer
+ * @author Roy Clarkson
  */
 @Configuration
 public class ConfigServerBootstrapConfiguration {
@@ -51,10 +51,20 @@ public class ConfigServerBootstrapConfiguration {
 
 		@Bean
 		public EnvironmentRepositoryPropertySourceLocator environmentRepositoryPropertySourceLocator() {
-			String label = StringUtils.hasText(client.getLabel()) ? client.getLabel()
-					: server.getDefaultLabel();
 			return new EnvironmentRepositoryPropertySourceLocator(repository,
-					client.getName(), client.getProfile(), label);
+					client.getName(), client.getProfile(), getDefaultLabel());
+		}
+
+		private String getDefaultLabel() {
+			if (StringUtils.hasText(client.getLabel())) {
+				return client.getLabel();
+			}
+			else if (StringUtils.hasText(server.getDefaultLabel())) {
+				return server.getDefaultLabel();
+			}
+			else {
+				return repository.getDefaultLabel();
+			}
 		}
 
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 @Configuration
 @ConditionalOnWebApplication
@@ -34,16 +35,25 @@ public class ConfigServerMvcConfiguration {
 
 	@Autowired
 	private EnvironmentRepository repository;
-	
+
 	@Autowired
 	private ConfigServerProperties server;
 
 	@Bean
 	public EnvironmentController environmentController() {
 		EnvironmentController controller = new EnvironmentController(repository, encryptionController());
-		controller.setDefaultLabel(server.getDefaultLabel());
+		controller.setDefaultLabel(getDefaultLabel());
 		controller.setOverrides(server.getOverrides());
 		return controller;
+	}
+
+	private String getDefaultLabel() {
+		if (StringUtils.hasText(server.getDefaultLabel())) {
+			return server.getDefaultLabel();
+		}
+		else {
+			return repository.getDefaultLabel();
+		}
 	}
 
 	@Bean

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 @ConfigurationProperties("spring.cloud.config.server")
 public class ConfigServerProperties {
-
-	public static final String MASTER = "master";
 
 	/**
 	 * Flag indicating that the config server should initialize its own Environment with
@@ -44,10 +42,9 @@ public class ConfigServerProperties {
 	private String prefix;
 
 	/**
-	 * Default repository label (defaults to "master") when incoming requests do not have
-	 * a specific label.
+	 * Default repository label when incoming requests do not have a specific label.
 	 */
-	private String defaultLabel = ConfigServerProperties.MASTER;
+	private String defaultLabel;
 
 	/**
 	 * Extra map for a property source to be sent to all clients unconditionally.

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.yaml.snakeyaml.Yaml;
+
 import org.springframework.boot.bind.PropertiesConfigurationFactory;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -41,8 +43,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.yaml.snakeyaml.Yaml;
 
+/**
+ * @author Dave Syer
+ * @author Spencer Gibb
+ * @author Roy Clarkson
+ */
 @RestController
 @RequestMapping("${spring.cloud.config.server.prefix:}")
 public class EnvironmentController {
@@ -53,7 +59,7 @@ public class EnvironmentController {
 
 	private EncryptionController encryption;
 
-	private String defaultLabel = ConfigServerProperties.MASTER;
+	private String defaultLabel;
 
 	private Map<String, String> overrides = new LinkedHashMap<String, String>();
 
@@ -61,11 +67,12 @@ public class EnvironmentController {
 			EncryptionController encryption) {
 		super();
 		this.repository = repository;
+		this.defaultLabel = repository.getDefaultLabel();
 		this.encryption = encryption;
 	}
 
 	@RequestMapping("/{name}/{profiles:.*[^-].*}")
-	public Environment master(@PathVariable String name, @PathVariable String profiles) {
+	public Environment defaultLabel(@PathVariable String name, @PathVariable String profiles) {
 		return labelled(name, profiles, defaultLabel);
 	}
 
@@ -188,7 +195,7 @@ public class EnvironmentController {
 	 * bound. Some of this might be do-able in RelaxedDataBinder, but we need to do it
 	 * here for now. Only supports arrays at leaf level currently (i.e. the properties
 	 * keys end in [*]).
-	 * 
+	 *
 	 * @param target the target Map
 	 * @param properties the properties (with key names to check)
 	 */

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import org.springframework.cloud.config.environment.Environment;
 
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 public interface EnvironmentRepository {
-	
+
+	String getDefaultLabel();
+
 	Environment findOne(String application, String profile, String label);
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/JGitEnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 
 import com.jcraft.jsch.Session;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.jgit.api.CheckoutCommand;
@@ -40,6 +39,7 @@ import org.eclipse.jgit.transport.OpenSshConfig.Host;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FileUtils;
+
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.UrlResource;
@@ -52,16 +52,23 @@ import static org.springframework.util.StringUtils.hasText;
  * An {@link EnvironmentRepository} backed by a single git repository.
  * 
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository {
 
 	private static Log logger = LogFactory.getLog(JGitEnvironmentRepository.class);
 
+	private static final String DEFAULT_LABEL = "master";
+
 	private boolean initialized;
 
 	public JGitEnvironmentRepository(ConfigurableEnvironment environment) {
 		super(environment);
+	}
+
+	@Override
+	public String getDefaultLabel() {
+		return DEFAULT_LABEL;
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.config.ConfigFileApplicationListener;
@@ -40,15 +41,16 @@ import org.springframework.util.StringUtils;
  * and configuration files located through the normal protocols. The resulting Environment
  * is composed of property sources located using the application name as the config file
  * stem (spring.config.name) and the environment name as a Spring profile.
- * 
- * @author Dave Syer
  *
+ * @author Dave Syer
+ * @author Roy Clarkson
  */
 @ConfigurationProperties("spring.cloud.config.server.native")
 public class NativeEnvironmentRepository implements EnvironmentRepository {
 
-	private static Log logger = LogFactory
-			.getLog(NativeEnvironmentRepository.class);
+	private static Log logger = LogFactory.getLog(NativeEnvironmentRepository.class);
+
+	private static final String DEFAULT_LABEL = "master";
 
 	/**
 	 * Locations to search for configuration files. Defaults to the same as a Spring Boot
@@ -76,6 +78,11 @@ public class NativeEnvironmentRepository implements EnvironmentRepository {
 
 	public boolean isFailOnError() {
 		return failOnError;
+	}
+
+	@Override
+	public String getDefaultLabel() {
+		return DEFAULT_LABEL;
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/PassthruEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/PassthruEnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,22 +21,24 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
-import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.support.StandardServletEnvironment;
 
 /**
  * Simple implementation of {@link EnvironmentRepository} that just reflects an existing
  * Spring Environment.
- * 
- * @author Dave Syer
  *
+ * @author Dave Syer
+ * @author Roy Clarkson
  */
 public class PassthruEnvironmentRepository implements EnvironmentRepository {
+
+	private static final String DEFAULT_LABEL = "master";
 
 	private Set<String> standardSources = new HashSet<String>(Arrays.asList(
 			"vcap",
@@ -50,6 +52,11 @@ public class PassthruEnvironmentRepository implements EnvironmentRepository {
 
 	public PassthruEnvironmentRepository(ConfigurableEnvironment environment) {
 		this.environment = environment;
+	}
+
+	@Override
+	public String getDefaultLabel() {
+		return DEFAULT_LABEL;
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/SvnKitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/SvnKitEnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.cloud.config.server;
 
 import java.io.File;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.config.environment.Environment;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNURL;
 import org.tmatesoft.svn.core.internal.wc.DefaultSVNAuthenticationManager;
@@ -33,17 +27,31 @@ import org.tmatesoft.svn.core.wc2.SvnOperationFactory;
 import org.tmatesoft.svn.core.wc2.SvnTarget;
 import org.tmatesoft.svn.core.wc2.SvnUpdate;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
 import static org.springframework.util.StringUtils.hasText;
 
 /**
  * Subversion-backed {@link EnvironmentRepository}.
- * 
+ *
  * @author Michael Prankl
+ * @author Roy Clarkson
  */
 @ConfigurationProperties("spring.cloud.config.server.svn")
 public class SvnKitEnvironmentRepository extends AbstractScmEnvironmentRepository {
 
 	private static Log logger = LogFactory.getLog(SvnKitEnvironmentRepository.class);
+
+	private static final String DEFAULT_LABEL = "trunk";
+
+	@Override
+	public String getDefaultLabel() {
+		return DEFAULT_LABEL;
+	}
 
 	@Override
 	public Environment findOne(String application, String profile, String label) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerIntegrationTests.java
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 public class EnvironmentControllerIntegrationTests {
 
@@ -36,6 +36,7 @@ public class EnvironmentControllerIntegrationTests {
 
 	@Before
 	public void init() {
+		Mockito.when(repository.getDefaultLabel()).thenReturn("master");
 		mvc = MockMvcBuilders.standaloneSetup(
 				new EnvironmentController(repository, new EncryptionController()))
 				.build();

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,17 @@
  */
 package org.springframework.cloud.config.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.http.MediaType;
@@ -35,9 +34,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 public class EnvironmentControllerTests {
 
@@ -46,10 +48,15 @@ public class EnvironmentControllerTests {
 
 	private EnvironmentRepository repository = Mockito.mock(EnvironmentRepository.class);
 
-	private EnvironmentController controller = new EnvironmentController(repository,
-			new EncryptionController());
+	private EnvironmentController controller;
 
 	private Environment environment = new Environment("foo", "master");
+
+	@Before
+	public void init() {
+		Mockito.when(repository.getDefaultLabel()).thenReturn("master");
+		this.controller = new EnvironmentController(repository, new EncryptionController());
+	}
 
 	@Test
 	public void vanillaYaml() throws Exception {
@@ -223,7 +230,7 @@ public class EnvironmentControllerTests {
 		map.put("a.b.c", "d");
 		environment.add(new PropertySource("one", map));
 		Mockito.when(repository.findOne("foo", "bar", "master")).thenReturn(environment);
-		assertEquals("{foo=bar}", controller.master("foo", "bar").getPropertySources()
+		assertEquals("{foo=bar}", controller.defaultLabel("foo", "bar").getPropertySources()
 				.get(0).getSource().toString());
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/JGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/JGitEnvironmentRepositoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.config.server;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -29,6 +26,7 @@ import org.eclipse.jgit.util.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.config.environment.Environment;
@@ -38,9 +36,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StreamUtils;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Dave Syer
- *
+ * @author Roy Clarkson
  */
 public class JGitEnvironmentRepositoryIntegrationTests {
 
@@ -110,6 +111,24 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 		repository.findOne("bar", "staging", "master");
 		Environment environment = repository.findOne("bar", "staging", "master");
 		assertEquals(2, environment.getPropertySources().size());
+	}
+
+	@Test
+	public void defaultLabel() throws Exception {
+		String uri = ConfigServerTestUtils.prepareLocalRepo();
+		context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.properties("spring.cloud.config.server.git.uri:" + uri).run();
+		EnvironmentRepository repository = context.getBean(EnvironmentRepository.class);
+		assertEquals("master", repository.getDefaultLabel());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void invalidLabel() throws IOException {
+		String uri = ConfigServerTestUtils.prepareLocalRepo();
+		context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.properties("spring.cloud.config.server.git.uri:" + uri).run();
+		EnvironmentRepository repository = context.getBean(EnvironmentRepository.class);
+		repository.findOne("bar", "staging", "unknownlabel");
 	}
 
 	@Configuration

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SVNKitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SVNKitEnvironmentRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,16 @@ import java.io.File;
 import org.eclipse.jgit.util.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.server.ConfigServerTestUtils;
-import org.springframework.cloud.config.server.SvnKitEnvironmentRepository;
 import org.springframework.core.env.StandardEnvironment;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Michael Prankl
- *
+ * @author Roy Clarkson
  */
 public class SVNKitEnvironmentRepositoryTests {
 
@@ -90,6 +89,12 @@ public class SVNKitEnvironmentRepositoryTests {
 				.contains("bar.properties"));
 		assertTrue(environment.getPropertySources().get(1).getName()
 				.contains("application.yml"));
+	}
+
+	@Test
+	public void invalidLabel() {
+		Environment environment = repository.findOne("bar", "staging", "unknownlabel");
+		assertEquals(0, environment.getPropertySources().size());
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SubversionConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SubversionConfigServerIntegrationTests.java
@@ -1,15 +1,31 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.config.server;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.server.ConfigServerApplication;
-import org.springframework.cloud.config.server.ConfigServerTestUtils;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -17,6 +33,11 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+/**
+ * @author Michael Prankl
+ * @author Dave Syer
+ * @author Roy Clarkson
+ */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = ConfigServerApplication.class)
 @IntegrationTest({ "server.port:0", "spring.config.name:configserver",
@@ -27,6 +48,9 @@ public class SubversionConfigServerIntegrationTests {
 
 	@Value("${local.server.port}")
 	private int port;
+
+	@Autowired
+	private ApplicationContext context;
 
 	@BeforeClass
 	public static void init() throws Exception {
@@ -42,6 +66,12 @@ public class SubversionConfigServerIntegrationTests {
 		assertEquals("overrides", environment.getPropertySources().get(0).getName());
 		assertEquals("{spring.cloud.config.enabled=true}", environment
 				.getPropertySources().get(0).getSource().toString());
+	}
+
+	@Test
+	public void defaultLabel() throws Exception {
+		EnvironmentRepository repository = context.getBean(EnvironmentRepository.class);
+		assertEquals("trunk", repository.getDefaultLabel());
 	}
 
 }


### PR DESCRIPTION
This commit adds a new AbstractEnvironmentRepository that includes
a getDefaultLabel() method for all EnvironmentRepository
implementations. The default implementation returns 'master'.
SvnKitEnvironmentRepository overrides this method to return 'trunk'.
ConfigServerMvcConfiguration and ConfigServerBootstrapConfiguration
will utilize labels configured on the client and server before falling
back to the repository's default label.

Resolves #107