### PR TITLE
Updated docs with proper name of `user` property in Eureka First Bootstrap

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -869,7 +869,7 @@ eureka:
   instance:
     ...
     metadataMap:
-      username: osufhalskjrtl
+      user: osufhalskjrtl
       password: lviuhlszvaorhvlo5847
       configPath: /config
 ----


### PR DESCRIPTION
According to [DiscoveryClientConfigServiceBootstrapConfiguration.java](https://github.com/spring-cloud/spring-cloud-config/blob/master/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfiguration.java), proper name of `username` property is `user`.