### PR TITLE
Fixing problem in windows loading files

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/NativeEnvironmentRepository.java
@@ -133,8 +133,8 @@ public class NativeEnvironmentRepository implements EnvironmentRepository {
 				boolean matches = false;
 				String normal = name;
 				if (normal.startsWith("file:")) {
-					normal = new File(normal.substring("file:".length()))
-							.getAbsolutePath();
+					normal = StringUtils.cleanPath(new File(normal.substring("file:".length()))
+							.getAbsolutePath());
 				}
 				for (String pattern : StringUtils
 						.commaDelimitedListToStringArray(getLocations(searchLocations,


### PR DESCRIPTION
Fixing method clean in NativeEnvironmentRepository to avoid problems with Windows separators ("\").
 
Fixes gh-133