### PR TITLE
fix svn repo to also check branches and tags folders for label

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
@@ -183,9 +183,9 @@ public class SvnKitEnvironmentRepository extends AbstractScmEnvironmentRepositor
 		File svnPath = new File(workingDirectory, label);
 		if(!svnPath.exists()) {
 			svnPath = new File(workingDirectory, "branches" + File.separator + label);
-		}
-		if(!svnPath.exists()) {
-			svnPath = new File(workingDirectory, "tags" + File.separator + label);
+			if(!svnPath.exists()) {
+				svnPath = new File(workingDirectory, "tags" + File.separator + label);
+			}
 		}
 		return svnPath; 
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
@@ -179,7 +179,15 @@ public class SvnKitEnvironmentRepository extends AbstractScmEnvironmentRepositor
 
 	private File getSvnPath(File workingDirectory, String label) {
 		// use label as path relative to repository root
-		return new File(workingDirectory, label);
+		// if it doesn't exists check branches and then tags folders
+		File svnPath = new File(workingDirectory, label);
+		if(!svnPath.exists()) {
+			svnPath = new File(workingDirectory, "branches" + File.separator + label);
+		}
+		if(!svnPath.exists()) {
+			svnPath = new File(workingDirectory, "tags" + File.separator + label);
+		}
+		return svnPath; 
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
@@ -185,6 +185,9 @@ public class SvnKitEnvironmentRepository extends AbstractScmEnvironmentRepositor
 			svnPath = new File(workingDirectory, "branches" + File.separator + label);
 			if(!svnPath.exists()) {
 				svnPath = new File(workingDirectory, "tags" + File.separator + label);
+				if(!svnPath.exists()) {
+					throw new NoSuchLabelException("No label found for: " + label);
+				}
 			}
 		}
 		return svnPath; 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.environment;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -141,6 +142,20 @@ public class SVNKitEnvironmentRepositoryIntegrationTests {
 		repository.findOne("bar", "staging", "unknownlabel");
 		Environment environment = repository.findOne("bar", "staging", "unknownlabel");
 		assertEquals(0, environment.getPropertySources().size());
+	}
+
+	@Test
+	public void branchLabel() throws Exception {
+		String uri = ConfigServerTestUtils.prepareLocalSvnRepo(
+				"src/test/resources/svn-config-repo", "target/config");
+		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.profiles("subversion")
+				.run("--spring.cloud.config.server.svn.uri=" + uri);
+		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
+		Environment environment = repository.findOne("bar", "staging", "demobranch");
+		assertTrue(environment.getPropertySources().get(0).getName()
+				.contains("bar.properties"));
+		assertEquals(1, environment.getPropertySources().size());
 	}
 
 	@Configuration

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
@@ -104,6 +104,15 @@ public class SVNKitEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void branch_no_folder() {
+		Environment environment = this.repository.findOne("bar", "staging",
+				"demobranch");
+		assertEquals(1, environment.getPropertySources().size());
+		assertTrue(environment.getPropertySources().get(0).getName()
+				.contains("bar.properties"));
+	}
+
+	@Test
 	public void vanilla_with_update() {
 		this.findOne();
 		Environment environment = this.findOne();


### PR DESCRIPTION
Currently {label} only works with 'trunk' for svn repository (using the standard svn folder layout), This fix allows to look for label inside branches and tags folder.