### PR TITLE
fix  bug #293

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -74,6 +74,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	private JGitEnvironmentRepository.JGitFactory gitFactory = new JGitEnvironmentRepository.JGitFactory();
 
+    private Git git;
+
 	private String defaultLabel = DEFAULT_LABEL;
 
 	public JGitEnvironmentRepository(ConfigurableEnvironment environment) {
@@ -271,12 +273,17 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		if (hasText(getUsername())) {
 			setCredentialsProvider(clone);
 		}
-		return clone.call();
+        git = clone.call();
+        return git;
 	}
 
 	private void deleteBaseDirIfExists() {
 		if (getBasedir().exists()) {
 			try {
+				// check if git repo is already initialized and close it to prevent file locking issue on windows
+				if (git != null) {
+                    git.close();
+                }
 				FileUtils.delete(getBasedir(), FileUtils.RECURSIVE);
 			}
 			catch (IOException e) {


### PR DESCRIPTION
"Windows error JGitEnvironmentRepository fails to delete .git\objects\*pack"

Windows creates a file lock at org.eclipse.jgit.internal.storage.file.PackFile:601 and prevents deleting the base dir.
If there is an existing git client it must be closed before deleting the base dir.