### PR TITLE
Add support for multiple config server addresses

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -830,8 +830,8 @@ property `spring.cloud.config.uri`) and initializes Spring
 
 The net result of this is that all client apps that want to consume
 the Config Server need a `bootstrap.yml` (or an environment variable)
-with the server address in `spring.cloud.config.uri` (defaults to
-"http://localhost:8888").
+with one or multiple, comma separated server addresses in 
+`spring.cloud.config.uri` (defaults to "http://localhost:8888"). 
 
 [[eureka-first-bootstrap]]
 === Eureka First Bootstrap

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerEndpointRepository.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerEndpointRepository.java
@@ -1,0 +1,27 @@
+package org.springframework.cloud.config.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.cloud.config.client.ConfigClientProperties.ConfigServerEndpoint;
+
+/**
+ * @author Felix Kissel
+ *
+ */
+public class ConfigServerEndpointRepository  {
+	
+	private List<ConfigServerEndpoint> configServerEndpoints = Collections.emptyList();
+
+	public synchronized void setConfigServerEndpoints(
+			List<ConfigServerEndpoint> configServerEndpoints) {
+		this.configServerEndpoints = Collections
+				.unmodifiableList(new ArrayList<>(configServerEndpoints));
+	}
+	
+	public List<ConfigServerEndpoint> getConfigServerEndpoints() {
+		return this.configServerEndpoints;
+	}
+	
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 
 /**
  * @author Dave Syer
+ * @author Felix Kissel
  *
  */
 @Configuration
@@ -48,12 +49,20 @@ public class ConfigServiceBootstrapConfiguration {
 		ConfigClientProperties client = new ConfigClientProperties(this.environment);
 		return client;
 	}
+	
+	@Bean
+	public ConfigServerEndpointRepository configServerEndpointSelector() {
+		ConfigServerEndpointRepository configServerEndpointSelector = new ConfigServerEndpointRepository();
+		configServerEndpointSelector.setConfigServerEndpoints(
+				configClientProperties().getConfigServerEndpoints());
+		return configServerEndpointSelector;
+	}
 
 	@Bean
 	@ConditionalOnProperty(value = "spring.cloud.config.enabled", matchIfMissing = true)
 	public ConfigServicePropertySourceLocator configServicePropertySource() {
 		ConfigServicePropertySourceLocator locator = new ConfigServicePropertySourceLocator(
-				configClientProperties());
+				configClientProperties(), configServerEndpointSelector());
 		return locator;
 	}
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
@@ -16,15 +16,25 @@
 package org.springframework.cloud.config.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
