### PR TITLE
Clean Windows paths before guessing the service name

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
@@ -111,7 +111,7 @@ public class PropertyPathEndpoint
 		Set<String> services = new LinkedHashSet<>();
 		if (path != null) {
 			String stem = StringUtils
-					.stripFilenameExtension(StringUtils.getFilename(path));
+					.stripFilenameExtension(StringUtils.getFilename(StringUtils.cleanPath(path)));
 			// TODO: correlate with service registry
 			int index = stem.indexOf("-");
 			while (index >= 0) {

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
@@ -87,6 +87,15 @@ public class PropertyPathEndpointTests {
 	}
 
 	@Test
+	public void testNotifyOneWithWindowsPath() throws Exception {
+		assertEquals("[foo]",
+				this.endpoint
+						.notifyByPath(new HttpHeaders(), Collections
+								.<String, Object> singletonMap("path", "C:\\config\\foo.yml"))
+				.toString());
+	}
+
+	@Test
 	public void testNotifyOneWithProfile() throws Exception {
 		assertEquals("[foo:local, foo-local]",
 				this.endpoint


### PR DESCRIPTION
When encountering windows paths when running in native profile, services
names would not be extracted correctly due to different path separators.
Now they are normalized before being used for service name guessing.

Fixes #531