### PR TITLE
Introducing TextEncryptorLocator abstraction

### DIFF
--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientAutoConfigurationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientAutoConfigurationTests.java
@@ -1,14 +1,29 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.config.client;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.config.client.ConfigClientAutoConfiguration;
-import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.Assert.assertEquals;
 
 public class ConfigClientAutoConfigurationTests {
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
@@ -35,8 +35,11 @@ public class ConfigServerMvcConfiguration {
 	@Autowired
 	private ConfigServerProperties server;
 
+	@Autowired
+	private EnvironmentEncryptor environmentEncryptor;
+
 	@Bean
-	public EnvironmentController environmentController(EnvironmentEncryptor environmentEncryptor) {
+	public EnvironmentController environmentController() {
 		EnvironmentController controller = new EnvironmentController(repository, environmentEncryptor);
 		controller.setDefaultLabel(getDefaultLabel());
 		controller.setOverrides(server.getOverrides());

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerMvcConfiguration.java
@@ -17,9 +17,9 @@ package org.springframework.cloud.config.server;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.cloud.config.server.encryption.EnvironmentEncryptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.util.StringUtils;
 
 /**
@@ -29,10 +29,6 @@ import org.springframework.util.StringUtils;
 @Configuration
 @ConditionalOnWebApplication
 public class ConfigServerMvcConfiguration {
-
-	@Autowired(required = false)
-	private TextEncryptor encryptor;
-
 	@Autowired
 	private EnvironmentRepository repository;
 
@@ -40,8 +36,8 @@ public class ConfigServerMvcConfiguration {
 	private ConfigServerProperties server;
 
 	@Bean
-	public EnvironmentController environmentController() {
-		EnvironmentController controller = new EnvironmentController(repository, encryptionController());
+	public EnvironmentController environmentController(EnvironmentEncryptor environmentEncryptor) {
+		EnvironmentController controller = new EnvironmentController(repository, environmentEncryptor);
 		controller.setDefaultLabel(getDefaultLabel());
 		controller.setOverrides(server.getOverrides());
 		controller.setStripDocumentFromYaml(server.isStripDocumentFromYaml());
@@ -55,14 +51,5 @@ public class ConfigServerMvcConfiguration {
 		else {
 			return repository.getDefaultLabel();
 		}
-	}
-
-	@Bean
-	public EncryptionController encryptionController() {
-		EncryptionController controller = new EncryptionController();
-		if (encryptor!=null) {
-			controller.setEncryptor(encryptor);
-		}
-		return controller;
 	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
@@ -60,7 +60,7 @@ public class ConfigServerProperties {
 	/**
 	 * Default application name when incoming requests do not have a specific one.
 	 */
-	private String defaultApplicationName = "default";
+	private String defaultApplicationName = "application";
 
 	/**
 	 * Default application profile when incoming requests do not have a specific one.

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerProperties.java
@@ -57,6 +57,17 @@ public class ConfigServerProperties {
 	 */
 	private boolean stripDocumentFromYaml = true;
 
+	/**
+	 * Default application name when incoming requests do not have a specific one.
+	 */
+	private String defaultApplicationName = "default";
+
+	/**
+	 * Default application profile when incoming requests do not have a specific one.
+	 */
+	private String defaultProfile = "default";
+	
+
 	public String getDefaultLabel() {
 		return defaultLabel;
 	}
@@ -97,4 +108,19 @@ public class ConfigServerProperties {
 		this.stripDocumentFromYaml = stripDocumentFromYaml;
 	}
 
+	public String getDefaultApplicationName() {
+		return defaultApplicationName;
+	}
+
+	public void setDefaultApplicationName(String defaultApplicationName) {
+		this.defaultApplicationName = defaultApplicationName;
+	}
+
+	public String getDefaultProfile() {
+		return defaultProfile;
+	}
+
+	public void setDefaultProfile(String defaultProfile) {
+		this.defaultProfile = defaultProfile;
+	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnableConfigServer.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnableConfigServer.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.cloud.config.server.encryption.ConfigServerEncryptionConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -30,7 +31,9 @@ import org.springframework.context.annotation.Import;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Import({ConfigServerConfiguration.class, ConfigServerMvcConfiguration.class})
+@Import({ConfigServerConfiguration.class,
+        ConfigServerMvcConfiguration.class,
+        ConfigServerEncryptionConfiguration.class})
 public @interface EnableConfigServer {
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnableConfigServer.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnableConfigServer.java
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Import;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Import({ConfigServerConfiguration.class,
-        ConfigServerMvcConfiguration.class,
-        ConfigServerEncryptionConfiguration.class})
+		ConfigServerMvcConfiguration.class,
+		ConfigServerEncryptionConfiguration.class})
 public @interface EnableConfigServer {
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EncryptionController.java
@@ -21,16 +21,14 @@ import java.net.URLDecoder;
 import java.security.KeyPair;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.encryption.SingleTextEncryptorLocator;
+import org.springframework.cloud.config.server.encryption.TextEncryptorLocator;
 import org.springframework.cloud.context.encrypt.EncryptorFactory;
 import org.springframework.cloud.context.encrypt.KeyFormatException;
 import org.springframework.core.io.ByteArrayResource;
@@ -63,15 +61,16 @@ public class EncryptionController {
 
 	private static Log logger = LogFactory.getLog(EncryptionController.class);
 
-	private TextEncryptor encryptor;
+	private final TextEncryptorLocator encryptorLocator;
 
-	@Autowired(required = false)
-	public void setEncryptor(TextEncryptor encryptor) {
-		this.encryptor = encryptor;
+	@Autowired
+	public EncryptionController (TextEncryptorLocator encryptorLocator) {
+		this.encryptorLocator = encryptorLocator;
 	}
 
 	@RequestMapping(value = "/key", method = RequestMethod.GET)
 	public String getPublicKey() {
+		TextEncryptor encryptor = encryptorLocator.locate();
 		if (!(encryptor instanceof RsaKeyHolder)) {
 			throw new KeyNotAvailableException();
 		}
@@ -90,8 +89,9 @@ public class EncryptionController {
 			ByteArrayResource resource = new ByteArrayResource(file.getBytes());
 			KeyPair keyPair = new KeyStoreKeyFactory(resource, password.toCharArray())
 					.getKeyPair(alias);
-			encryptor = new RsaSecretEncryptor(keyPair);
-			body.put("publicKey", ((RsaKeyHolder) encryptor).getPublicKey());
+			RsaSecretEncryptor encryptor = new RsaSecretEncryptor(keyPair);
+            updateEncryptor(encryptor);
+            body.put("publicKey", encryptor.getPublicKey());
 		}
 		catch (IOException e) {
 			throw new KeyFormatException();
@@ -102,22 +102,32 @@ public class EncryptionController {
 
 	}
 
-	@RequestMapping(value = "/key", method = RequestMethod.POST, params = { "!password" })
+    @RequestMapping(value = "/key", method = RequestMethod.POST, params = { "!password" })
 	public ResponseEntity<Map<String, Object>> uploadKey(@RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
 
 		Map<String, Object> body = new HashMap<String, Object>();
 		body.put("status", "OK");
 
-		encryptor = new EncryptorFactory().create(stripFormData(data, type, false));
-
+		TextEncryptor encryptor = new EncryptorFactory().create(stripFormData(data, type, false));
+        updateEncryptor(encryptor);
 		if (encryptor instanceof RsaKeyHolder) {
 			body.put("publicKey", ((RsaKeyHolder) encryptor).getPublicKey());
 		}
 		logger.info("Key changed with literal value");
 		return new ResponseEntity<Map<String, Object>>(body, HttpStatus.CREATED);
-
 	}
+
+    // this is temporary solution to support existing REST API
+    // downcasting is only necessary until we introduce some key management abstraction,
+    // we don't want TextEncryptorLocator to have setEncryptor method
+    private void updateEncryptor(TextEncryptor encryptor) {
+        if (encryptorLocator instanceof SingleTextEncryptorLocator) {
+            ((SingleTextEncryptorLocator) encryptorLocator).setEncryptor(encryptor);
+        } else {
+            throw new IncompatibleTextEncryptorLocatorException();
+        }
+    }
 
 	@ExceptionHandler(KeyFormatException.class)
 	@ResponseBody
@@ -139,7 +149,7 @@ public class EncryptionController {
 
 	@RequestMapping(value = "encrypt/status", method = RequestMethod.GET)
 	public Map<String, Object> status() {
-		if (encryptor == null) {
+		if (encryptorLocator.locate() == null) {
 			throw new KeyNotInstalledException();
 		}
 		return Collections.<String, Object> singletonMap("status", "OK");
@@ -148,6 +158,7 @@ public class EncryptionController {
 	@RequestMapping(value = "encrypt", method = RequestMethod.POST)
 	public String encrypt(@RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
+		TextEncryptor encryptor = encryptorLocator.locate();
 		if (encryptor == null) {
 			throw new KeyNotInstalledException();
 		}
@@ -160,6 +171,7 @@ public class EncryptionController {
 	@RequestMapping(value = "decrypt", method = RequestMethod.POST)
 	public String decrypt(@RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
+		TextEncryptor encryptor = encryptorLocator.locate();
 		if (encryptor == null) {
 			throw new KeyNotInstalledException();
 		}
@@ -228,40 +240,7 @@ public class EncryptionController {
 		return new ResponseEntity<Map<String, Object>>(body, HttpStatus.BAD_REQUEST);
 	}
 
-	public Environment decrypt(Environment environment) {
-		Environment result = new Environment(environment.getName(), environment.getProfiles(),
-				environment.getLabel());
-		for (PropertySource source : environment.getPropertySources()) {
-			Map<Object, Object> map = new LinkedHashMap<Object, Object>(
-					source.getSource());
-			for (Entry<Object,Object> entry : new LinkedHashSet<>(map.entrySet())) {
-				Object key = entry.getKey();
-				String name = key.toString();
-				String value = entry.getValue().toString();
-				if (value.startsWith("{cipher}")) {
-					map.remove(key);
-					if (encryptor == null) {
-						map.put(name, value);
-					}
-					else {
-						try {
-							value = value == null ? null : encryptor.decrypt(value
-									.substring("{cipher}".length()));
-						}
-						catch (Exception e) {
-							value = "<n/a>";
-							name = "invalid." + name;
-							logger.warn("Cannot decrypt key: " + key + " ("
-									+ e.getClass() + ": " + e.getMessage() + ")");
-						}
-						map.put(name, value);
-					}
-				}
-			}
-			result.add(new PropertySource(source.getName(), map));
-		}
-		return result;
-	}
+
 }
 
 @SuppressWarnings("serial")
@@ -274,4 +253,8 @@ class KeyNotAvailableException extends RuntimeException {
 
 @SuppressWarnings("serial")
 class InvalidCipherException extends RuntimeException {
+}
+
+@SuppressWarnings("serial")
+class IncompatibleTextEncryptorLocatorException extends RuntimeException {
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EncryptionController.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.config.server.encryption.SingleTextEncryptorLocator;
 import org.springframework.cloud.config.server.encryption.TextEncryptorLocator;
 import org.springframework.cloud.context.encrypt.EncryptorFactory;
@@ -63,8 +62,7 @@ public class EncryptionController {
 
 	private final TextEncryptorLocator encryptorLocator;
 
-	@Autowired
-	public EncryptionController (TextEncryptorLocator encryptorLocator) {
+	public EncryptionController(TextEncryptorLocator encryptorLocator) {
 		this.encryptorLocator = encryptorLocator;
 	}
 
@@ -90,8 +88,8 @@ public class EncryptionController {
 			KeyPair keyPair = new KeyStoreKeyFactory(resource, password.toCharArray())
 					.getKeyPair(alias);
 			RsaSecretEncryptor encryptor = new RsaSecretEncryptor(keyPair);
-            updateEncryptor(encryptor);
-            body.put("publicKey", encryptor.getPublicKey());
+			updateEncryptor(encryptor);
+			body.put("publicKey", encryptor.getPublicKey());
 		}
 		catch (IOException e) {
 			throw new KeyFormatException();
@@ -118,16 +116,16 @@ public class EncryptionController {
 		return new ResponseEntity<Map<String, Object>>(body, HttpStatus.CREATED);
 	}
 
-    // this is temporary solution to support existing REST API
-    // downcasting is only necessary until we introduce some key management abstraction,
-    // we don't want TextEncryptorLocator to have setEncryptor method
-    private void updateEncryptor(TextEncryptor encryptor) {
-        if (encryptorLocator instanceof SingleTextEncryptorLocator) {
-            ((SingleTextEncryptorLocator) encryptorLocator).setEncryptor(encryptor);
-        } else {
-            throw new IncompatibleTextEncryptorLocatorException();
-        }
-    }
+	// this is temporary solution to support existing REST API
+	// downcasting is only necessary until we introduce some key management abstraction,
+	// we don't want TextEncryptorLocator to have setEncryptor method
+	private void updateEncryptor(TextEncryptor encryptor) {
+		if (encryptorLocator instanceof SingleTextEncryptorLocator) {
+			((SingleTextEncryptorLocator) encryptorLocator).setEncryptor(encryptor);
+		} else {
+			throw new IncompatibleTextEncryptorLocatorException();
+		}
+	}
 
 	@ExceptionHandler(KeyFormatException.class)
 	@ResponseBody
@@ -158,6 +156,7 @@ public class EncryptionController {
 	@RequestMapping(value = "encrypt", method = RequestMethod.POST)
 	public String encrypt(@RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
+
 		TextEncryptor encryptor = encryptorLocator.locate();
 		if (encryptor == null) {
 			throw new KeyNotInstalledException();
@@ -171,6 +170,7 @@ public class EncryptionController {
 	@RequestMapping(value = "decrypt", method = RequestMethod.POST)
 	public String decrypt(@RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
+
 		TextEncryptor encryptor = encryptorLocator.locate();
 		if (encryptor == null) {
 			throw new KeyNotInstalledException();

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.boot.bind.PropertiesConfigurationFactory;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
@@ -25,12 +25,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.boot.bind.PropertiesConfigurationFactory;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.encryption.EnvironmentEncryptor;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.http.HttpHeaders;
@@ -60,7 +60,7 @@ public class EnvironmentController {
 
 	private EnvironmentRepository repository;
 
-	private EncryptionController encryption;
+	private EnvironmentEncryptor environmentEncryptor;
 
 	private String defaultLabel;
 
@@ -68,12 +68,11 @@ public class EnvironmentController {
 
 	private boolean stripDocument = true;
 
-	public EnvironmentController(EnvironmentRepository repository,
-			EncryptionController encryption) {
+	public EnvironmentController(EnvironmentRepository repository, EnvironmentEncryptor environmentEncryptor) {
 		super();
 		this.repository = repository;
 		this.defaultLabel = repository.getDefaultLabel();
-		this.encryption = encryption;
+		this.environmentEncryptor = environmentEncryptor;
 	}
 
 	/**
@@ -94,7 +93,7 @@ public class EnvironmentController {
 	@RequestMapping("/{name}/{profiles}/{label:.*}")
 	public Environment labelled(@PathVariable String name, @PathVariable String profiles,
 			@PathVariable String label) {
-		Environment environment = encryption.decrypt(repository.findOne(name, profiles,
+		Environment environment = environmentEncryptor.decrypt(repository.findOne(name, profiles,
 				label));
 		if (!overrides.isEmpty()) {
 			environment.addFirst(new PropertySource("overrides", overrides));

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
@@ -52,6 +52,9 @@ import org.yaml.snakeyaml.nodes.Tag;
  * @author Dave Syer
  * @author Spencer Gibb
  * @author Roy Clarkson
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
  */
 @RestController
 @RequestMapping("${spring.cloud.config.server.prefix:}")

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
@@ -32,50 +32,47 @@ import org.springframework.stereotype.Component;
 @Component
 public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
 
-    private static Log logger = LogFactory.getLog(CipherEnvironmentEncryptor.class);
+	private static Log logger = LogFactory.getLog(CipherEnvironmentEncryptor.class);
 
-    private final TextEncryptorLocator encryptorLocator;
+	private final TextEncryptorLocator encryptorLocator;
 
-    @Autowired
-    public CipherEnvironmentEncryptor(TextEncryptorLocator encryptorLocator) {
-        this.encryptorLocator = encryptorLocator;
-    }
+	@Autowired
+	public CipherEnvironmentEncryptor(TextEncryptorLocator encryptorLocator) {
+		this.encryptorLocator = encryptorLocator;
+	}
 
-    @Override
-    public Environment decrypt(Environment environment) {
-        TextEncryptor encryptor = encryptorLocator.locate(environment);
-        return encryptor != null ? decrypt(environment, encryptor) : environment;
-    }
+	@Override
+	public Environment decrypt(Environment environment) {
+		TextEncryptor encryptor = encryptorLocator.locate(environment);
+		return encryptor != null ? decrypt(environment, encryptor) : environment;
+	}
 
-    private Environment decrypt(Environment environment, TextEncryptor encryptor) {
-        Environment result = new Environment(environment.getName(), environment.getProfiles(), environment.getLabel());
-        for (PropertySource source : environment.getPropertySources()) {
-            Map<Object, Object> map = new LinkedHashMap<Object, Object>(
-                    source.getSource());
-            for (Map.Entry<Object,Object> entry : new LinkedHashSet<>(map.entrySet())) {
-                Object key = entry.getKey();
-                String name = key.toString();
-                String value = entry.getValue().toString();
-                if (value.startsWith("{cipher}")) {
-                    map.remove(key);
-
-                    try {
-                        value = value == null ? null : encryptor.decrypt(value
-                                .substring("{cipher}".length()));
-                    }
-                    catch (Exception e) {
-                        value = "<n/a>";
-                        name = "invalid." + name;
-                        logger.warn("Cannot decrypt key: " + key + " ("
-                                + e.getClass() + ": " + e.getMessage() + ")");
-                    }
-                    map.put(name, value);
-
-                }
-            }
-            result.add(new PropertySource(source.getName(), map));
-        }
-        return result;
-    }
+	private Environment decrypt(Environment environment, TextEncryptor encryptor) {
+		Environment result = new Environment(environment.getName(),
+		environment.getProfiles(), environment.getLabel());
+		for (PropertySource source : environment.getPropertySources()) {
+			Map<Object, Object> map = new LinkedHashMap<Object, Object>(source.getSource());
+			for (Map.Entry<Object, Object> entry : new LinkedHashSet<>(map.entrySet())) {
+				Object key = entry.getKey();
+				String name = key.toString();
+				String value = entry.getValue().toString();
+				if (value.startsWith("{cipher}")) {
+					map.remove(key);
+					try {
+						value = value == null ? null : encryptor.decrypt(value.substring(
+																	"{cipher}".length()));
+					} catch (Exception e) {
+						value = "<n/a>";
+						name = "invalid." + name;
+						logger.warn("Cannot decrypt key: " + key
+								+ " (" + e.getClass() + ": " + e.getMessage() + ")");
+					}
+					map.put(name, value);
+				}
+			}
+			result.add(new PropertySource(source.getName(), map));
+		}
+		return result;
+	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
+
+    private static Log logger = LogFactory.getLog(CipherEnvironmentEncryptor.class);
+
+    private final TextEncryptorLocator encryptorLocator;
+
+    @Autowired
+    public CipherEnvironmentEncryptor(TextEncryptorLocator encryptorLocator) {
+        this.encryptorLocator = encryptorLocator;
+    }
+
+    @Override
+    public Environment decrypt(Environment environment) {
+        TextEncryptor encryptor = encryptorLocator.locate(environment);
+        return encryptor != null ? decrypt(environment, encryptor) : environment;
+    }
+
+    private Environment decrypt(Environment environment, TextEncryptor encryptor) {
+        Environment result = new Environment(environment.getName(), environment.getProfiles(), environment.getLabel());
+        for (PropertySource source : environment.getPropertySources()) {
+            Map<Object, Object> map = new LinkedHashMap<Object, Object>(
+                    source.getSource());
+            for (Map.Entry<Object,Object> entry : new LinkedHashSet<>(map.entrySet())) {
+                Object key = entry.getKey();
+                String name = key.toString();
+                String value = entry.getValue().toString();
+                if (value.startsWith("{cipher}")) {
+                    map.remove(key);
+
+                    try {
+                        value = value == null ? null : encryptor.decrypt(value
+                                .substring("{cipher}".length()));
+                    }
+                    catch (Exception e) {
+                        value = "<n/a>";
+                        name = "invalid." + name;
+                        logger.warn("Cannot decrypt key: " + key + " ("
+                                + e.getClass() + ": " + e.getMessage() + ")");
+                    }
+                    map.put(name, value);
+
+                }
+            }
+            result.add(new PropertySource(source.getName(), map));
+        }
+        return result;
+    }
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
@@ -43,7 +44,8 @@ public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
 
 	@Override
 	public Environment decrypt(Environment environment) {
-		TextEncryptor encryptor = encryptorLocator.locate(environment);
+		TextEncryptor encryptor = encryptorLocator.locate(environment.getName(),
+				StringUtils.arrayToCommaDelimitedString(environment.getProfiles()));
 		return encryptor != null ? decrypt(environment, encryptor) : environment;
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
@@ -30,6 +30,14 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+/**
+ * EnvironmentEncryptor that can decrypt property values prefixed with {cipher} marker.
+ *
+ * @author Dave Syer
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
+ */
 @Component
 public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.config.server.ConfigServerProperties;
 import org.springframework.cloud.config.server.EncryptionController;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +52,7 @@ public class ConfigServerEncryptionConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	public TextEncryptorLocator textEncryptorLocator() {
 		return new SingleTextEncryptorLocator(encryptor);
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -25,21 +25,21 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 @Configuration
 public class ConfigServerEncryptionConfiguration {
 
-    @Autowired(required = false)
-    private TextEncryptor encryptor;
+	@Autowired(required = false)
+	private TextEncryptor encryptor;
 
-    @Bean
-    public EncryptionController encryptionController(TextEncryptorLocator locator) {
-        return new EncryptionController(locator);
-    }
+	@Bean
+	public EncryptionController encryptionController(TextEncryptorLocator locator) {
+		return new EncryptionController(locator);
+	}
 
-    @Bean
-    public EnvironmentEncryptor environmentEncryptor(TextEncryptorLocator locator) {
-        return new CipherEnvironmentEncryptor(locator);
-    }
+	@Bean
+	public EnvironmentEncryptor environmentEncryptor(TextEncryptorLocator locator) {
+		return new CipherEnvironmentEncryptor(locator);
+	}
 
-    @Bean
-    public TextEncryptorLocator textEncryptorLocator() {
-        return new SingleTextEncryptorLocator(encryptor);
-    }
+	@Bean
+	public TextEncryptorLocator textEncryptorLocator() {
+		return new SingleTextEncryptorLocator(encryptor);
+	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.config.server.EncryptionController;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+@Configuration
+public class ConfigServerEncryptionConfiguration {
+
+    @Autowired(required = false)
+    private TextEncryptor encryptor;
+
+    @Bean
+    public EncryptionController encryptionController(TextEncryptorLocator locator) {
+        return new EncryptionController(locator);
+    }
+
+    @Bean
+    public EnvironmentEncryptor environmentEncryptor(TextEncryptorLocator locator) {
+        return new CipherEnvironmentEncryptor(locator);
+    }
+
+    @Bean
+    public TextEncryptorLocator textEncryptorLocator() {
+        return new SingleTextEncryptorLocator(encryptor);
+    }
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -23,6 +23,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
+/**
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
+ */
 @Configuration
 public class ConfigServerEncryptionConfiguration {
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.config.server.ConfigServerProperties;
 import org.springframework.cloud.config.server.EncryptionController;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,13 +29,19 @@ public class ConfigServerEncryptionConfiguration {
 	@Autowired(required = false)
 	private TextEncryptor encryptor;
 
+	@Autowired
+	private TextEncryptorLocator locator;
+
+	@Autowired
+	private ConfigServerProperties properties;
+
 	@Bean
-	public EncryptionController encryptionController(TextEncryptorLocator locator) {
-		return new EncryptionController(locator);
+	public EncryptionController encryptionController() {
+		return new EncryptionController(locator, properties);
 	}
 
 	@Bean
-	public EnvironmentEncryptor environmentEncryptor(TextEncryptorLocator locator) {
+	public EnvironmentEncryptor environmentEncryptor() {
 		return new CipherEnvironmentEncryptor(locator);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
@@ -19,5 +19,5 @@ package org.springframework.cloud.config.server.encryption;
 import org.springframework.cloud.config.environment.Environment;
 
 public interface EnvironmentEncryptor {
-    Environment decrypt(Environment environment);
+	Environment decrypt(Environment environment);
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
@@ -18,6 +18,13 @@ package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.cloud.config.environment.Environment;
 
+/**
+ * Service interface for decrypting properties in Environment object.
+ *
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
+ */
 public interface EnvironmentEncryptor {
 	Environment decrypt(Environment environment);
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentEncryptor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import org.springframework.cloud.config.environment.Environment;
+
+public interface EnvironmentEncryptor {
+    Environment decrypt(Environment environment);
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.config.server.encryption;
 
-import org.springframework.cloud.config.environment.Environment;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 public class SingleTextEncryptorLocator implements TextEncryptorLocator {
@@ -35,12 +34,7 @@ public class SingleTextEncryptorLocator implements TextEncryptorLocator {
 	}
 
 	@Override
-	public TextEncryptor locate() {
+	public TextEncryptor locate(String applicationName, String profiles) {
 		return encryptor;
-	}
-
-	@Override
-	public TextEncryptor locate(Environment environment) {
-		return locate();
 	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+public class SingleTextEncryptorLocator implements TextEncryptorLocator {
+    private TextEncryptor encryptor;
+
+    public SingleTextEncryptorLocator() {
+    }
+
+    public SingleTextEncryptorLocator(TextEncryptor encryptor) {
+        this.encryptor = encryptor;
+    }
+
+    // temporary solution to support EncryptionController REST API
+    public void setEncryptor(TextEncryptor encryptor) {
+        this.encryptor = encryptor;
+    }
+
+    @Override
+    public TextEncryptor locate() {
+        return encryptor;
+    }
+
+    @Override
+    public TextEncryptor locate(Environment environment) {
+        return locate();
+    }
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
@@ -20,27 +20,27 @@ import org.springframework.cloud.config.environment.Environment;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 public class SingleTextEncryptorLocator implements TextEncryptorLocator {
-    private TextEncryptor encryptor;
+	private TextEncryptor encryptor;
 
-    public SingleTextEncryptorLocator() {
-    }
+	public SingleTextEncryptorLocator() {
+	}
 
-    public SingleTextEncryptorLocator(TextEncryptor encryptor) {
-        this.encryptor = encryptor;
-    }
+	public SingleTextEncryptorLocator(TextEncryptor encryptor) {
+		this.encryptor = encryptor;
+	}
 
-    // temporary solution to support EncryptionController REST API
-    public void setEncryptor(TextEncryptor encryptor) {
-        this.encryptor = encryptor;
-    }
+	// temporary solution to support EncryptionController REST API
+	public void setEncryptor(TextEncryptor encryptor) {
+		this.encryptor = encryptor;
+	}
 
-    @Override
-    public TextEncryptor locate() {
-        return encryptor;
-    }
+	@Override
+	public TextEncryptor locate() {
+		return encryptor;
+	}
 
-    @Override
-    public TextEncryptor locate(Environment environment) {
-        return locate();
-    }
+	@Override
+	public TextEncryptor locate(Environment environment) {
+		return locate();
+	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SingleTextEncryptorLocator.java
@@ -18,6 +18,14 @@ package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
+/**
+ * Basic implementation of TextEncryptorLocator which uses
+ * single TextEncryptor for all applications and profiles.
+ *
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
+ */
 public class SingleTextEncryptorLocator implements TextEncryptorLocator {
 	private TextEncryptor encryptor;
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+public interface TextEncryptorLocator {
+    TextEncryptor locate();
+    TextEncryptor locate(Environment environment);
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.config.server.encryption;
 
-import org.springframework.cloud.config.environment.Environment;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 public interface TextEncryptorLocator {
-	TextEncryptor locate();
-	TextEncryptor locate(Environment environment);
+	TextEncryptor locate(String applicationName, String profiles);
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
@@ -18,6 +18,20 @@ package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
+/**
+ * Service interface for locating proper TextEncryptor to be used for particular application.
+ * It can be used to provide config server with application and environment specific encryption.
+ *
+ * @author Bartosz Wojtkiewicz
+ * @author Rafal Zukowski
+ *
+ */
 public interface TextEncryptorLocator {
+	/**
+	 * Returns TextEncryptor to be used for given application and profiles.
+	 *
+	 * @param applicationName application name
+	 * @param profiles comma separated list of profiles
+	 */
 	TextEncryptor locate(String applicationName, String profiles);
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/TextEncryptorLocator.java
@@ -20,6 +20,6 @@ import org.springframework.cloud.config.environment.Environment;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 
 public interface TextEncryptorLocator {
-    TextEncryptor locate();
-    TextEncryptor locate(Environment environment);
+	TextEncryptor locate();
+	TextEncryptor locate(Environment environment);
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
@@ -1,14 +1,12 @@
 package org.springframework.cloud.config.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +23,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = TestConfiguration.class)
@@ -63,7 +66,9 @@ public class ConfigClientOffIntegrationTests {
 		
 		@Bean
 		public EnvironmentRepository environmentRepository() {
-			return Mockito.mock(EnvironmentRepository.class);
+			EnvironmentRepository repository = Mockito.mock(EnvironmentRepository.class);
+			given(repository.findOne(anyString(), anyString(), anyString())).willReturn(new Environment("", ""));
+			return repository;
 		}
 		
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
@@ -1,14 +1,12 @@
 package org.springframework.cloud.config.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +23,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = TestConfiguration.class)
@@ -63,7 +66,9 @@ public class ConfigClientOnIntegrationTests {
 		
 		@Bean
 		public EnvironmentRepository environmentRepository() {
-			return Mockito.mock(EnvironmentRepository.class);
+			EnvironmentRepository repository = Mockito.mock(EnvironmentRepository.class);
+			given(repository.findOne(anyString(), anyString(), anyString())).willReturn(new Environment("", ""));
+			return repository;
 		}
 		
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EncryptionControllerTests.java
@@ -33,8 +33,8 @@ import static org.junit.Assert.assertTrue;
 public class EncryptionControllerTests {
 
 	private SingleTextEncryptorLocator textEncryptorLocator = new SingleTextEncryptorLocator();
-
-	private EncryptionController controller = new EncryptionController(textEncryptorLocator);
+	private ConfigServerProperties properties = new ConfigServerProperties();
+	private EncryptionController controller = new EncryptionController(textEncryptorLocator, properties);
 
 	@Test(expected = KeyNotInstalledException.class)
 	public void cannotDecryptWithoutKey() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerIntegrationTests.java
@@ -19,7 +19,10 @@ package org.springframework.cloud.config.server;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.encryption.CipherEnvironmentEncryptor;
+import org.springframework.cloud.config.server.encryption.SingleTextEncryptorLocator;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -38,7 +41,7 @@ public class EnvironmentControllerIntegrationTests {
 	public void init() {
 		Mockito.when(repository.getDefaultLabel()).thenReturn("master");
 		mvc = MockMvcBuilders.standaloneSetup(
-				new EnvironmentController(repository, new EncryptionController()))
+				new EnvironmentController(repository, new CipherEnvironmentEncryptor(new SingleTextEncryptorLocator())))
 				.build();
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/EnvironmentControllerTests.java
@@ -28,6 +28,8 @@ import org.mockito.Mockito;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.encryption.CipherEnvironmentEncryptor;
+import org.springframework.cloud.config.server.encryption.SingleTextEncryptorLocator;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -55,7 +57,7 @@ public class EnvironmentControllerTests {
 	@Before
 	public void init() {
 		Mockito.when(repository.getDefaultLabel()).thenReturn("master");
-		this.controller = new EnvironmentController(repository, new EncryptionController());
+		this.controller = new EnvironmentController(repository, new CipherEnvironmentEncryptor(new SingleTextEncryptorLocator()));
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptorTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptorTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.encryption;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.context.encrypt.EncryptorFactory;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.Assert.assertEquals;
+
+public class CipherEnvironmentEncryptorTests {
+    TextEncryptor textEncryptor = new EncryptorFactory().create("foo");
+    TextEncryptorLocator textEncryptorLocator =  new SingleTextEncryptorLocator(textEncryptor);
+    EnvironmentEncryptor encryptor = new CipherEnvironmentEncryptor(textEncryptorLocator);
+
+    @Test
+    public void shouldDecryptEnvironment() {
+        // given
+        String secret = randomUUID().toString();
+
+        // when
+        Environment environment = new Environment("name", "profile", "label");
+        environment.add(new PropertySource("a",
+                Collections.<Object, Object>singletonMap(environment.getName(), "{cipher}" + textEncryptor.encrypt(secret))));
+
+        // then
+        assertEquals(secret, encryptor.decrypt(environment).getPropertySources().get(0).getSource().get(environment.getName()));
+    }
+}


### PR DESCRIPTION
We are trying to extend current encryption functionality by adding feature to use different TextEncryptor per environment. However we think that scope of adding such a feature seems to be too large for a single PR. In this PR we introduced no functional changes but some abstractions that will help us to extend current implementation in the future. Please let us know what do you think and if we are moving in the right direction.

TextEncryptorLocator can now be overridden with custom implementation which enables providing different encryption strategies per application profile.

Notable changes:

- TextEncryptorLocator - this class will be responsible for locating appropriate TextEncryptor for given application name and profile, in this version implementation is rather simplistic and mimics old behaviour found in EncryptionController
- EnvironmentEncryptor - encryptor that operates on Environment abstraction, contains extracted logic from EncryptionController.decrypt(Environment) function