### PR TITLE
Support for applications with dashes in its names

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 /**
  * @author Dave Syer
  * @author Roy Clarkson
+ * @author Ivan Corrales Solera
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = ControllerConfiguration.class)
@@ -84,6 +85,14 @@ public class EnvironmentControllerIntegrationTests {
 		this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-default.properties")).andExpect(
 				MockMvcResultMatchers.status().isOk());
 		Mockito.verify(this.repository).findOne("foo", "default", "label");
+	}
+
+	@Test
+	public void propertiesLabelWhenApplicationNameContainsHyphen() throws Exception {
+		Mockito.when(this.repository.findOne("foo-bar", "default", "label")).thenReturn(new Environment("foo-bar", "default"));
+		this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-bar-default.properties")).andExpect(
+				MockMvcResultMatchers.status().isOk());
+		Mockito.verify(this.repository).findOne("foo-bar", "default", "label");
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -15,16 +15,7 @@
  */
 package org.springframework.cloud.config.server.environment;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,9 +28,18 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Dave Syer
  * @author Roy Clarkson
+ * @author Ivan Corrales Solera
  */
 public class EnvironmentControllerTests {
 
@@ -251,11 +251,11 @@ public class EnvironmentControllerTests {
 
 	@Test
 	public void mappingForLabelledYamlWithHyphen() throws Exception {
-		Mockito.when(this.repository.findOne("foo", "bar-spam", "other")).thenReturn(
+		Mockito.when(this.repository.findOne("foo-bar-foo2-bar2", "spam", "other")).thenReturn(
 				this.environment);
 		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
-		mvc.perform(MockMvcRequestBuilders.get("/other/foo-bar-spam.yml")).andExpect(
-				MockMvcResultMatchers.status().isBadRequest());
+		mvc.perform(MockMvcRequestBuilders.get("/other/foo-bar-foo2-bar2-spam.yml")).andExpect(
+				MockMvcResultMatchers.content().contentType(MediaType.TEXT_PLAIN));
 	}
 
 	@Test
@@ -276,11 +276,12 @@ public class EnvironmentControllerTests {
 
 	@Test
 	public void mappingForLabelledJsonPropertiesWithHyphen() throws Exception {
-		Mockito.when(this.repository.findOne("foo", "bar-spam", "other")).thenReturn(
+		Mockito.when(this.repository.findOne("foo-bar-foo2-bar2", "spam", "other")).thenReturn(
 				this.environment);
 		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
-		mvc.perform(MockMvcRequestBuilders.get("/other/foo-bar-spam.json")).andExpect(
-				MockMvcResultMatchers.status().isBadRequest());
+		mvc.perform(MockMvcRequestBuilders.get("/other/foo-bar-foo2-bar2-spam.json")).andExpect(
+				MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON));
+
 	}
 
 }


### PR DESCRIPTION
Support applications and profiles with dashes in its names in properties, json & yml endpoints.

See discussion on #384 