### PR TITLE
Fix inline comments in EnvironmentControllerTests

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -346,7 +346,7 @@ public class EnvironmentControllerTests {
 	public void placeholdersNotResolvedInJsonFromSystemPropertiesWhenNotFlaggedWithDefault() throws Exception {
 		whenPlaceholdersSystemPropsWithDefault();
 		String json = this.controller.jsonProperties("foo", "bar", false).getBody();
-		// If there is a default value we do not prevent the placeholder being resolved
+		// If there is a default value we prevent the placeholder being resolved
 		assertEquals("{\"a\":{\"b\":{\"c\":\"${foo:spam}\"}}}", json);
 	}
 
@@ -354,7 +354,7 @@ public class EnvironmentControllerTests {
 	public void placeholdersResolvedInJsonFromSystemPropertiesWhenFlagged() throws Exception {
 		whenPlaceholdersSystemPropsWithDefault();
 		String json = this.controller.jsonProperties("foo", "bar", true).getBody();
-		// If there is a default value we prevent the placeholder being resolved
+		// If there is a default value we do not prevent the placeholder being resolved
 		assertEquals("{\"a\":{\"b\":{\"c\":\"spam\"}}}", json);
 	}
 
@@ -408,7 +408,6 @@ public class EnvironmentControllerTests {
 		mvc.perform(MockMvcRequestBuilders.get("/foo-bar.json"))
 				.andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(MockMvcResultMatchers.content().string("{}"));
-		;
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes inline comments in `EnvironmentControllerTests` as they look opposite.