### PR TITLE
Adds ability to add static headers to config client request.

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.config.client;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -94,6 +96,11 @@ public class ConfigClientProperties {
 	 * Authorization token used by the client to connect to the server.
 	 */
 	private String authorization;
+
+	/**
+	 * Additional headers used to create the client request.
+	 */
+	private Map<String, String> headers = new HashMap<>();
 
 	private ConfigClientProperties() {
 	}
@@ -196,6 +203,14 @@ public class ConfigClientProperties {
 
 	public void setAuthorization(String authorization) {
 		this.authorization = authorization;
+	}
+
+	public Map<String, String> getHeaders() {
+		return headers;
+	}
+
+	public void setHeaders(Map<String, String> headers) {
+		this.headers = headers;
 	}
 
 	private Credentials extractCredentials() {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.config.client;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,11 +94,6 @@ public class ConfigClientProperties {
 	 * Authorization token used by the client to connect to the server.
 	 */
 	private String authorization;
-
-	/**
-	 * Additional headers used to create the client request.
-	 */
-	private Map<String, String> headers = new HashMap<>();
 
 	private ConfigClientProperties() {
 	}
@@ -203,14 +196,6 @@ public class ConfigClientProperties {
 
 	public void setAuthorization(String authorization) {
 		this.authorization = authorization;
-	}
-
-	public Map<String, String> getHeaders() {
-		return headers;
-	}
-
-	public void setHeaders(Map<String, String> headers) {
-		this.headers = headers;
 	}
 
 	private Credentials extractCredentials() {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.config.client;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,13 +32,9 @@ import org.springframework.core.env.MapPropertySource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpRequestExecution;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.util.Base64Utils;
@@ -52,6 +48,7 @@ import static org.springframework.cloud.config.client.ConfigClientProperties.TOK
 
 /**
  * @author Dave Syer
+ * @author Mathieu Ouellet
  *
  */
 @Order(0)
@@ -66,15 +63,13 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 	public ConfigServicePropertySourceLocator(ConfigClientProperties defaultProperties) {
 		this.defaultProperties = defaultProperties;
 	}
-
+ 
 	@Override
 	@Retryable(interceptor = "configServerRetryInterceptor")
 	public org.springframework.core.env.PropertySource<?> locate(
 			org.springframework.core.env.Environment environment) {
 		ConfigClientProperties properties = this.defaultProperties.override(environment);
 		CompositePropertySource composite = new CompositePropertySource("configService");
-		RestTemplate restTemplate = this.restTemplate == null ? getSecureRestTemplate(properties)
-				: this.restTemplate;
 		Exception error = null;
 		String errorBody = null;
 		logger.info("Fetching config from server at: " + properties.getRawUri());
@@ -88,8 +83,8 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 
 			// Try all the labels until one works
 			for (String label : labels) {
-				Environment result = getRemoteEnvironment(restTemplate,
-						properties, label.trim(), state);
+				Environment result = getRemoteEnvironment(properties, label.trim(),
+						state);
 				if (result != null) {
 					logger.info(String.format("Located environment: name=%s, profiles=%s, label=%s, version=%s, state=%s",
 							result.getName(),
@@ -143,8 +138,8 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		}
 	}
 
-	private Environment getRemoteEnvironment(RestTemplate restTemplate, ConfigClientProperties properties,
-											 String label, String state) {
+	private Environment getRemoteEnvironment(ConfigClientProperties properties, String label,
+											 String state) {
 		String path = "/{name}/{profile}";
 		String name = properties.getName();
 		String profile = properties.getProfile();
@@ -159,7 +154,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		ResponseEntity<Environment> response = null;
 
 		try {
-			HttpHeaders headers = new HttpHeaders();
+			HttpHeaders headers = getHttpHeaders(properties);
 			if (StringUtils.hasText(token)) {
 				headers.add(TOKEN_HEADER, token);
 			}
@@ -167,7 +162,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 				headers.add(STATE_HEADER, state);
 			}
 			final HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-			response = restTemplate.exchange(uri + path, HttpMethod.GET,
+			response = getRestTemplate().exchange(uri + path, HttpMethod.GET,
 					entity, Environment.class, args);
 		}
 		catch (HttpClientErrorException e) {
@@ -187,67 +182,38 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		this.restTemplate = restTemplate;
 	}
 
-	private RestTemplate getSecureRestTemplate(ConfigClientProperties client) {
+	private RestTemplate getRestTemplate() {
+		if (this.restTemplate != null) {
+			return this.restTemplate;
+		}
 		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
 		requestFactory.setReadTimeout((60 * 1000 * 3) + 5000); //TODO 3m5s, make configurable?
 		RestTemplate template = new RestTemplate(requestFactory);
-		String password = client.getPassword();
-		String authorization = client.getAuthorization();
-
-		if (password != null && authorization != null) {
-			throw new IllegalStateException(
-					"You must set either 'password' or 'authorization'");
-		}
-
-		if (password != null) {
-			template.setInterceptors(Arrays.<ClientHttpRequestInterceptor> asList(
-					new BasicAuthorizationInterceptor(client.getUsername(), password)));
-		}
-		else if (authorization != null) {
-			template.setInterceptors(Arrays.<ClientHttpRequestInterceptor> asList(
-					new GenericAuthorization(authorization)));
-		}
-
 		return template;
 	}
 
-	private static class BasicAuthorizationInterceptor implements
-			ClientHttpRequestInterceptor {
+	private HttpHeaders getHttpHeaders(ConfigClientProperties properties) {
+		HttpHeaders headers = new HttpHeaders();
+		String password = properties.getPassword();
+		String authorization = properties.getAuthorization();
+		if (!properties.getHeaders().containsKey("Authorization")) {
+			if (password != null && authorization != null) {
+				throw new IllegalStateException(
+						"You must set either 'password' or 'authorization'");
+			}
 
-		private final String username;
-
-		private final String password;
-
-		public BasicAuthorizationInterceptor(String username, String password) {
-			this.username = username;
-			this.password = (password == null ? "" : password);
+			if (password != null) {
+				headers.add("Authorization", "Basic " + new String(Base64Utils
+						.encode((properties.getUsername() + ":" + password).getBytes())));
+			}
+			else if (authorization != null) {
+				headers.add("Authorization", authorization);
+			}
 		}
-
-		@Override
-		public ClientHttpResponse intercept(HttpRequest request, byte[] body,
-				ClientHttpRequestExecution execution) throws IOException {
-			byte[] token = Base64Utils.encode((this.username + ":" + this.password).getBytes());
-			request.getHeaders().add("Authorization", "Basic " + new String(token));
-			return execution.execute(request, body);
+		for (Entry<String, String> header : properties.getHeaders().entrySet()) {
+			headers.add(header.getKey(), header.getValue());
 		}
-
+		return headers;
 	}
 
-
-	private static class GenericAuthorization implements
-			ClientHttpRequestInterceptor {
-
-		private final String authorizationToken;
-
-		public GenericAuthorization(String authorizationToken) {
-			this.authorizationToken = (authorizationToken == null ? "" : authorizationToken);
-		}
-
-		@Override
-		public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
-				throws IOException {
-			request.getHeaders().add("Authorization", authorizationToken);
-			return execution.execute(request, body);
-		}
-	}
 }

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -196,7 +196,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		String username = client.getUsername();
 		String password = client.getPassword();
 		String authorization = client.getAuthorization();
-		Map<String, String> headers = client.getHeaders();
+		Map<String, String> headers = new HashMap<>(client.getHeaders());
 
 		if (password != null && authorization != null) {
 			throw new IllegalStateException(

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -218,7 +218,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		return template;
 	}
 
-	private static class BasicAuthorizationInterceptor implements
+	public static class BasicAuthorizationInterceptor implements
 			ClientHttpRequestInterceptor {
 
 		private final String username;
@@ -241,7 +241,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 	}
 
 
-	private static class GenericAuthorization implements
+	public static class GenericAuthorization implements
 			ClientHttpRequestInterceptor {
 
 		private final String authorizationToken;
@@ -258,7 +258,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 		}
 	}
 
-	private static class CustomHeadersInterceptor
+	public static class CustomHeadersInterceptor
 			implements ClientHttpRequestInterceptor {
 
 		private final Map<String, String> headers;

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNull;
@@ -28,7 +26,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.util.Base64Utils;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -137,153 +134,6 @@ public class ConfigServicePropertySourceLocatorTests {
 		assertNull(this.locator.locate(this.environment));
 	}
 
-	@Test
-	public void sunnyDayWithCustomHeaders() throws Exception {
-		ClientHttpRequestFactory requestFactory = Mockito
-				.mock(ClientHttpRequestFactory.class);
-		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
-		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
-				Mockito.any(HttpMethod.class))).thenReturn(request);
-
-		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
-
-		Map<String, String> customHeaders = new HashMap<>();
-		customHeaders.put("X-Example-Version", "2.1");
-
-		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
-		defaults.setHeaders(customHeaders);
-
-		this.locator = new ConfigServicePropertySourceLocator(defaults);
-		this.locator.setRestTemplate(restTemplate);
-		this.locator.locate(this.environment);
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Example-Version", "2.1");
-		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-
-		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
-				Mockito.any(HttpMethod.class), Mockito.eq(entity),
-				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
-	}
-
-	@Test
-	public void passwordPropertyAddsAuthorizationHeader() throws Exception {
-		ClientHttpRequestFactory requestFactory = Mockito
-				.mock(ClientHttpRequestFactory.class);
-		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
-		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
-				Mockito.any(HttpMethod.class))).thenReturn(request);
-
-		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
-
-		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
-		defaults.setUsername("username");
-		defaults.setPassword("password");
-
-		this.locator = new ConfigServicePropertySourceLocator(defaults);
-		this.locator.setRestTemplate(restTemplate);
-		this.locator.locate(this.environment);
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Basic "
-				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
-		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-
-		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
-				Mockito.any(HttpMethod.class), Mockito.eq(entity),
-				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
-	}
-
-	@Test
-	public void authorizationPropertyAddsGenericAuthorizationHeader() throws Exception {
-		ClientHttpRequestFactory requestFactory = Mockito
-				.mock(ClientHttpRequestFactory.class);
-		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
-		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
-				Mockito.any(HttpMethod.class))).thenReturn(request);
-
-		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
-
-		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
-		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
-
-		this.locator = new ConfigServicePropertySourceLocator(defaults);
-		this.locator.setRestTemplate(restTemplate);
-		this.locator.locate(this.environment);
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
-		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-
-		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
-				Mockito.any(HttpMethod.class), Mockito.eq(entity),
-				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
-	}
-
-	@Test
-	public void failWhenBothPasswordAndAuthorizationPropertiesSet() throws Exception {
-		ClientHttpRequestFactory requestFactory = Mockito
-				.mock(ClientHttpRequestFactory.class);
-		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
-		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
-				Mockito.any(HttpMethod.class))).thenReturn(request);
-
-		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
-
-		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
-		defaults.setFailFast(true);
-		defaults.setUsername("username");
-		defaults.setPassword("password");
-		defaults.setAuthorization("Basic "
-				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
-
-		this.expected.expectCause(
-				IsInstanceOf.<Throwable> instanceOf(IllegalStateException.class));
-
-		this.locator = new ConfigServicePropertySourceLocator(defaults);
-		this.locator.setRestTemplate(restTemplate);
-		this.locator.locate(this.environment);
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Basic "
-				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
-		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-
-		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
-				Mockito.any(HttpMethod.class), Mockito.eq(entity),
-				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
-	}
-
-	@Test
-	public void authorizationHeaderTakesPrecedenceOverProperties() throws Exception {
-		ClientHttpRequestFactory requestFactory = Mockito
-				.mock(ClientHttpRequestFactory.class);
-		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
-		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
-				Mockito.any(HttpMethod.class))).thenReturn(request);
-
-		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
-
-		Map<String, String> customHeaders = new HashMap<>();
-		customHeaders.put("Authorization", "Custom Headers");
-
-		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
-		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
-		defaults.setHeaders(customHeaders);
-
-		this.locator = new ConfigServicePropertySourceLocator(defaults);
-		this.locator.setRestTemplate(restTemplate);
-		this.locator.locate(this.environment);
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Custom Headers");
-		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
-
-		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
-				Mockito.any(HttpMethod.class), Mockito.eq(entity),
-				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
-	}
-
 	@SuppressWarnings("unchecked")
 	private void mockRequestResponseWithLabel(ResponseEntity<?> response, String label) {
 		Mockito.when(
@@ -301,9 +151,4 @@ public class ConfigServicePropertySourceLocatorTests {
 						Mockito.any(Class.class), Matchers.anyString(),
 						Matchers.anyString())).thenReturn(response);
 	}
-
-	private String encodePassword(String username, String password) {
-		return new String(Base64Utils.encode((username + ":" + password).getBytes()));
-	}
-
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNull;
@@ -26,6 +28,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.Base64Utils;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -134,6 +137,153 @@ public class ConfigServicePropertySourceLocatorTests {
 		assertNull(this.locator.locate(this.environment));
 	}
 
+	@Test
+	public void sunnyDayWithCustomHeaders() throws Exception {
+		ClientHttpRequestFactory requestFactory = Mockito
+				.mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
+		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
+				Mockito.any(HttpMethod.class))).thenReturn(request);
+
+		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
+
+		Map<String, String> customHeaders = new HashMap<>();
+		customHeaders.put("X-Example-Version", "2.1");
+
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setHeaders(customHeaders);
+
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		this.locator.setRestTemplate(restTemplate);
+		this.locator.locate(this.environment);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("X-Example-Version", "2.1");
+		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+
+		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
+				Mockito.any(HttpMethod.class), Mockito.eq(entity),
+				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void passwordPropertyAddsAuthorizationHeader() throws Exception {
+		ClientHttpRequestFactory requestFactory = Mockito
+				.mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
+		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
+				Mockito.any(HttpMethod.class))).thenReturn(request);
+
+		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
+
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setUsername("username");
+		defaults.setPassword("password");
+
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		this.locator.setRestTemplate(restTemplate);
+		this.locator.locate(this.environment);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Basic "
+				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
+		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+
+		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
+				Mockito.any(HttpMethod.class), Mockito.eq(entity),
+				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void authorizationPropertyAddsGenericAuthorizationHeader() throws Exception {
+		ClientHttpRequestFactory requestFactory = Mockito
+				.mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
+		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
+				Mockito.any(HttpMethod.class))).thenReturn(request);
+
+		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
+
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
+
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		this.locator.setRestTemplate(restTemplate);
+		this.locator.locate(this.environment);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
+		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+
+		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
+				Mockito.any(HttpMethod.class), Mockito.eq(entity),
+				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void failWhenBothPasswordAndAuthorizationPropertiesSet() throws Exception {
+		ClientHttpRequestFactory requestFactory = Mockito
+				.mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
+		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
+				Mockito.any(HttpMethod.class))).thenReturn(request);
+
+		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
+
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setFailFast(true);
+		defaults.setUsername("username");
+		defaults.setPassword("password");
+		defaults.setAuthorization("Basic "
+				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
+
+		this.expected.expectCause(
+				IsInstanceOf.<Throwable> instanceOf(IllegalStateException.class));
+
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		this.locator.setRestTemplate(restTemplate);
+		this.locator.locate(this.environment);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Basic "
+				+ encodePassword(defaults.getUsername(), defaults.getPassword()));
+		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+
+		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
+				Mockito.any(HttpMethod.class), Mockito.eq(entity),
+				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void authorizationHeaderTakesPrecedenceOverProperties() throws Exception {
+		ClientHttpRequestFactory requestFactory = Mockito
+				.mock(ClientHttpRequestFactory.class);
+		ClientHttpRequest request = Mockito.mock(ClientHttpRequest.class);
+		Mockito.when(requestFactory.createRequest(Mockito.any(URI.class),
+				Mockito.any(HttpMethod.class))).thenReturn(request);
+
+		RestTemplate restTemplate = Mockito.spy(new RestTemplate(requestFactory));
+
+		Map<String, String> customHeaders = new HashMap<>();
+		customHeaders.put("Authorization", "Custom Headers");
+
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
+		defaults.setHeaders(customHeaders);
+
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		this.locator.setRestTemplate(restTemplate);
+		this.locator.locate(this.environment);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Custom Headers");
+		HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);
+
+		Mockito.verify(restTemplate).exchange(Mockito.anyString(),
+				Mockito.any(HttpMethod.class), Mockito.eq(entity),
+				Mockito.eq(Environment.class), Mockito.any(), Mockito.any());
+	}
+
 	@SuppressWarnings("unchecked")
 	private void mockRequestResponseWithLabel(ResponseEntity<?> response, String label) {
 		Mockito.when(
@@ -151,4 +301,9 @@ public class ConfigServicePropertySourceLocatorTests {
 						Mockito.any(Class.class), Matchers.anyString(),
 						Matchers.anyString())).thenReturn(response);
 	}
+
+	private String encodePassword(String username, String password) {
+		return new String(Base64Utils.encode((username + ":" + password).getBytes()));
+	}
+
 }


### PR DESCRIPTION
This commit provides an alternative implementation for creating
config client request using 'ConfigurationProperties' instead
of having to create custom 'RestTemplate' when adding header to
the request.

See discusions at gh-650

Not covering gh-613