### PR TITLE
Cache config client health indicator.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1166,6 +1166,10 @@ If you use another form of security you might need to <<custom-rest-template,pro
 `RestTemplate`>> to the `ConfigServicePropertySourceLocator` (e.g. by
 grabbing it in the bootstrap context and injecting one).
 
+==== Health Indicator
+
+The Config Client supplies a Spring Boot Health Indicator that attempts to load configuration from Config Server. The health indicator can be disabled by setting `health.config.enabled=false`. The response is also cached for performance reasons. The default cache time to live is 5 minutes. To change that value set the `health.config.time-to-live` property (in milliseconds).
+
 [[custom-rest-template]]
 ==== Providing A Custom RestTemplate
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
@@ -53,6 +53,11 @@ public class ConfigClientAutoConfiguration {
 		return client;
 	}
 
+	@Bean
+	public ConfigClientHealthProperties configClientHealthProperties() {
+		return new ConfigClientHealthProperties();
+	}
+
 	@Configuration
 	@ConditionalOnClass(HealthIndicator.class)
 	@ConditionalOnBean(ConfigServicePropertySourceLocator.class)
@@ -61,24 +66,9 @@ public class ConfigClientAutoConfiguration {
 
 		@Bean
 		public ConfigServerHealthIndicator configServerHealthIndicator(
-				ConfigServicePropertySourceLocator locator, Environment environment) {
-			return new ConfigServerHealthIndicator(locator, environment);
-		}
-	}
-
-	@ConfigurationProperties("health.config")
-	public static class Health {
-		/**
-		 * Flag to indicate that the config server health indicator should be installed.
-		 */
-		boolean enabled;
-
-		public boolean isEnabled() {
-			return this.enabled;
-		}
-
-		public void setEnabled(boolean enabled) {
-			this.enabled = enabled;
+				ConfigServicePropertySourceLocator locator,
+				ConfigClientHealthProperties properties, Environment environment) {
+			return new ConfigServerHealthIndicator(locator, environment, properties);
 		}
 	}
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientHealthProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientHealthProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.config.client;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Spencer Gibb
+ */
+@ConfigurationProperties("health.config")
+public class ConfigClientHealthProperties {
+	/**
+	 * Flag to indicate that the config server health indicator should be installed.
+	 */
+	boolean enabled;
+
+	/**
+	 * Time to live for cached result, in milliseconds. Default 300000 (5 min).
+	 */
+	private long timeToLive = 60 * 5 * 1000;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public long getTimeToLive() {
+		return timeToLive;
+	}
+
+	public void setTimeToLive(long timeToLive) {
+		this.timeToLive = timeToLive;
+	}
+}


### PR DESCRIPTION
So config server isn't bombarded with requests.

Should `health.config.enabled` default to `false`?

/cc @dsyer @marcingrzejszczak @adriancole 

I'd also bump version to 1.2.0 for Camden.