### PR TITLE
Add AllowHostsUsernamePasswordCredentialProvider class to fix ssh url issues.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -328,6 +328,13 @@ of the box when you store keys in the default directories (`~/.ssh`)
 and the uri points to an SSH location,
 e.g. "git@github.com:configuration/cloud-configuration". It is important that all
 keys in ~/.ssh/known_hosts are in "ssh-rsa" format. The new "ecdsa-sha2-nistp256" format is NOT supported.
+
+Alternatively you can set the property
+`spring.cloud.config.server.git.allow-ssh=true`. 
+This essentially tells the ssh client to trust all hosts.
+This is useful in cloud environments 
+where you may not be able to set up the known_hosts file on each node in a cluster.
+
 The repository is accessed using JGit, so any documentation you find on
 that should be applicable. HTTPS proxy settings can be set in
 `~/.git/config` or in the same way as for any other JVM process via

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProvider.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016  Michael Davis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.URIish;
+
+/**
+ * This is based on the class org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+ * but provides better support for ssh git urls. The idea was borrowed from:
+ * https://github.com/centic9/jgit-cookbook/blob/master/src/main/java/org/dstadler/jgit/porcelain/CloneRemoteRepositoryWithAuthentication.java
+ * by Dominik Stadler.
+ * 
+ * @author Michael Davis
+ *
+ */
+public class AllowHostsUsernamePasswordCredentialProvider extends CredentialsProvider {
+	
+	private String username;
+	private char[] password;
+	
+    public AllowHostsUsernamePasswordCredentialProvider(String username, String password) {
+		this.username = username;
+		this.password = password.toCharArray();
+	}
+
+	@Override
+    public boolean supports(CredentialItem... items) {
+
+		for (CredentialItem i : items) {
+
+			if (i instanceof CredentialItem.Username)
+				continue;
+
+			else if (i instanceof CredentialItem.Password)
+				continue;
+
+			else if (i instanceof CredentialItem.YesNoType)
+				continue;
+
+			else
+				return false;
+
+		}
+		return true;
+    }
+
+    @Override
+    public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
+
+		for (CredentialItem i : items) {
+
+			if (i instanceof CredentialItem.Username) {
+				((CredentialItem.Username) i).setValue(username);
+				continue;
+			}
+			if (i instanceof CredentialItem.Password) {
+				((CredentialItem.Password) i).setValue(password);
+				continue;
+			}
+			if (i instanceof CredentialItem.StringType) {
+				if (i.getPromptText().equals("Password: ")) {
+					((CredentialItem.StringType) i).setValue(new String(
+							password));
+					continue;
+				}
+			}
+            if(i instanceof CredentialItem.YesNoType) {
+                ((CredentialItem.YesNoType)i).setValue(true);
+                return true;
+            }
+			throw new UnsupportedCredentialItem(uri, i.getClass().getName()
+					+ ":" + i.getPromptText());
+		}
+		
+		return true;
+    }
+
+    @Override
+    public boolean isInteractive() {
+        return false;
+    }
+    
+	public void clear() {
+		username = null;
+
+		if (password != null) {
+			Arrays.fill(password, (char) 0);
+			password = null;
+		}
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProvider.java
@@ -56,14 +56,13 @@ public class AllowHostsUsernamePasswordCredentialProvider extends CredentialsPro
 			if (i instanceof CredentialItem.StringType)
 				continue;
 
-			else if (i instanceof CredentialItem.Username)
+			if (i instanceof CredentialItem.Username)
 				continue;
 
-			else if (i instanceof CredentialItem.YesNoType)
+			if (i instanceof CredentialItem.YesNoType)
 				continue;
 
-			else
-				return false;
+			return false;
 
 		}
 		return true;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -40,9 +40,11 @@ import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
 import org.eclipse.jgit.transport.OpenSshConfig.Host;
 import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FileUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -91,6 +93,14 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	 */
 	private boolean forcePull;
 
