### PR TITLE
Incorrect version returned on first request after git commit

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -148,6 +148,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 			Ref ref = checkout(git, label);
 			if (shouldPull(git, ref)) {
 				pull(git, label, ref);
+				ref = checkout(git, label);
 			}
 			return ref;
 		}


### PR DESCRIPTION
There is a bug where the version returned on the first request after an update is committed to git incorrectly returns the previous version (commit ID).  This was because the Ref returned was from the checkout prior to the pull. 