### PR TITLE
Add `resolvePlaceholders` request parameter to `EnvironmentController`.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerMvcConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerMvcConfiguration.java
@@ -29,6 +29,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * @author Dave Syer
  * @author Roy Clarkson
@@ -49,6 +51,9 @@ public class ConfigServerMvcConfiguration extends WebMvcConfigurerAdapter {
 	@Autowired(required = false)
 	private EnvironmentEncryptor environmentEncryptor;
 
+	@Autowired(required = false)
+	private ObjectMapper objectMapper = new ObjectMapper();
+
 	@Override
 	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
 		configurer.mediaType("properties", MediaType.valueOf("text/plain"));
@@ -58,7 +63,7 @@ public class ConfigServerMvcConfiguration extends WebMvcConfigurerAdapter {
 
 	@Bean
 	public EnvironmentController environmentController() {
-		EnvironmentController controller = new EnvironmentController(encrypted());
+		EnvironmentController controller = new EnvironmentController(encrypted(), this.objectMapper);
 		controller.setStripDocumentFromYaml(this.server.isStripDocumentFromYaml());
 		return controller;
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -19,11 +19,9 @@ package org.springframework.cloud.config.server.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Map;
 
-import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.server.environment.EnvironmentRepository;
-import org.springframework.core.env.PropertySource;
+import org.springframework.cloud.config.server.support.EnvironmentPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -109,26 +107,6 @@ public class ResourceController {
 	@ExceptionHandler(NoSuchResourceException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public void notFound(NoSuchResourceException e) {
-	}
-
-	private static class EnvironmentPropertySource extends PropertySource<Environment> {
-
-		public EnvironmentPropertySource(Environment sources) {
-			super("cloudEnvironment", sources);
-		}
-
-		@Override
-		public Object getProperty(String name) {
-			for (org.springframework.cloud.config.environment.PropertySource source : getSource()
-					.getPropertySources()) {
-				Map<?, ?> map = source.getSource();
-				if (map.containsKey(name)) {
-					return map.get(name);
-				}
-			}
-			return null;
-		}
-
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 
 import org.springframework.cloud.config.server.environment.EnvironmentRepository;
-import org.springframework.cloud.config.server.support.EnvironmentPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -33,6 +32,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
 
 /**
  * An HTTP endpoint for serving up templated plain text resources from an underlying
@@ -63,24 +65,19 @@ public class ResourceController {
 	public synchronized String resolve(@PathVariable String name,
 			@PathVariable String profile, @PathVariable String label,
 			@PathVariable String path) throws IOException {
-		StandardEnvironment environment = new StandardEnvironment();
 		if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");
 		}
-		environment.getPropertySources().addAfter(
-				StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
-				new EnvironmentPropertySource(
-						this.environmentRepository.findOne(name, profile, label)));
+		StandardEnvironment environment = prepareEnvironment(
+						this.environmentRepository.findOne(name, profile, label));
 
 		// ensure InputStream will be closed to prevent file locks on Windows
 		try (InputStream is = this.resourceRepository.findOne(name, profile, label, path)
 				.getInputStream()) {
 			String text = StreamUtils.copyToString(is, Charset.forName("UTF-8"));
-			// Mask out escaped placeholders
-			text = text.replace("\\${", "$_{");
-			return environment.resolvePlaceholders(text).replace("$_{", "${");
+			return resolvePlaceholders(environment, text);
 		}
 	}
 
@@ -88,16 +85,13 @@ public class ResourceController {
 	public synchronized byte[] binary(@PathVariable String name,
 			@PathVariable String profile, @PathVariable String label,
 			@PathVariable String path) throws IOException {
-		StandardEnvironment environment = new StandardEnvironment();
 		if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");
 		}
-		environment.getPropertySources().addAfter(
-				StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
-				new EnvironmentPropertySource(
-						this.environmentRepository.findOne(name, profile, label)));
+		//TODO: is this line needed for side effects?
+		prepareEnvironment(this.environmentRepository.findOne(name, profile, label));
 		try (InputStream is = this.resourceRepository.findOne(name, profile, label, path)
 				.getInputStream()) {
 			return StreamUtils.copyToByteArray(is);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.config.server.support;
+
+import java.util.Map;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * @author Spencer Gibb
+ */
+public class EnvironmentPropertySource extends PropertySource<Environment> {
+
+	public static String resolvePlaceholders(Environment environment, String text) {
+		StandardEnvironment standardEnvironment = new StandardEnvironment();
+		standardEnvironment.getPropertySources().addAfter(
+				StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
+				new EnvironmentPropertySource(environment));
+		// Mask out escaped placeholders
+		text = text.replace("\\${", "$_{");
+		text = standardEnvironment.resolvePlaceholders(text).replace("$_{", "${");
+		return text;
+	}
+
+	public EnvironmentPropertySource(Environment sources) {
+		super("cloudEnvironment", sources);
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		for (org.springframework.cloud.config.environment.PropertySource source : getSource()
+				.getPropertySources()) {
+			Map<?, ?> map = source.getSource();
+			if (map.containsKey(name)) {
+				return map.get(name);
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
@@ -11,15 +11,18 @@ import org.springframework.core.env.StandardEnvironment;
  */
 public class EnvironmentPropertySource extends PropertySource<Environment> {
 
-	public static String resolvePlaceholders(Environment environment, String text) {
+	public static StandardEnvironment prepareEnvironment(Environment environment) {
 		StandardEnvironment standardEnvironment = new StandardEnvironment();
 		standardEnvironment.getPropertySources().addAfter(
 				StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
 				new EnvironmentPropertySource(environment));
+		return standardEnvironment;
+	}
+
+	public static String resolvePlaceholders(StandardEnvironment preparedEnvironment, String text) {
 		// Mask out escaped placeholders
 		text = text.replace("\\${", "$_{");
-		text = standardEnvironment.resolvePlaceholders(text).replace("$_{", "${");
-		return text;
+		return preparedEnvironment.resolvePlaceholders(text).replace("$_{", "${");
 	}
 
 	public EnvironmentPropertySource(Environment sources) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -173,12 +173,10 @@ public class EnvironmentControllerTests {
 	}
 
 	@Test
-	@Ignore("until json placeholders are resolved")
 	public void placeholdersResolvedInJson() throws Exception {
 		whenPlaceholders();
-		Map<String, Object> map = this.controller.jsonProperties("foo", "bar", true).getBody();
-		assertEquals("bar", map.get("a.b.c"));
-		assertEquals("bar", map.get("foo"));
+		String json = this.controller.jsonProperties("foo", "bar", true).getBody();
+		assertEquals("{\"a\":{\"b\":{\"c\":\"bar\"}},\"foo\":\"bar\"}", json);
 	}
 
 	private void whenPlaceholders() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -62,7 +63,7 @@ public class EnvironmentControllerTests {
 		map.put("a.b.c", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("a:\n  b:\n    c: d\n", yaml);
 	}
 
@@ -74,8 +75,15 @@ public class EnvironmentControllerTests {
 		this.environment.addFirst(new PropertySource("two", Collections.singletonMap("a.b.c",
 				"e")));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("a:\n  b:\n    c: e\n", yaml);
+	}
+
+	@Test
+	public void placeholdersResolvedInYaml() throws Exception {
+		whenPlaceholders();
+		String yaml = this.controller.yaml("foo", "bar", true).getBody();
+		assertEquals("a:\n  b:\n    c: bar\nfoo: bar\n", yaml);
 	}
 
 	@Test
@@ -85,7 +93,7 @@ public class EnvironmentControllerTests {
 		map.put("a.b[1]", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("a:\n  b:\n  - c\n  - d\n", yaml);
 	}
 
@@ -95,7 +103,7 @@ public class EnvironmentControllerTests {
 		map.put("document", "blah");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("blah\n", yaml);
 	}
 
@@ -106,7 +114,7 @@ public class EnvironmentControllerTests {
 		map.put("document[1]", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("- c\n- d\n", yaml);
 	}
 
@@ -117,7 +125,7 @@ public class EnvironmentControllerTests {
 		map.put("document[1].a", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("- a: c\n- a: d\n", yaml);
 	}
 
@@ -129,7 +137,7 @@ public class EnvironmentControllerTests {
 		map.put("a.b[1].c", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertTrue("Wrong output: " + yaml,
 				"a:\n  b:\n  - d: e\n    c: d\n  - c: d\n".equals(yaml)
 				|| "a:\n  b:\n  - c: d\n    d: e\n  - c: d\n".equals(yaml));
@@ -142,7 +150,7 @@ public class EnvironmentControllerTests {
 		map.put("b[1].c", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("b:\n- c: d\n- c: d\n", yaml);
 	}
 
@@ -153,8 +161,32 @@ public class EnvironmentControllerTests {
 		map.put("x.a.b[1].c", "d");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
-		String yaml = this.controller.yaml("foo", "bar").getBody();
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
 		assertEquals("x:\n  a:\n    b:\n    - c: d\n    - c: d\n", yaml);
+	}
+
+	@Test
+	public void placeholdersResolvedInProperties() throws Exception {
+		whenPlaceholders();
+		String text = this.controller.properties("foo", "bar", true).getBody();
+		assertEquals("a.b.c: bar\nfoo: bar", text);
+	}
+
+	@Test
+	@Ignore("until json placeholders are resolved")
+	public void placeholdersResolvedInJson() throws Exception {
+		whenPlaceholders();
+		Map<String, Object> map = this.controller.jsonProperties("foo", "bar", true).getBody();
+		assertEquals("bar", map.get("a.b.c"));
+		assertEquals("bar", map.get("foo"));
+	}
+
+	private void whenPlaceholders() {
+		Map<String, Object> map = new LinkedHashMap<String, Object>();
+		map.put("foo", "bar");
+		this.environment.add(new PropertySource("one", map));
+		this.environment.addFirst(new PropertySource("two", Collections.singletonMap("a.b.c", "${foo}")));
+		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
 	}
 
 	@Test


### PR DESCRIPTION
Specifically to the `{json|yaml|properties}` endpoints to support sidecar or non-jvm apps to have placeholders resolved automatically.

See https://github.com/spring-cloud/spring-cloud-netflix/issues/877

/cc @dsyer what do you think?