### PR TITLE
Added /encrypt/validate endpoint

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -121,6 +121,17 @@ public class EncryptionController {
 		return encrypt(this.defaultApplicationName, this.defaultProfile, data, type);
 	}
 
+	@RequestMapping(value = "/encrypt/validate", method = RequestMethod.POST)
+	public ResponseEntity<String> validate(@RequestBody String data,
+			@RequestHeader("Content-Type") MediaType type) {
+		try {
+			decrypt(data, type);
+			return new ResponseEntity("Valid", HttpStatus.OK);
+		} catch (IllegalStateException ex) {
+			return new ResponseEntity<String>("Invalid", HttpStatus.BAD_REQUEST);
+		}
+	}
+
 	@RequestMapping(value = "/encrypt/{name}/{profiles}", method = RequestMethod.POST)
 	public String encrypt(@PathVariable String name, @PathVariable String profiles,
 			@RequestBody String data, @RequestHeader("Content-Type") MediaType type) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
@@ -31,7 +31,9 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.encrypt.Encryptors;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.security.rsa.crypto.RsaSecretEncryptor;
@@ -139,6 +141,25 @@ public class EncryptionControllerTests {
 		String decrypt = this.controller.decrypt("app", "default", cipher,
 				MediaType.TEXT_PLAIN);
 		assertEquals("Wrong decrypted plaintext: " + decrypt, "foo bar", decrypt);
+	}
+
+	@Test
+	public void validateShouldReturn200IfPassedValidEncryptedValue() {
+		this.controller = new EncryptionController(
+				new SingleTextEncryptorLocator(new RsaSecretEncryptor()));
+		String cipher = this.controller.encrypt("foo", MediaType.TEXT_PLAIN);
+		ResponseEntity<String> response = this.controller.validate(cipher, MediaType.TEXT_PLAIN);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	public void validateShouldReturn400IfPassedInvalidEncryptedValue() {
+		this.controller = new EncryptionController(
+				new SingleTextEncryptorLocator(new RsaSecretEncryptor()));
+		String cipher = this.controller.encrypt("foo", MediaType.TEXT_PLAIN);
+		cipher = ((char) (cipher.charAt(0) + 1)) + cipher.substring(1);
+		ResponseEntity<String> response = this.controller.validate(cipher, MediaType.TEXT_PLAIN);
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
 	}
 
 }


### PR DESCRIPTION
We've had a number of instances where someone has checked in an encrypted value which ended up being incorrect (wrong key, character accidentally deleted before commit, etc).  We've added this endpoint to our config server which allows us to run validation checks on config repo commit.

I figured if we ran into this issue, other people may as well, so figured I'd raise a PR.  If the functionality is something y'all would like to add but in a different form, let me know.
