### PR TITLE
GH-193 logs warning if failFast is false

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -104,7 +104,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 					"Could not locate PropertySource and the fail fast property is set, failing",
 					error);
 		}
-		logger.error("Could not locate PropertySource: "
+		logger.warn("Could not locate PropertySource: "
 				+ (errorBody == null ? error==null ? "label not found" : error.getMessage() : errorBody));
 		return null;
 


### PR DESCRIPTION
ConfigServicePropertySourceLocator should log a warning and not an error if failFast is false