+	/**
+	 * This flag indicates that when given a git url using ssh, it should effectively say
+	 * "yes" to the question: "Do you accept this host's keys?"
+	 * 
+	 * This may be configured using the property spring.cloud.config.server.git.allow-ssh
+	 */
+	private boolean allowSsh = false;
+
 	public JGitEnvironmentRepository(ConfigurableEnvironment environment) {
 		super(environment);
 	}
@@ -133,6 +143,14 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	public void setForcePull(boolean forcePull) {
 		this.forcePull = forcePull;
+	}
+
+	public boolean isAllowSsh() {
+		return allowSsh;
+	}
+
+	public void setAllowSsh(boolean allowSsh) {
+		this.allowSsh = allowSsh;
 	}
 
 	@Override
@@ -404,8 +422,12 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	}
 
 	private void setCredentialsProvider(TransportCommand<?, ?> cmd) {
-		cmd.setCredentialsProvider(
-				new AllowHostsUsernamePasswordCredentialProvider(getUsername(), getPassword()));
+		CredentialsProvider credentialProvider = allowSsh
+				? new AllowHostsUsernamePasswordCredentialProvider(getUsername(),
+						getPassword())
+				: new UsernamePasswordCredentialsProvider(getUsername(), getPassword());
+				
+		cmd.setCredentialsProvider(credentialProvider);
 	}
 
 	private void setTimeout(TransportCommand<?, ?> pull) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -43,7 +43,6 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
 import org.eclipse.jgit.transport.OpenSshConfig.Host;
 import org.eclipse.jgit.transport.SshSessionFactory;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FileUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -60,6 +59,7 @@ import com.jcraft.jsch.Session;
  * @author Roy Clarkson
  * @author Marcos Barbero
  * @author Daniel Lavoie
+ * @author Michael Davis
  */
 public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		implements EnvironmentRepository, SearchPathLocator, InitializingBean {
@@ -405,7 +405,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	private void setCredentialsProvider(TransportCommand<?, ?> cmd) {
 		cmd.setCredentialsProvider(
-				new UsernamePasswordCredentialsProvider(getUsername(), getPassword()));
+				new AllowHostsUsernamePasswordCredentialProvider(getUsername(), getPassword()));
 	}
 
 	private void setTimeout(TransportCommand<?, ?> pull) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProviderTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AllowHostsUsernamePasswordCredentialProviderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.config.server.environment;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URISyntaxException;
+
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.URIish;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Michael Davis
+ */
+public class AllowHostsUsernamePasswordCredentialProviderTest {
+
+	private AllowHostsUsernamePasswordCredentialProvider provider;
+
+	private CredentialItem.CharArrayType charArrayType = new CredentialItem.CharArrayType(
+			null, true);
+	private CredentialItem.Password password = new CredentialItem.Password();
+	private CredentialItem.StringType stringType = new CredentialItem.StringType(null,
+			false);
+	private CredentialItem.Username username = new CredentialItem.Username();
+	private CredentialItem.YesNoType yesNo = new CredentialItem.YesNoType(null);
+
+	@Before
+	public void setUp() throws Exception {
+		provider = new AllowHostsUsernamePasswordCredentialProvider("username",
+				"password");
+	}
+
+	@Test
+	public void testSupports() {
+		assertTrue(provider.supports(username, password, stringType, yesNo));
+		assertFalse(provider.supports(username, password, charArrayType));
+	}
+
+	@Test
+	public void testGet() {
+		URIish uri;
+		try {
+			uri = new URIish("uri");
+			assertTrue(provider.get(uri, password, stringType, username, yesNo));
+			assertTrue(provider.get(uri, username, password, charArrayType));
+			fail("provider should have thrown an exception when passed a CredentialItem.CharArrayType.");
+		}
+		catch (UnsupportedCredentialItem uci) {
+			// this is expected when provider is passed the charArrayType.
+		}
+		catch (URISyntaxException e) {
+			fail("Unexpected exception: " + e);
+		}
+	}
+}


### PR DESCRIPTION
When cloning a git repo using an ssh url, often it fails because
the host is not in the ssh known-hosts list.

This fix essentially lets Spring Config answer yes to the question:
Do you trust this host.

It works by providing a new jgit CredentialsProvider class that supports the YesNoType of credential as well as Username and Password.

Issue: SCC-101
