### PR TITLE
Fixed ConcurrentModificationException when properties stored in Map a…

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnvironmentController.java
@@ -16,15 +16,8 @@
 package org.springframework.cloud.config.server;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -297,9 +290,10 @@ public class EnvironmentController {
 	}
 
 	private void postProcessProperties(Map<String, Object> propertiesMap) {
-		for (String key : propertiesMap.keySet()) {
-			if (key.equals("spring.profiles")) {
-				propertiesMap.remove(key);
+		Iterator<String> i = propertiesMap.keySet().iterator();
+		while(i.hasNext()) {
+			if (i.next().equals("spring.profiles")) {
+				i.remove();
 			}
 		}
 	}


### PR DESCRIPTION
This is the fix for the issue I reported under:
ConcurrentModificationException when properties stored in Map after "spring.profiles" #180