### PR TITLE
Prefix keys not stripped prior to encryption

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -129,8 +129,9 @@ public class EncryptionController {
 			String input = stripFormData(data, type, false);
 			Map<String, String> keys = this.helper.getEncryptorKeys(name, profiles,
 					input);
+			String textToEncrypt = this.helper.stripPrefix(input);
 			String encrypted = this.helper.addPrefix(keys,
-					this.encryptor.locate(keys).encrypt(input));
+					this.encryptor.locate(keys).encrypt(textToEncrypt));
 			logger.info("Encrypted data");
 			return encrypted;
 		}
@@ -156,7 +157,7 @@ public class EncryptionController {
 					profiles, input);
 			TextEncryptor encryptor = this.encryptor.locate(encryptorKeys);
 			String encryptedText = this.helper.stripPrefix(input);
-			String decrypted = this.helper.stripPrefix(encryptor.decrypt(encryptedText));
+			String decrypted = encryptor.decrypt(encryptedText);
 			logger.info("Decrypted cipher data");
 			return decrypted;
 		}


### PR DESCRIPTION
**Expected**: When `POST`ing "{name: value}textToEncrypt" to the `/encrypt` endpoint, then only "textToEncrypt" should be encrypted.
**Actual** (broken) behavior: "{name: value}textToEncrypt" is encrypted.

Note that `EncryptionController.decrypt()` masks the problem by stripping prefixes twice, once prior to decrypting and once *after* decrypting the value.