### PR TITLE
Changed Health-Endpoint-Status if git-scm not available and extend logging-settings to set level to error if repo not available

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/environment/Environment.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/environment/Environment.java
@@ -46,6 +46,12 @@ public class Environment {
 
 	private String state;
 
+	/**
+	 * Marks an environment as cached means that the last request to update the property sources failed
+	 * and the last existing information is used instead.
+	 */
+	private Boolean cached = false;
+
 	public Environment(String name, String... profiles) {
 		this(name, profiles, "master", null, null);
 	}
@@ -56,6 +62,7 @@ public class Environment {
 	 */
 	public Environment(Environment env) {
 		this(env.getName(), env.getProfiles(), env.getLabel(), env.getVersion(), env.getState());
+		this.setCached(env.getCached());
 	}
 
 	@JsonCreator
@@ -128,12 +135,21 @@ public class Environment {
 		this.state = state;
 	}
 
+	public Boolean getCached() {
+		return cached;
+	}
+
+	public void setCached(Boolean cached) {
+		this.cached = cached;
+	}
+
 	@Override
 	public String toString() {
 		return "Environment [name=" + name + ", profiles=" + Arrays.asList(profiles)
 				+ ", label=" + label + ", propertySources=" + propertySources
 				+ ", version=" + version
-				+ ", state=" + state + "]";
+				+ ", state=" + state
+				+ ", cached=" + cached + "]";
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerHealthIndicator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerHealthIndicator.java
@@ -19,6 +19,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Spencer Gibb
+ * @author Mark Bonnekessel
  */
 @ConfigurationProperties("spring.cloud.config.server.health")
 public class ConfigServerHealthIndicator extends AbstractHealthIndicator {
@@ -53,6 +54,11 @@ public class ConfigServerHealthIndicator extends AbstractHealthIndicator {
 				HashMap<String, Object> detail = new HashMap<>();
 				detail.put("name", environment.getName());
 				detail.put("label", environment.getLabel());
+
+				if (environment.getCached()) {
+					builder.unknown();
+				}
+
 				if (environment.getProfiles() != null && environment.getProfiles().length > 0) {
 					detail.put("profiles", Arrays.asList(environment.getProfiles()));
 				}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractScmEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractScmEnvironmentRepository.java
@@ -23,6 +23,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * @author Dave Syer
+ * @author Mark Bonnekessel
  *
  */
 public abstract class AbstractScmEnvironmentRepository extends AbstractScmAccessor
@@ -42,6 +43,9 @@ public abstract class AbstractScmEnvironmentRepository extends AbstractScmAccess
 		Locations locations = getLocations(application, profile, label);
 		delegate.setSearchLocations(locations.getLocations());
 		Environment result = delegate.findOne(application, profile, "");
+		if(!locations.getLatest()){
+			result.setCached(true);
+		}
 		result.setVersion(locations.getVersion());
 		result.setLabel(label);
 		return this.cleaner.clean(result, getWorkingDirectory().toURI().toString(),

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
@@ -23,6 +23,7 @@ import org.springframework.core.OrderComparator;
 /**
  * An {@link EnvironmentRepository} composed of multiple ordered {@link EnvironmentRepository}s.
  * @author Ryan Baxter
+ * @author Mark Bonnekessel
  */
 public class CompositeEnvironmentRepository implements EnvironmentRepository {
 
@@ -40,10 +41,15 @@ public class CompositeEnvironmentRepository implements EnvironmentRepository {
 
 	@Override
 	public Environment findOne(String application, String profile, String label) {
-		Environment env = new Environment(application, new String[]{profile}, label, null, null);
+		Environment resultEnv = new Environment(application, new String[]{profile}, label, null, null);
 		for(EnvironmentRepository repo : environmentRepositories) {
-			env.addAll(repo.findOne(application, profile, label).getPropertySources());
+			Environment env = repo.findOne(application, profile, label);
+			if(env.getCached()){
+				resultEnv.setCached(true);
+			}
+
+			resultEnv.addAll(env.getPropertySources());
 		}
-		return env;
+		return resultEnv;
 	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/ScmUpdateFailedException.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/ScmUpdateFailedException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.config.server.environment;
+
+/**
+ * Signals that the scm could not be updated and provides an older version that can be used instead.
+ *
+ * @author Mark Bonnekessel
+ */
+public class ScmUpdateFailedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Specifies the version that can be used if the current repository cannot be fetched!
+	 */
+	private String existingVersion = "";
+
+	public ScmUpdateFailedException(String msg) {
+		super(msg);
+	}
+	public ScmUpdateFailedException(String msg, String existingVersion) {
+		super(msg);
+		this.existingVersion = existingVersion;
+	}
+
+	public ScmUpdateFailedException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+	public ScmUpdateFailedException(String msg, String existingVersion, Throwable cause) {
+		super(msg, cause);
+		this.existingVersion = existingVersion;
+	}
+
+	public String getExistingVersion() {
+		return existingVersion;
+	}
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SearchPathLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SearchPathLocator.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
  * classpath).
  *
  * @author Dave Syer
+ * @author Mark Bonnekessel
  *
  */
 public interface SearchPathLocator {
@@ -35,6 +36,7 @@ public interface SearchPathLocator {
 		private final String label;
 		private final String[] locations;
 		private final String version;
+		private boolean latest;
 
 		public Locations(String application, String profile, String label, String version, String[] locations) {
 			this.application = application;
@@ -42,7 +44,14 @@ public interface SearchPathLocator {
 			this.label = label;
 			this.locations = locations;
 			this.version = version;
+			this.latest = true;
 		}
+
+		public Locations(String application, String profile, String label, String version, String[] locations, Boolean latest) {
+			this(application, profile, label, version, locations);
+			this.latest = latest;
+		}
+
 
 		public String[] getLocations() {
 			return locations;
@@ -62,6 +71,10 @@ public interface SearchPathLocator {
 
 		public String getLabel() {
 			return label;
+		}
+
+		public boolean getLatest() {
+			return latest;
 		}
 
 		@Override

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/ConfigServerHealthIndicatorTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/ConfigServerHealthIndicatorTests.java
@@ -49,6 +49,20 @@ public class ConfigServerHealthIndicatorTests {
 	}
 
 	@Test
+	public void repositoryCachedStatusIsOutOfService() {
+		when(environment.getCached()).thenReturn(true);
+		when(repository.findOne(anyString(), anyString(), anyString())).thenReturn(environment);
+		assertEquals("wrong status", Status.UNKNOWN, indicator.health().getStatus());
+	}
+
+	@Test
+	public void repositoryNotCachedLatestStatusIsUp() {
+		when(environment.getCached()).thenReturn(false);
+		when(repository.findOne(anyString(), anyString(), anyString())).thenReturn(environment);
+		assertEquals("status is not up", Status.UP, indicator.health().getStatus());
+	}
+
+	@Test
 	public void customLabelWorks() {
 		Repository repo = new Repository();
 		repo.setName("myname");


### PR DESCRIPTION
- Added property spring.cloud.config.server.git.error-log-on-failing-fetch
  to set logging type to error if fetch failed

- Updated Health-Status to set to out-of-service if git repo is currenty
  not fetchable

- Created new Variable 'cached' for Class Environment

Fixes gh-584