### PR TITLE
Optionally decrypt secret properties before sending them to the clients

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/ConfigServerEncryptionConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.encryption;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.config.server.ConfigServerProperties;
 import org.springframework.cloud.config.server.EncryptionController;
 import org.springframework.context.annotation.Bean;
@@ -37,6 +38,7 @@ public class ConfigServerEncryptionConfiguration {
 	private ConfigServerProperties properties;
 
 	@Bean
+	@ConditionalOnProperty(value = "spring.cloud.config.server.decrypt.enabled", matchIfMissing = true)
 	public EnvironmentEncryptor environmentEncryptor() {
 		return new CipherEnvironmentEncryptor(locator);
 	}


### PR DESCRIPTION
Add the option to disable decryption in the EnvironmentController to let clients manage decryption of the ciphered properties. In this way, secret properties go encrypted from server to client.