### PR TITLE
Handle Git Environment Repository updated from a forced push.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/test/ConfigServerTestUtils.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/test/ConfigServerTestUtils.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.config.server.test;
 
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryCache.FileKey;
+import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.FileUtils;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
@@ -24,8 +27,22 @@ import java.io.IOException;
 
 /**
  * @author Dave Syer
+ * @author Daniel Lavoie
  */
 public class ConfigServerTestUtils {
+	public static Repository prepareBareRemote() throws IOException {
+		// Create a folder in the temp folder that will act as the remote repository
+		File remoteDir = File.createTempFile("remote", "");
+		remoteDir.delete();
+		remoteDir.mkdirs();
+
+		// Create a bare repository
+		FileKey fileKey = FileKey.exact(remoteDir, FS.DETECTED);
+		Repository remoteRepo = fileKey.open(false);
+		remoteRepo.create(true);
+
+		return remoteRepo;
+	}
 
 	public static String prepareLocalRepo() throws IOException {
 		return prepareLocalRepo("./", "target/repos", "config-repo", "target/config");


### PR DESCRIPTION
Fixes gh-481.

The unit test might not seem obvious so feel free to ask about it. If you want to fully understand the reason behind this PR, checkout my branch, revert the `JGitEnvironmentRepository` changes I made and run the `JGitEnvironmentRepositoryIntegrationTests.pullDivergedRepo()` test. You will see that the local repositroy will be left in a conflicting state. It represents the issue I encountered in production. 

In order to fix this issue, I changed the `git pull` operation performed by `JGitEnvironmentRepository` to a `git fetch` then `git reset --hard`. IMO, hard is reset is acceptable since the local repository should not be modified.