### PR TITLE
Add ability specify base dir which will not be cleaned after restart

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
@@ -68,6 +68,11 @@ public class ConfigServerProperties {
 	private String defaultProfile = "default";
 
 	/**
+	 * Base directory for local working copy of repository. If not set the default temporary-file directory will be used.
+	 */
+	private String baseDir;
+
+	/**
 	 * Decryption configuration for when server handles encrypted properties before sending them to clients.
 	 */
 	private Encrypt encrypt = new Encrypt();
@@ -130,6 +135,14 @@ public class ConfigServerProperties {
 
 	public void setDefaultProfile(String defaultProfile) {
 		this.defaultProfile = defaultProfile;
+	}
+
+	public String getBaseDir() {
+		return baseDir;
+	}
+
+	public void setBaseDir(String baseDir) {
+		this.baseDir = baseDir;
 	}
 
 	public static class Encrypt {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -59,7 +59,7 @@ public class EnvironmentRepositoryConfiguration {
 
 		@Bean
 		public MultipleJGitEnvironmentRepository defaultEnvironmentRepository() {
-			MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment);
+			MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment, server);
 			if (this.server.getDefaultLabel()!=null) {
 				repository.setDefaultLabel(this.server.getDefaultLabel());
 			}
@@ -95,7 +95,7 @@ public class EnvironmentRepositoryConfiguration {
 
 		@Bean
 		public SvnKitEnvironmentRepository svnKitEnvironmentRepository() {
-			SvnKitEnvironmentRepository repository = new SvnKitEnvironmentRepository(this.environment);
+			SvnKitEnvironmentRepository repository = new SvnKitEnvironmentRepository(this.environment, server);
 			if (this.server.getDefaultLabel()!=null) {
 				repository.setDefaultLabel(this.server.getDefaultLabel());
 			}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractScmEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractScmEnvironmentRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.environment;
 
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.support.AbstractScmAccessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -31,8 +32,8 @@ public abstract class AbstractScmEnvironmentRepository extends AbstractScmAccess
 	private EnvironmentCleaner cleaner = new EnvironmentCleaner();
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
-	public AbstractScmEnvironmentRepository(ConfigurableEnvironment environment) {
-		super(environment);
+	public AbstractScmEnvironmentRepository(ConfigurableEnvironment environment, ConfigServerProperties serverSettings) {
+		super(environment, serverSettings);
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -47,6 +47,7 @@ import org.eclipse.jgit.transport.TagOpt;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FileUtils;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.support.PassphraseCredentialsProvider;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.UrlResource;
@@ -96,8 +97,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	 */
 	private boolean forcePull;
 
-	public JGitEnvironmentRepository(ConfigurableEnvironment environment) {
-		super(environment);
+	public JGitEnvironmentRepository(ConfigurableEnvironment environment, ConfigServerProperties serverSettings) {
+		super(environment, serverSettings);
 	}
 
 	public boolean isCloneOnStart() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
@@ -55,8 +56,8 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 
 	private Map<String, JGitEnvironmentRepository> placeholders = new LinkedHashMap<String, JGitEnvironmentRepository>();
 
-	public MultipleJGitEnvironmentRepository(ConfigurableEnvironment environment) {
-		super(environment);
+	public MultipleJGitEnvironmentRepository(ConfigurableEnvironment environment, ConfigServerProperties serverSettings) {
+		super(environment, serverSettings);
 	}
 
 	@Override
@@ -64,6 +65,7 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 		super.afterPropertiesSet();
 		for (String name : this.repos.keySet()) {
 			PatternMatchingJGitEnvironmentRepository repo = this.repos.get(name);
+			repo.setServerSettings(getServerSettings());
 			repo.setEnvironment(getEnvironment());
 			if (!StringUtils.hasText(repo.getName())) {
 				repo.setName(name);
@@ -194,9 +196,8 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 		return this.placeholders.get(key);
 	}
 
-	private JGitEnvironmentRepository getRepository(JGitEnvironmentRepository source,
-			String uri) {
-		JGitEnvironmentRepository repository = new JGitEnvironmentRepository(null);
+	private JGitEnvironmentRepository getRepository(JGitEnvironmentRepository source, String uri) {
+		JGitEnvironmentRepository repository = new JGitEnvironmentRepository(null,getServerSettings());
 		File basedir = repository.getBasedir();
 		BeanUtils.copyProperties(source, repository);
 		repository.setUri(uri);
@@ -217,7 +218,7 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 		private String name;
 
 		public PatternMatchingJGitEnvironmentRepository() {
-			super(null);
+			super(null, null);
 		}
 
 		public PatternMatchingJGitEnvironmentRepository(String uri) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SvnKitEnvironmentRepository.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -64,8 +65,8 @@ public class SvnKitEnvironmentRepository extends AbstractScmEnvironmentRepositor
 		this.defaultLabel = defaultLabel;
 	}
 
-	public SvnKitEnvironmentRepository(ConfigurableEnvironment environment) {
-		super(environment);
+	public SvnKitEnvironmentRepository(ConfigurableEnvironment environment, ConfigServerProperties serverSettings) {
+		super(environment, serverSettings);
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
@@ -241,7 +241,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 				.getBean(JGitEnvironmentRepository.class);
 		assertThat(repository.getSearchPaths(), Matchers.arrayContaining("{application}"));
 		assertFalse(Arrays.equals(repository.getSearchPaths(),
-				new JGitEnvironmentRepository(repository.getEnvironment())
+				new JGitEnvironmentRepository(repository.getEnvironment(), repository.getServerSettings())
 						.getSearchPaths()));
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -56,6 +56,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.support.PassphraseCredentialsProvider;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
 import org.springframework.core.env.StandardEnvironment;
@@ -82,8 +83,9 @@ import static org.mockito.Mockito.when;
 public class JGitEnvironmentRepositoryTests {
 
 	private StandardEnvironment environment = new StandardEnvironment();
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
 	private JGitEnvironmentRepository repository = new JGitEnvironmentRepository(
-			this.environment);
+			this.environment, serverSettings);
 
 	private File basedir = new File("target/config");
 
@@ -220,7 +222,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(mockCloneCommand.setDirectory(any(File.class))).thenReturn(mockCloneCommand);
 
 		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("http://somegitserver/somegitrepo");
 		envRepository.setCloneOnStart(true);
@@ -238,7 +240,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(mockCloneCommand.setDirectory(any(File.class))).thenReturn(mockCloneCommand);
 
 		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("http://somegitserver/somegitrepo");
 		envRepository.afterPropertiesSet();
@@ -256,7 +258,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(mockCloneCommand.setDirectory(any(File.class))).thenReturn(mockCloneCommand);
 
 		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("file://somefilesystem/somegitrepo");
 		envRepository.setCloneOnStart(true);
@@ -281,7 +283,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(status.isClean()).thenReturn(false);
 
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		repo.setForcePull(true);
 
 		boolean shouldPull = repo.shouldPull(git);
@@ -305,7 +307,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(status.isClean()).thenReturn(false);
 
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 
 		boolean shouldPull = repo.shouldPull(git);
 
@@ -328,7 +330,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(status.isClean()).thenReturn(true);
 
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 
 		boolean shouldPull = repo.shouldPull(git);
 
@@ -342,7 +344,7 @@ public class JGitEnvironmentRepositoryTests {
 		CloneCommand cloneCommand = mock(CloneCommand.class);
 		MockGitFactory factory = new MockGitFactory(git, cloneCommand);
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		this.repository.setGitFactory(factory);
 
 		//refresh()->shouldPull
@@ -398,7 +400,7 @@ public class JGitEnvironmentRepositoryTests {
 		CloneCommand cloneCommand = mock(CloneCommand.class);
 		MockGitFactory factory = new MockGitFactory(git, cloneCommand);
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		this.repository.setGitFactory(factory);
 
 		//refresh()->shouldPull
@@ -456,7 +458,7 @@ public class JGitEnvironmentRepositoryTests {
 		CloneCommand cloneCommand = mock(CloneCommand.class);
 		MockGitFactory factory = new MockGitFactory(git, cloneCommand);
 		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		this.repository.setGitFactory(factory);
 
 		//refresh()->shouldPull
@@ -522,7 +524,7 @@ public class JGitEnvironmentRepositoryTests {
 		when(mockCloneCommand.call()).thenThrow(new TransportException("failed to clone"));
 
 		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(
-				this.environment);
+				this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("http://somegitserver/somegitrepo");
 		envRepository.setBasedir(this.basedir);
@@ -542,7 +544,7 @@ public class JGitEnvironmentRepositoryTests {
 		Git mockGit = mock(Git.class);
 		MockCloneCommand mockCloneCommand = new MockCloneCommand(mockGit);
 
-		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment);
+		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("git+ssh://git@somegitserver/somegitrepo");
 		envRepository.setBasedir(new File("./mybasedir"));
@@ -573,7 +575,7 @@ public class JGitEnvironmentRepositoryTests {
 		Git mockGit = mock(Git.class);
 		MockCloneCommand mockCloneCommand = new MockCloneCommand(mockGit);
 
-		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment);
+		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment, serverSettings);
 		envRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
 		envRepository.setUri("git+ssh://git@somegitserver/somegitrepo");
 		envRepository.setBasedir(new File("./mybasedir"));
@@ -597,7 +599,7 @@ public class JGitEnvironmentRepositoryTests {
 	public void strictHostKeyCheckShouldCheck() throws Exception {
 		String uri = "git+ssh://git@somegitserver/somegitrepo";
 		SshSessionFactory.setInstance(null);
-		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment);
+		JGitEnvironmentRepository envRepository = new JGitEnvironmentRepository(this.environment, serverSettings);
 		envRepository.setUri(uri);
 		envRepository.setBasedir(new File("./mybasedir"));
 		envRepository.setStrictHostKeyChecking(true);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentRepository.PatternMatchingJGitEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.SearchPathLocator.Locations;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
@@ -38,8 +39,9 @@ import org.springframework.core.env.StandardEnvironment;
 public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 
 	private StandardEnvironment environment = new StandardEnvironment();
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(
-			this.environment);
+			this.environment, serverSettings);
 
 	@Before
 	public void init() throws Exception {
@@ -63,6 +65,7 @@ public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 			String pattern, String uri) {
 		PatternMatchingJGitEnvironmentRepository repo = new PatternMatchingJGitEnvironmentRepository();
 		repo.setEnvironment(this.environment);
+		repo.setServerSettings(serverSettings);
 		repo.setName(name);
 		repo.setPattern(new String[] { pattern });
 		repo.setUri(uri);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.config.server.environment;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
 import org.springframework.core.env.StandardEnvironment;
 
@@ -34,8 +35,9 @@ import static org.junit.Assert.assertTrue;
 public class MultipleJGitEnvironmentLabelPlaceholderRepositoryTests {
 
 	private StandardEnvironment environment = new StandardEnvironment();
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(
-			this.environment);
+			this.environment, serverSettings);
 	private String defaultUri;
 
 	@Before

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentRepository.PatternMatchingJGitEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.SearchPathLocator.Locations;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
@@ -39,8 +40,9 @@ import org.springframework.core.env.StandardEnvironment;
 public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 
 	private StandardEnvironment environment = new StandardEnvironment();
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(
-			this.environment);
+			this.environment, serverSettings);
 
 	@Before
 	public void init() throws Exception {
@@ -64,6 +66,7 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 			String pattern, String uri) {
 		PatternMatchingJGitEnvironmentRepository repo = new PatternMatchingJGitEnvironmentRepository();
 		repo.setEnvironment(this.environment);
+		repo.setServerSettings(serverSettings);
 		repo.setName(name);
 		repo.setPattern(new String[] { pattern });
 		repo.setUri(uri);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentRepository.PatternMatchingJGitEnvironmentRepository;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
 import org.springframework.core.env.StandardEnvironment;
@@ -40,7 +41,8 @@ import org.springframework.core.env.StandardEnvironment;
 public class MultipleJGitEnvironmentRepositoryTests {
 
 	private StandardEnvironment environment = new StandardEnvironment();
-	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment);
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
+	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment, serverSettings);
 
 	@Before
 	public void init() throws Exception {
@@ -60,6 +62,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	private PatternMatchingJGitEnvironmentRepository createRepository(String name, String pattern, String uri) {
 		PatternMatchingJGitEnvironmentRepository repo = new PatternMatchingJGitEnvironmentRepository();
 		repo.setEnvironment(this.environment);
+		repo.setServerSettings(serverSettings);
 		repo.setName(name);
 		repo.setPattern(new String[] {pattern});
 		repo.setUri(uri);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.test.ConfigServerTestUtils;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.StandardEnvironment;
@@ -41,8 +42,9 @@ public class SVNKitEnvironmentRepositoryTests {
 
 	private static final String REPOSITORY_NAME = "svn-config-repo";
 	private StandardEnvironment environment = new StandardEnvironment();
+	private ConfigServerProperties serverSettings = new ConfigServerProperties();
 	private SvnKitEnvironmentRepository repository = new SvnKitEnvironmentRepository(
-			this.environment);
+			this.environment, serverSettings);
 
 	private File basedir = new File("target/config");
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/AbstractScmAccessorTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/AbstractScmAccessorTest.java
@@ -1,0 +1,46 @@
+package org.springframework.cloud.config.server.support;
+
+import org.junit.Test;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+import static org.junit.Assert.assertTrue;
+
+public class AbstractScmAccessorTest {
+
+    private String userHome = System.getProperty("user.home");
+    private String tmpDir = System.getProperty("java.io.tmpdir");
+    private ConfigServerProperties serverSettings = new ConfigServerProperties();
+
+    @Test
+    public void shouldUseDefaultIfNoBaseDirConfigured() {
+        serverSettings.setBaseDir(userHome);
+        AbstractScmAccessor tested = new AbstractScmAccessor(null, serverSettings);
+
+        assertTrue(tested.getBasedir().getAbsolutePath().startsWith(userHome));
+    }
+
+    @Test
+    public void shouldUseUriAsSubfolderName() {
+        AbstractScmAccessor tested = new AbstractScmAccessor(null, serverSettings);
+        tested.setUri("https://repo.com/scm/rp/repo.git");
+        serverSettings.setBaseDir(userHome);
+
+        assertTrue(tested.getBasedir().getAbsolutePath().startsWith(userHome));
+        assertTrue(tested.getBasedir().getAbsolutePath().endsWith("https___repo_com_scm_rp_repo_git"));
+    }
+
+    @Test
+    public void shouldNotFailIfNoSettingsPassed() {
+        AbstractScmAccessor tested = new AbstractScmAccessor(null, null);
+
+        assertTrue(tested.getBasedir().getAbsolutePath().startsWith(tmpDir));
+    }
+
+    @Test
+    public void shouldUseBaseDirConfigured() {
+        AbstractScmAccessor tested = new AbstractScmAccessor(null, serverSettings);
+        serverSettings.setBaseDir(null);
+
+        assertTrue(tested.getBasedir().getAbsolutePath().startsWith(tmpDir));
+    }
+}


### PR DESCRIPTION
Here is the case:
- my git repo is inaccessible
- I've got nodes with config server crashing (require new instance startup)

I'll probably loose my config server under these conditions in production. It would be nice to 

a) allow to specify some base path so I can use mounted folder to keep files
b) use same folder on startup

Does this make any sense to implement? I tried to use repo uri as the key for each checkout, so if there is overlapping repos by key, they might get corrupted

NOTE: Not sure who decided to instantiate MultipleJGitEnvironmentRepository via ConfigurationProperties, but this is really strange decision. Its complaining that  PatternMatchingJGitEnvironmentRepository must have default constructor? Really?