### PR TITLE
Uses ./mvnw instead of mvn

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Start the server:
 
 ----
 $ cd spring-cloud-config-server
-$ mvn spring-boot:run
+$ ./mvnw spring-boot:run
 ----
 
 The server is a Spring Boot application so you can run it from your


### PR DESCRIPTION
Uses mvnw to prevent users from getting stuck due to errors (like I did).