-import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.cloud.config.client.ConfigClientProperties.ConfigSelectionProperties;
+import org.springframework.cloud.config.client.ConfigClientProperties.ConfigServerEndpoint;
+import org.springframework.cloud.config.client.ConfigClientProperties.Credentials;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 
+
 /**
  * @author Dave Syer
+ * @author Felix Kissel
  *
  */
 public class ConfigClientPropertiesTests {
@@ -36,26 +46,90 @@ public class ConfigClientPropertiesTests {
 	public void vanilla() {
 		locator.setUri("http://localhost:9999");
 		locator.setPassword("secret");
-		assertEquals("http://localhost:9999", locator.getRawUri());
-		assertEquals("user", locator.getUsername());
-		assertEquals("secret", locator.getPassword());
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals(ConfigServerEndpoint.DEFAULT_USERNAME_user,
+				credentials.getUsername());
+		assertEquals("secret", credentials.getPassword());
 	}
 
 	@Test
 	public void uriCreds() {
 		locator.setUri("http://foo:bar@localhost:9999");
-		assertEquals("http://localhost:9999", locator.getRawUri());
-		assertEquals("foo", locator.getUsername());
-		assertEquals("bar", locator.getPassword());
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals("foo", credentials.getUsername());
+		assertEquals("bar", credentials.getPassword());
 	}
 
 	@Test
-	public void explicitPassword() {
+	public void overrideUriPassword() {
 		locator.setUri("http://foo:bar@localhost:9999");
 		locator.setPassword("secret");
-		assertEquals("http://localhost:9999", locator.getRawUri());
-		assertEquals("foo", locator.getUsername());
-		assertEquals("secret", locator.getPassword());
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals("foo", credentials.getUsername());
+		assertEquals("secret", credentials.getPassword());
+	}
+	
+	@Test
+	public void explicitCreds() {
+		locator.setUri("http://foo:bar@localhost:9999");
+		locator.setUsername("username");
+		locator.setPassword("secret");
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals("username", credentials.getUsername());
+		assertEquals("secret", credentials.getPassword());
+	}
+	
+	@Test
+	public void ignoreExplicitUsernameWithoutExplicitPassword() {
+		locator.setUri("http://foo:bar@localhost:9999");
+		locator.setUsername("username");
+
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals("foo", credentials.getUsername());
+		assertEquals("bar", credentials.getPassword());
+	}
+	
+	@Test
+	public void explicitPassword() {
+		locator.setUri("http://foo@localhost:9999");
+		locator.setPassword("secret");
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals("foo", credentials.getUsername());
+		assertEquals("secret", credentials.getPassword());
 	}
 
 	@Test
@@ -63,8 +137,118 @@ public class ConfigClientPropertiesTests {
 		locator.setName("one");
 		ConfigurableEnvironment environment = new StandardEnvironment();
 		EnvironmentTestUtils.addEnvironment(environment, "spring.application.name:two");
-		ConfigClientProperties override = locator.override(environment);
-		assertEquals("two", override.getName());
+		ConfigSelectionProperties configSelectionProperties = locator
+				.getConfigSelectionProperties(environment);
+		assertEquals("two", configSelectionProperties.getName());
+	}
+	
+	@Test
+	public void ignoreUriUsernameWithoutPassword() {
+		locator.setUri("http://foo@localhost:9999");
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		assertNull(configServerEndpoint.getCredentials());
+	}
+	
+	@Test
+	public void kickoutEmptyUriCreds() {
+		locator.setUri("http://:@localhost:9999");
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		assertNull(configServerEndpoint.getCredentials());
+	}
+	
+	@Test
+	public void ignoreUriCredsWithMissingPassword() {
+		locator.setUri("http://foo:@localhost:9999");
+
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		assertNull(configServerEndpoint.getCredentials());
+	}
+	
+	@Test
+	public void useFallbackUsernameForUriCredsWithMissingUsername() {
+		locator.setUri("http://:bar@localhost:9999");
+		
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(1, configServerEndpoints.size());
+		ConfigServerEndpoint configServerEndpoint = configServerEndpoints.get(0);
+		assertEquals("http://localhost:9999", configServerEndpoint.getRawUri());
+		Credentials credentials = configServerEndpoint.getCredentials();
+		assertNotNull(credentials);
+		assertEquals(ConfigServerEndpoint.DEFAULT_USERNAME_user,
+				credentials.getUsername());
+		assertEquals("bar", credentials.getPassword());
+	}
+	
+	public void missingUriTriggerIllegalStateException() {
+		locator.setUri(null);
+		
+		assertTrue( locator.getConfigServerEndpoints().isEmpty());
+	}
+	
+	@Test
+	public void multipleUrisVanilla() {
+		locator.setUri("http://localhost1:9999,http://localhost2:9999");
+		locator.setPassword("secret");
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(2, configServerEndpoints.size());
+		
+		assertEquals("http://localhost1:9999", configServerEndpoints.get(0).getRawUri());
+		assertEquals(ConfigServerEndpoint.DEFAULT_USERNAME_user,
+				configServerEndpoints.get(0).getCredentials().getUsername());
+		assertEquals("secret", configServerEndpoints.get(0).getCredentials().getPassword());
+
+		assertEquals("http://localhost2:9999", configServerEndpoints.get(1).getRawUri());
+		assertEquals(ConfigServerEndpoint.DEFAULT_USERNAME_user,
+				configServerEndpoints.get(1).getCredentials().getUsername());
+		assertEquals("secret", configServerEndpoints.get(1).getCredentials().getPassword());
 	}
 
+	@Test
+	public void multipleUrisExplicitPassword() {
+		locator.setUri("http://localhost1:9999,http://foo@localhost2:9999");
+		locator.setPassword("secret");
+		List<ConfigServerEndpoint> configServerEndpoints = locator.getConfigServerEndpoints();
+		assertEquals(2, configServerEndpoints.size());
+		
+		assertEquals("http://localhost1:9999", configServerEndpoints.get(0).getRawUri());
+		assertEquals(ConfigServerEndpoint.DEFAULT_USERNAME_user,
+				configServerEndpoints.get(0).getCredentials().getUsername());
+		assertEquals("secret", configServerEndpoints.get(0).getCredentials().getPassword());
+		
+		assertEquals("http://localhost2:9999", configServerEndpoints.get(1).getRawUri());
+		assertEquals("foo", configServerEndpoints.get(1).getCredentials().getUsername());
+		assertEquals("secret", configServerEndpoints.get(1).getCredentials().getPassword());
+	}
+	
+	@SuppressWarnings("deprecation")
+	@Test(expected = IllegalStateException.class) 
+	public void getUsernameFailsForMissingServerEndpoint() {
+		locator.setUri(null);
+		locator.getUsername();
+	}
+	
+	@SuppressWarnings("deprecation")
+	@Test(expected = IllegalStateException.class) 
+	public void getPasswordFailsForMissingServerEndpoint() {
+		locator.setUri(null);
+		locator.getPassword();
+	}
+	@SuppressWarnings("deprecation")
+	@Test(expected = IllegalStateException.class) 
+	public void getRawUriFailsForMissingServerEndpoint() {
+		locator.setUri(null);
+		locator.getRawUri();
+	}
+	
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerEndpointRepositoryTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerEndpointRepositoryTests.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.config.client;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.cloud.config.client.ConfigClientProperties.ConfigServerEndpoint;
+
+public class ConfigServerEndpointRepositoryTests {
+
+	@Test
+	public void newRepoIsEmpty() {
+		Assert.assertTrue(new ConfigServerEndpointRepository().getConfigServerEndpoints()
+				.isEmpty());
+	}
+
+	@Test
+	public void vanilla() {
+		ConfigServerEndpointRepository configServerEndpointRepository = new ConfigServerEndpointRepository();
+		ConfigServerEndpoint endpoint1 = mock(ConfigServerEndpoint.class);
+		ConfigServerEndpoint endpoint2 = mock(ConfigServerEndpoint.class);
+		List<ConfigServerEndpoint> list = Arrays.asList(endpoint1, endpoint2);
+		configServerEndpointRepository.setConfigServerEndpoints(list);
+
+		Assert.assertEquals(list,
+				configServerEndpointRepository.getConfigServerEndpoints());
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/CredentialsTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/CredentialsTests.java
@@ -1,0 +1,26 @@
+package org.springframework.cloud.config.client;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.springframework.cloud.config.client.ConfigClientProperties.Credentials;
+
+public class CredentialsTests {
+
+	@Test(expected = NullPointerException.class)
+	public void emptyUsernameFails() {
+		new ConfigClientProperties.Credentials(null, "x");
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void emptyPasswordFails() {
+		new ConfigClientProperties.Credentials("x", null);
+	}
+
+	@Test
+	public void passwordDoesNotAppearInToString() {
+		Credentials credentials = new ConfigClientProperties.Credentials("foo", "bar");
+		assertFalse(credentials.toString().contains("bar"));
+	}
+
+}


### PR DESCRIPTION
Multiple config server addresses can be set in spring.cloud.config.uri
as a comma separated list. If server discovery is enabled, all provided
service instances are taken.

The result of the first available server is used.

See https://github.com/spring-cloud/spring-cloud-config/issues/342