### PR TITLE
Fix error loading config files in config server on Windows

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
@@ -133,8 +133,8 @@ public class NativeEnvironmentRepository implements EnvironmentRepository {
 				boolean matches = false;
 				String normal = name;
 				if (normal.startsWith("file:")) {
-					normal = new File(normal.substring("file:".length()))
-							.getAbsolutePath();
+					normal = StringUtils.cleanPath(new File(normal.substring("file:".length()))
+							.getAbsolutePath());
 				}
 				for (String pattern : StringUtils
 						.commaDelimitedListToStringArray(getLocations(searchLocations,


### PR DESCRIPTION
Make sure that the "normal" file path does not have Windows separators ("\") to be coherent with the "pattern" file path