### PR TITLE
Support nested arrays when translating properties to map

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -428,19 +428,16 @@ public class EnvironmentController {
 		private String getKey() {
 			// Consider initial value or previous char '.' or '['
 			int start = currentPos + 1;
-			char_loop:
 			for (int i = start; i < propertyKey.length(); i++) {
-				switch (propertyKey.charAt(i)) {
-					case '.':
-						currentPos = i;
-						valueType = NodeType.MAP;
-						break char_loop;
-					case '[':
-						currentPos = i;
-						valueType = NodeType.ARRAY;
-						break char_loop;
-					default:
-						continue;
+				char currentChar = propertyKey.charAt(i);
+				if (currentChar == '.') {
+					valueType = NodeType.MAP;
+					currentPos = i;
+					break;
+				} else if (currentChar == '[') {
+					valueType = NodeType.ARRAY;
+					currentPos = i;
+					break;
 				}
 			}
 			// If there's no delimiter then it's a key of a leaf

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -208,11 +208,10 @@ public class EnvironmentController {
 	/**
 	 * Method {@code convertToMap} converts an {@code Environment} to a nested Map which represents a yml/json structure.
 	 *
-	 * @param input
-	 * @return
-	 * @throws BindException
+	 * @param input the environment to be converted
+	 * @return the nested map containing the environment's properties
 	 */
-	private Map<String, Object> convertToMap(Environment input) throws BindException {
+	private Map<String, Object> convertToMap(Environment input) {
 		// First use the current convertToProperties to get a flat Map from the environment
 		Map<String, Object> properties = convertToProperties(input);
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -329,19 +329,19 @@ public class EnvironmentController {
 	 */
 	private static class PropertyNavigator {
 
-		enum NodeType {LEAF, MAP, ARRAY}
+		private enum NodeType {LEAF, MAP, ARRAY}
 
-		final String propertyKey;
-		int currentPos;
-		NodeType valueType;
+		private final String propertyKey;
+		private int currentPos;
+		private NodeType valueType;
 
-		PropertyNavigator(String propertyKey) {
+		private PropertyNavigator(String propertyKey) {
 			this.propertyKey = propertyKey;
 			currentPos = -1;
 			valueType = NodeType.MAP;
 		}
 
-		void setMapValue(Map<String, Object> map, Object value) {
+		private void setMapValue(Map<String, Object> map, Object value) {
 			String key = getKey();
 			if (NodeType.MAP.equals(valueType)) {
 				Map<String, Object> nestedMap = (Map<String, Object>) map.get(key);
@@ -362,7 +362,7 @@ public class EnvironmentController {
 			}
 		}
 
-		void setListValue(List<Object> list, Object value) {
+		private void setListValue(List<Object> list, Object value) {
 			int index = getIndex();
 			// Fill missing elements if needed
 			while (list.size() <= index) {
@@ -387,7 +387,7 @@ public class EnvironmentController {
 			}
 		}
 
-		int getIndex() {
+		private int getIndex() {
 			// Consider [
 			int start = currentPos + 1;
 
@@ -425,7 +425,7 @@ public class EnvironmentController {
 			}
 		}
 
-		String getKey() {
+		private String getKey() {
 			// Consider initial value or previous char '.' or '['
 			int start = currentPos + 1;
 			char_loop:
@@ -439,6 +439,8 @@ public class EnvironmentController {
 						currentPos = i;
 						valueType = NodeType.ARRAY;
 						break char_loop;
+					default:
+						continue;
 				}
 			}
 			// If there's no delimiter then it's a key of a leaf

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -267,6 +267,8 @@ public class EnvironmentControllerTests {
 		map.put("a.b[0].d[2]", "yy");
 		map.put("a.b[0].d[0]", "xx");
 		map.put("a.b[2].c", "y");
+		map.put("a.b[3][0]", "r");
+		map.put("a.b[3][1]", "s");
 		this.environment.add(new PropertySource("one", map));
 		Mockito.when(this.repository.findOne("foo", "bar", null)).thenReturn(this.environment);
 		String yaml = this.controller.yaml("foo", "bar", false).getBody();
@@ -281,7 +283,9 @@ public class EnvironmentControllerTests {
 				"  - null\n" +
 				"  - c: y\n" +
 				"    e:\n" +
-				"    - d: z\n";
+				"    - d: z\n" +
+				"  - - r\n" +
+				"    - s\n";
 		assertThat("Wrong output: " + yaml, yaml, is(expected));
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.cloud.config.server.environment;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
I've replaced the previous implementation which only supports array at leaf level of yaml.  The new implementation is based on how snakeyaml builds a nested map from a yaml file (i.e. LinkedHashMap to represent the dictionaries and ArrayList to represent arrays).  The new implementation also removes the need for switching off placeholder resolution as the operation of converting an environment to a map doesn't really involve setting placeholder values.
