### PR TITLE
Adding Generic "Authorization" support for Config Client

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -90,6 +90,11 @@ public class ConfigClientProperties {
 	 */
 	private String token;
 
+	/**
+	 * Authorization token used by the client to connect to the server.
+	 */
+	private String authorization;
+
 	private ConfigClientProperties() {
 	}
 
@@ -184,6 +189,16 @@ public class ConfigClientProperties {
 	public void setToken(String token) {
 		this.token = token;
 	}
+
+	public String getAuthorization() {
+		return this.authorization;
+	}
+
+	public void setAuthorization(String authorization) {
+		this.authorization = authorization;
+	}
+
+
 
 	private String[] extractCredentials() {
 		String[] result = new String[3];
@@ -286,6 +301,7 @@ public class ConfigClientProperties {
 				+ this.profile + ", name=" + this.name + ", label="
 				+ (this.label == null ? "" : this.label) + ", username=" + this.username
 				+ ", password=" + this.password + ", uri=" + this.uri
+				+ ", authorization=" + this.authorization
 				+ ", discovery.enabled=" + this.discovery.enabled + ", failFast="
 				+ this.failFast + ", token=" + this.token + "]";
 	}


### PR DESCRIPTION
* Adds the Cloud Config Property "authorization" to the Config Client Properties
* Adds a GenericAuthorization header to the `restTemplate`
 * Inspired by the Basic Authorization support
* ResourceLocator uses the generic HTTP Authorization header to connect to the config server uri. 
 * Users won't be able to set both the "password" and "authorization" at the same time.

When set, the client will use the value to create a generic Authorization header with the value provided, instead of the Basic Auth.

Discussions about this at https://github.com/spring-cloud/spring-cloud-config/issues/177#issuecomment-239076005

Client Setup
=====

* Client configuration is provided using `authorization`. 

```yml
spring:
  cloud:
    config:
      uri: http://config.platform.company.net:8888
      authorization: Company_IAM_Authorization appid=myapp,appsecret=preprddtWGsk4WpFdL
```

This is very similar to the following:

```
curl -H "Authorization: Company_IAM_Authorization appid=myapp,appsecret=preprddtWGsk4WpFdL" \
    http://config.platform.company.net:8888/admin/env | jq
```