### PR TITLE
Make fetching of config server from Eureka retryable, add support for failfast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
 		  <type>pom</type>
 		  <scope>import</scope>
 		</dependency>
+		<dependency>
+		  <groupId>org.springframework.cloud</groupId>
+		  <artifactId>spring-cloud-commons</artifactId>
+		  <type>test-jar</type>
+		  <scope>test</scope>
+		  <version>${spring-cloud-commons.version}</version>
+		</dependency>
      </dependencies>
     </dependencyManagement>
 	<profiles>

--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -76,6 +76,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-commons</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceProvider.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceProvider.java
@@ -1,0 +1,33 @@
+package org.springframework.cloud.config.client;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.retry.annotation.Retryable;
+
+import java.util.List;
+
+public class ConfigServerInstanceProvider {
+
+	private static Log logger = LogFactory.getLog(ConfigServerInstanceProvider.class);
+	private final DiscoveryClient client;
+
+	public ConfigServerInstanceProvider(DiscoveryClient client) {
+		this.client = client;
+	}
+
+	@Retryable(interceptor = "configServerRetryInterceptor")
+	public ServiceInstance getConfigServerInstance(String serviceId) {
+		logger.debug("Locating configserver (" + serviceId + ") via discovery");
+		List<ServiceInstance> instances = this.client.getInstances(serviceId);
+		if (instances.isEmpty()) {
+			throw new IllegalStateException(
+					"No instances found of configserver (" + serviceId + ")");
+		}
+		ServiceInstance instance = instances.get(0);
+		logger.debug(
+				"Located configserver (" + serviceId + ") via discovery: " + instance);
+		return instance;
+	}
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/BaseDiscoveryClientConfigServiceBootstrapConfigurationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/BaseDiscoveryClientConfigServiceBootstrapConfigurationTests.java
@@ -1,0 +1,106 @@
+package org.springframework.cloud.config.client;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.cloud.config.client.ConfigClientProperties.Discovery.DEFAULT_CONFIG_SERVER;
+
+public abstract class BaseDiscoveryClientConfigServiceBootstrapConfigurationTests {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	protected AnnotationConfigApplicationContext context;
+
+	protected DiscoveryClient client = Mockito.mock(DiscoveryClient.class);
+
+	protected ServiceInstance info = new DefaultServiceInstance("app", "foo", 8877,
+			false);
+
+	@After
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	void givenDiscoveryClientReturnsNoInfo() {
+		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
+				.willReturn(Collections.<ServiceInstance> emptyList());
+	}
+
+	void givenDiscoveryClientReturnsInfo() {
+		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
+				.willReturn(Arrays.asList(this.info));
+	}
+
+	void givenDiscoveryClientReturnsInfoOnThirdTry() {
+		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
+				.willReturn(Collections.<ServiceInstance> emptyList())
+				.willReturn(Collections.<ServiceInstance> emptyList())
+				.willReturn(Arrays.asList(this.info));
+	}
+
+	void expectNoInstancesOfConfigServerException() {
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(
+				"No instances found of configserver (" + DEFAULT_CONFIG_SERVER + ")");
+	}
+
+	void expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup() {
+		assertEquals(1, this.context.getBeanNamesForType(
+				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
+	}
+
+	void expectConfigClientPropertiesHasDefaultConfiguration() {
+		expectConfigClientPropertiesHasConfiguration("http://localhost:8888");
+	}
+
+	void expectConfigClientPropertiesHasConfigurationFromEureka() {
+		expectConfigClientPropertiesHasConfiguration("http://foo:8877/");
+	}
+
+	void expectConfigClientPropertiesHasConfiguration(final String expectedUri) {
+		ConfigClientProperties properties = this.context
+				.getBean(ConfigClientProperties.class);
+		assertEquals(expectedUri, properties.getRawUri());
+	}
+
+	void verifyDiscoveryClientCalledThreeTimes() {
+		verify(this.client, times(3)).getInstances(DEFAULT_CONFIG_SERVER);
+	}
+
+	void verifyDiscoveryClientCalledOnce() {
+		verify(this.client).getInstances(DEFAULT_CONFIG_SERVER);
+	}
+
+	void setup(String... env) {
+		this.context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context, env);
+		EnvironmentTestUtils.addEnvironment(this.context, "eureka.client.enabled=false");
+		this.context.getDefaultListableBeanFactory().registerSingleton("discoveryClient",
+				this.client);
+		this.context.register(UtilAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class,
+				DiscoveryClientConfigServiceBootstrapConfiguration.class,
+				ConfigServiceBootstrapConfiguration.class, ConfigClientProperties.class);
+		this.context.refresh();
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfigurationNoSpringRetryTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfigurationNoSpringRetryTests.java
@@ -1,0 +1,50 @@
+package org.springframework.cloud.config.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.cloud.ClassPathExclusions;
+import org.springframework.cloud.FilteredClassPathRunner;
+
+@RunWith(FilteredClassPathRunner.class)
+@ClassPathExclusions({ "spring-retry-*.jar", "spring-boot-starter-aop-*.jar" })
+public class DiscoveryClientConfigServiceBootstrapConfigurationNoSpringRetryTests
+		extends BaseDiscoveryClientConfigServiceBootstrapConfigurationTests {
+
+	@Test
+	public void shouldFailWithExceptionGetConfigServerInstanceFromDiscoveryClient()
+			throws Exception {
+		givenDiscoveryClientReturnsNoInfo();
+
+		expectNoInstancesOfConfigServerException();
+
+		setup("spring.cloud.config.discovery.enabled=true",
+				"spring.cloud.config.failFast=true");
+	}
+
+	@Test
+	public void shouldFailWithMessageGetConfigServerInstanceFromDiscoveryClient()
+			throws Exception {
+		givenDiscoveryClientReturnsNoInfo();
+
+		setup("spring.cloud.config.discovery.enabled=true",
+				"spring.cloud.config.failFast=false");
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		expectConfigClientPropertiesHasDefaultConfiguration();
+		verifyDiscoveryClientCalledOnce();
+	}
+
+	@Test
+	public void shouldSucceedGetConfigServerInstanceFromDiscoveryClient()
+			throws Exception {
+		givenDiscoveryClientReturnsInfo();
+
+		setup("spring.cloud.config.discovery.enabled=true",
+				"spring.cloud.config.failFast=true");
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		expectConfigClientPropertiesHasConfigurationFromEureka();
+		verifyDiscoveryClientCalledOnce();
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfigurationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfigurationTests.java
@@ -16,53 +16,24 @@
 
 package org.springframework.cloud.config.client;
 
-import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.cloud.client.DefaultServiceInstance;
-import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
-import org.springframework.cloud.commons.util.UtilAutoConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import static org.junit.Assert.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.cloud.config.client.ConfigClientProperties.Discovery.DEFAULT_CONFIG_SERVER;
 
 /**
  * @author Dave Syer
  */
-public class DiscoveryClientConfigServiceBootstrapConfigurationTests {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-
-	private AnnotationConfigApplicationContext context;
-
-	private DiscoveryClient client = Mockito.mock(DiscoveryClient.class);
-
-	private ServiceInstance info = new DefaultServiceInstance("app", "foo", 8877, false);
-
-	@After
-	public void close() {
-		if (this.context != null) {
-			this.context.close();
-		}
-	}
+public class DiscoveryClientConfigServiceBootstrapConfigurationTests extends BaseDiscoveryClientConfigServiceBootstrapConfigurationTests {
 
 	@Test
 	public void offByDefault() throws Exception {
 		this.context = new AnnotationConfigApplicationContext(
 				DiscoveryClientConfigServiceBootstrapConfiguration.class);
+
 		assertEquals(0, this.context.getBeanNamesForType(DiscoveryClient.class).length);
 		assertEquals(0, this.context.getBeanNamesForType(
 				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
@@ -70,51 +41,49 @@ public class DiscoveryClientConfigServiceBootstrapConfigurationTests {
 
 	@Test
 	public void onWhenRequested() throws Exception {
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Arrays.asList(this.info));
+		givenDiscoveryClientReturnsInfo();
+
 		setup("spring.cloud.config.discovery.enabled=true");
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
-		verify(this.client).getInstances(DEFAULT_CONFIG_SERVER);
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://foo:8877/", locator.getRawUri());
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		verifyDiscoveryClientCalledOnce();
+		expectConfigClientPropertiesHasConfigurationFromEureka();
 	}
 
 	@Test
 	public void onWhenHeartbeat() throws Exception {
 		setup("spring.cloud.config.discovery.enabled=true");
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Arrays.asList(this.info));
-		verify(this.client).getInstances(DEFAULT_CONFIG_SERVER);
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+
+		givenDiscoveryClientReturnsInfo();
+		verifyDiscoveryClientCalledOnce();
+
 		context.publishEvent(new HeartbeatEvent(context, "new"));
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://foo:8877/", locator.getRawUri());
+
+		expectConfigClientPropertiesHasConfigurationFromEureka();
 	}
 
 	@Test
 	public void secureWhenRequested() throws Exception {
 		this.info = new DefaultServiceInstance("app", "foo", 443, true);
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Arrays.asList(this.info));
+		givenDiscoveryClientReturnsInfo();
+
 		setup("spring.cloud.config.discovery.enabled=true");
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
-		verify(this.client).getInstances(DEFAULT_CONFIG_SERVER);
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("https://foo:443/", locator.getRawUri());
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+
+		verifyDiscoveryClientCalledOnce();
+		expectConfigClientPropertiesHasConfiguration("https://foo:443/");
 	}
 
 	@Test
 	public void setsPasssword() throws Exception {
 		this.info.getMetadata().put("password", "bar");
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Arrays.asList(this.info));
+		givenDiscoveryClientReturnsInfo();
+
 		setup("spring.cloud.config.discovery.enabled=true");
+
 		ConfigClientProperties locator = this.context
 				.getBean(ConfigClientProperties.class);
 		assertEquals("http://foo:8877/", locator.getRawUri());
@@ -125,60 +94,61 @@ public class DiscoveryClientConfigServiceBootstrapConfigurationTests {
 	@Test
 	public void setsPath() throws Exception {
 		this.info.getMetadata().put("configPath", "/bar");
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Arrays.asList(this.info));
+		givenDiscoveryClientReturnsInfo();
+
 		setup("spring.cloud.config.discovery.enabled=true");
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://foo:8877/bar", locator.getRawUri());
+
+		expectConfigClientPropertiesHasConfiguration("http://foo:8877/bar");
 	}
 
 	@Test
 	public void shouldFailGetConfigServerInstanceFromDiscoveryClient() throws Exception {
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Collections.<ServiceInstance> emptyList());
+		givenDiscoveryClientReturnsNoInfo();
 
 		setup("spring.cloud.config.discovery.enabled=true");
 
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
-		verify(client).getInstances(DEFAULT_CONFIG_SERVER);
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://localhost:8888", locator.getRawUri());
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		verifyDiscoveryClientCalledOnce();
+		expectConfigClientPropertiesHasDefaultConfiguration();
 	}
 
 	@Test
 	public void shouldRetryAndSucceedGetConfigServerInstanceFromDiscoveryClient()
 			throws Exception {
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Collections.<ServiceInstance> emptyList())
-				.willReturn(Collections.<ServiceInstance> emptyList())
-				.willReturn(Arrays.asList(this.info));
+		givenDiscoveryClientReturnsInfoOnThirdTry();
 
 		setup("spring.cloud.config.discovery.enabled=true",
 				"spring.cloud.config.retry.maxAttempts=3",
 				"spring.cloud.config.retry.initialInterval=10",
 				"spring.cloud.config.failFast=true");
 
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		verifyDiscoveryClientCalledThreeTimes();
 
 		context.publishEvent(new HeartbeatEvent(context, "new"));
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://foo:8877/", locator.getRawUri());
+
+		expectConfigClientPropertiesHasConfigurationFromEureka();
+	}
+
+	@Test
+	public void shouldNotRetryIfNotFailFastPropertySet() throws Exception {
+		givenDiscoveryClientReturnsInfoOnThirdTry();
+
+		setup("spring.cloud.config.discovery.enabled=true",
+				"spring.cloud.config.retry.maxAttempts=3",
+				"spring.cloud.config.retry.initialInterval=10");
+
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		verifyDiscoveryClientCalledOnce();
+		expectConfigClientPropertiesHasDefaultConfiguration();
 	}
 
 	@Test
 	public void shouldRetryAndFailWithExceptionGetConfigServerInstanceFromDiscoveryClient()
 			throws Exception {
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Collections.<ServiceInstance> emptyList());
+		givenDiscoveryClientReturnsNoInfo();
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage(
-				"No instances found of configserver (" + DEFAULT_CONFIG_SERVER + ")");
+		expectNoInstancesOfConfigServerException();
 
 		setup("spring.cloud.config.discovery.enabled=true",
 				"spring.cloud.config.retry.maxAttempts=3",
@@ -189,32 +159,15 @@ public class DiscoveryClientConfigServiceBootstrapConfigurationTests {
 	@Test
 	public void shouldRetryAndFailWithMessageGetConfigServerInstanceFromDiscoveryClient()
 			throws Exception {
-		given(this.client.getInstances(DEFAULT_CONFIG_SERVER))
-				.willReturn(Collections.<ServiceInstance> emptyList());
+		givenDiscoveryClientReturnsNoInfo();
 
 		setup("spring.cloud.config.discovery.enabled=true",
 				"spring.cloud.config.retry.maxAttempts=3",
 				"spring.cloud.config.retry.initialInterval=10",
 				"spring.cloud.config.failFast=false");
 
-		assertEquals(1, this.context.getBeanNamesForType(
-				DiscoveryClientConfigServiceBootstrapConfiguration.class).length);
-		ConfigClientProperties locator = this.context
-				.getBean(ConfigClientProperties.class);
-		assertEquals("http://localhost:8888", locator.getRawUri());
-	}
-
-	private void setup(String... env) {
-		this.context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(this.context, env);
-		EnvironmentTestUtils.addEnvironment(this.context, "eureka.client.enabled=false");
-		this.context.getDefaultListableBeanFactory().registerSingleton("discoveryClient",
-				this.client);
-		this.context.register(UtilAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class,
-				DiscoveryClientConfigServiceBootstrapConfiguration.class,
-				ConfigServiceBootstrapConfiguration.class, ConfigClientProperties.class);
-		this.context.refresh();
+		expectDiscoveryClientConfigServiceBootstrapConfigurationIsSetup();
+		expectConfigClientPropertiesHasDefaultConfiguration();
 	}
 
 }


### PR DESCRIPTION
I would like to write functional tests for this feature, but haven't found where to put them. Could you please point where they are? Thanks