### PR TITLE
Quote {application} in searchPaths placeholder doc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -329,7 +329,7 @@ spring:
       server:
         git:
           uri: https://github.com/spring-cloud-samples/config-repo
-          searchPaths: {application}
+          searchPaths: '{application}'
 ----
 
 searches the repository for files in the same name as the directory


### PR DESCRIPTION
Previously it was not quoted in the sample configuration in the documentation. This is not a valid YAML literal.

See #328

As pointed out by @westse in 2043b05bbe8cda91037fbaf464f5c47c8855ef07