### PR TITLE
Add configuration option to allow for a passphrase to be specified.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
@@ -65,6 +65,14 @@ public class AbstractScmAccessor implements ResourceLoaderAware {
 	 */
 	private String password;
 	/**
+	 * Passphrase for unlocking your ssh private key.
+	 */
+	private String passphrase;
+ 	/**
+  	 * Reject incoming SSH host keys from remote servers not in the known host list.
+  	 */
+	private boolean strictHostKeyChecking;
+	/**
 	 * Search paths to use within local working copy. By default searches only the root.
 	 */
 	private String[] searchPaths = DEFAULT_LOCATIONS.clone();
@@ -157,6 +165,22 @@ public class AbstractScmAccessor implements ResourceLoaderAware {
 
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	public String getPassphrase() {
+		return passphrase;
+	}
+
+	public void setPassphrase(String passphrase) {
+		this.passphrase = passphrase;
+	}
+
+	public boolean isStrictHostKeyChecking() {
+		return strictHostKeyChecking;
+	}
+
+	public void setStrictHostKeyChecking(boolean strictHostKeyChecking) {
+		this.strictHostKeyChecking = strictHostKeyChecking;
 	}
 
 	protected File getWorkingDirectory() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PassphraseCredentialsProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PassphraseCredentialsProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.support;
+
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.URIish;
+
+public class PassphraseCredentialsProvider extends CredentialsProvider {
+	public static final String PROMPT = "Passphrase for";
+	private final String passphrase;
+
+	/**
+	 * Initialize the provider with a the ssh passphrase.
+	 *
+	 * @param passphrase
+	 */
+	public PassphraseCredentialsProvider(String passphrase) {
+		super();
+		this.passphrase = passphrase;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @return
+	 */
+	@Override
+	public boolean isInteractive() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @return
+	 */
+	@Override
+	public boolean supports(CredentialItem... items) {
+		for (final CredentialItem item : items) {
+			if (item instanceof CredentialItem.StringType && item.getPromptText().startsWith(PROMPT)) {
+				continue;
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Ask for the credential items to be populated with the passphrase.
+	 *
+	 * @param uri
+	 *            the URI of the remote resource that needs authentication.
+	 * @param items
+	 *            the items the application requires to complete authentication.
+	 * @return {@code true} if the request was successful and values were
+	 *         supplied; {@code false} if the user canceled the request and did
+	 *         not supply all requested values.
+	 * @throws UnsupportedCredentialItem
+	 *             if one of the items supplied is not supported.
+     */
+	@Override
+	public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
+		for (final CredentialItem item : items) {
+			if (item instanceof CredentialItem.StringType && item.getPromptText().startsWith(PROMPT)) {
+				((CredentialItem.StringType) item).setValue(passphrase);
+				continue;
+			}
+			throw new UnsupportedCredentialItem(uri, item.getClass().getName() + ":" + item.getPromptText());
+		}
+		return true;
+	}
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
@@ -483,6 +483,27 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 		return localRef.getObjectId().getName();
 	}
 
+	public void passphrase() throws IOException {
+		String uri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
+		final String passphrase = "thisismypassphrase";
+		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.run("--spring.cloud.config.server.git.uri=" + uri,
+						"--spring.cloud.config.server.git.passphrase=" + passphrase);
+		JGitEnvironmentRepository repository = this.context.getBean(JGitEnvironmentRepository.class);
+		assertThat(repository.getPassphrase(), Matchers.containsString(passphrase));
+	}
+
+	@Test
+	public void strictHostKeyChecking() throws IOException {
+		String uri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
+		final boolean strictHostKeyChecking = true;
+		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.run("--spring.cloud.config.server.git.uri=" + uri,
+						"--spring.cloud.config.server.git.strict-host-key-checking=" + strictHostKeyChecking);
+		JGitEnvironmentRepository repository = this.context.getBean(JGitEnvironmentRepository.class);
+		assertEquals(repository.isStrictHostKeyChecking(), strictHostKeyChecking);
+	}
+
 	@Configuration
 	@EnableConfigurationProperties(ConfigServerProperties.class)
 	@Import({ PropertyPlaceholderAutoConfiguration.class,


### PR DESCRIPTION
- Add `passphrase` configuration for SSH connections
- add `strict.host.key.checking` configuration flag
- fixes #431
- addresses `strictHostKeyChecking` request in #101 