### PR TITLE
Fixing a typo in the documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -622,7 +622,7 @@ part of the server.
 
 When using Vault as a backend you can share configuration with
 all applications by placing configuration in
-`{backend}/application`.  For example, if you run this Vault command
+`secret/application`.  For example, if you run this Vault command
 
 [source,sh]
 ----


### PR DESCRIPTION
There's a typo in the **Vault Server** section:
...
"When using Vault as a backend you can share configuration with all applications by placing configuration in `html5/application`. For example, if you run this Vault command"
...

When it should be:
...
"When using Vault as a backend you can share configuration with all applications by placing configuration in `secret/application`. For example, if you run this Vault command"
...