### PR TITLE
Add acceptEmpty option to accept or reject empty PropertySources

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -417,6 +417,15 @@ behavior, set the bootstrap configuration property
 `spring.cloud.config.failFast=true` and the client will halt with
 an Exception.
 
+[[config-client-accept-empty]]
+=== Config Client Accept Empty Property Sources
+
+By default, the Config Client will accept empty PropertySources, i.e.
+if the application is not found. However, if it is desired to reject empty 
+PropertySources and fail, either fast or retry, set the bootstrap configuration property
+`spring.cloud.config.acceptEmpty=false` and the client will throw an 
+`IllegalStateException` if empty PropertySources are retrieved. 
+
 === Locating Remote Configuration Resources
 
 The Config Service serves property sources from `/{name}/{env}/{label}`, where the default bindings in the

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -28,6 +28,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Dave Syer
+ * @author Haris Michopoulos
  *
  */
 @ConfigurationProperties(ConfigClientProperties.PREFIX)
@@ -60,6 +61,8 @@ public class ConfigClientProperties {
 	private Discovery discovery = new Discovery();
 
 	private boolean failFast = false;
+	
+	private boolean acceptEmpty = true;
 
 	private ConfigClientProperties() {
 	}
@@ -146,6 +149,14 @@ public class ConfigClientProperties {
 
 	public void setFailFast(boolean failFast) {
 		this.failFast = failFast;
+	}
+
+	public boolean isAcceptEmpty() {
+		return acceptEmpty;
+	}
+
+	public void setAcceptEmpty(boolean acceptEmpty) {
+		this.acceptEmpty = acceptEmpty;
 	}
 
 	private String[] extractCredentials() {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -42,6 +42,7 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Dave Syer
+ * @author Haris Michopoulos
  *
  */
 @Order(0)
@@ -78,6 +79,9 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 			Environment result = restTemplate.exchange(client.getRawUri() + path,
 					HttpMethod.GET, new HttpEntity<Void>((Void) null), Environment.class,
 					args).getBody();
+			if (!client.isAcceptEmpty() && result.getPropertySources().isEmpty()) {
+				throw new IllegalStateException("Empty property sources returned but fail if empty is set to true");
+			}
 			for (PropertySource source : result.getPropertySources()) {
 				@SuppressWarnings("unchecked")
 				Map<String, Object> map = (Map<String, Object>) source.getSource();
@@ -97,7 +101,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		}
 		if (client != null && client.isFailFast()) {
 			throw new IllegalStateException(
-					"Could not locate PropertySource and the fail fast property is set, failing",
+					"Could not locate PropertySource (or PropertySource empty) and the fail fast property is set, failing",
 					error);
 		}
 		logger.error("Could not locate PropertySource: "

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -97,6 +97,33 @@ public class ConfigServicePropertySourceLocatorTests {
 		expected.expectMessage("fail fast property is set");
 		assertNull(locator.locate(environment));
 	}
+	
+	@Test
+	public void failsQuietlyOnEmpty() throws Exception {
+		ConfigClientProperties configClientProperties = new ConfigClientProperties(environment);
+		configClientProperties.setAcceptEmpty(false);
+		ConfigServicePropertySourceLocator locator = new ConfigServicePropertySourceLocator(configClientProperties);
+		Environment body = new Environment("app", "master");
+		mockRequestResponseWithoutLabel(new ResponseEntity<Environment>(body, HttpStatus.OK));
+		locator.setRestTemplate(restTemplate);
+		assertNull(locator.locate(environment));
+	}
+
+	@Test
+	public void failsOnEmpty() throws Exception {
+		ConfigClientProperties configClientProperties = new ConfigClientProperties(environment);
+		configClientProperties.setAcceptEmpty(false);
+		configClientProperties.setFailFast(true);
+		
+		ConfigServicePropertySourceLocator locator = new ConfigServicePropertySourceLocator(configClientProperties);
+		Environment body = new Environment("app", "master");
+		mockRequestResponseWithoutLabel(new ResponseEntity<Environment>(body, HttpStatus.OK));
+		locator.setRestTemplate(restTemplate);
+		expected.expectCause(IsInstanceOf
+				.<Throwable> instanceOf(IllegalStateException.class));
+		expected.expectMessage("fail fast property is set");
+		assertNull(locator.locate(environment));
+	}
 
 	@SuppressWarnings("unchecked")
 	private void mockRequestResponseWithLabel(ResponseEntity<?> response, String label) {
@@ -116,3 +143,4 @@ public class ConfigServicePropertySourceLocatorTests {
 						Matchers.anyString())).thenReturn(response);
 	}
 }
+


### PR DESCRIPTION
Add acceptEmpty configuration option. If set to false and empty
PropertySources are returned, the client throws an
IllegalStateException.

Fixes gh-155