### PR TITLE
add randomize option to randomly select which config server instance …

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -228,6 +228,10 @@ public class ConfigClientProperties {
 		 * Service id to locate config server.
 		 */
 		private String serviceId = DEFAULT_CONFIG_SERVER;
+		/**
+		 * instead of just getting the first instance from discovery every time, get a random instance
+		 */
+		private boolean randomize = true;
 
 		public boolean isEnabled() {
 			return this.enabled;
@@ -243,6 +247,14 @@ public class ConfigClientProperties {
 
 		public void setServiceId(String serviceId) {
 			this.serviceId = serviceId;
+		}
+		
+		public boolean isRandomize() {
+		  return this.randomize;
+		}
+		
+		public void setRandomize(boolean randomize) {
+		  this.randomize = randomize;
 		}
 
 	}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.client;
 
 import java.util.List;
+import java.util.Random;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -77,7 +78,7 @@ public class DiscoveryClientConfigServiceBootstrapConfiguration {
 				logger.warn("No instances found of configserver (" + serviceId + ")");
 				return;
 			}
-			ServiceInstance server = instances.get(0);
+			ServiceInstance server = getServiceInstance(instances);
 			String url = getHomePage(server);
 			if (server.getMetadata().containsKey("password")) {
 				String user = server.getMetadata().get("user");
@@ -102,6 +103,15 @@ public class DiscoveryClientConfigServiceBootstrapConfiguration {
 
 	private String getHomePage(ServiceInstance server) {
 		return server.getUri().toString() + "/";
+	}
+	
+	private ServiceInstance getServiceInstance(List<ServiceInstance> instances) {
+	  int indexToGet = 0;
+	  if (config.getDiscovery().isRandomize()) {
+	    Random random = new Random();
+	    indexToGet = random.nextInt(instances.size());
+	  }
+	  return instances.get(indexToGet);
 	}
 
 }


### PR DESCRIPTION
…to use from discovery.

When starting up many microservices all at once (a full stack), we need some kind of load balancing of which config server is used