### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -87,7 +87,7 @@ Server? The strategy that governs this behaviour is the
 
 * `{application}` maps to "spring.application.name" on the client side;
 
-* `{profile}` maps to "spring.active.profiles" on the client (comma separated list); and 
+* `{profile}` maps to "spring.profiles.active" on the client (comma separated list); and 
 
 * `{label}` which is a server side feature labelling a "versioned" set of config files.
 


### PR DESCRIPTION
In documentation, at one place, it is mentioned "spring.active.profiles" but it should be "spring.profiles.active".  