### PR TITLE
Add ability to set JGit TransportConfigCallback

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.config.server.config;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.eclipse.jgit.api.TransportConfigCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -57,9 +58,13 @@ public class EnvironmentRepositoryConfiguration {
 		@Autowired
 		private ConfigServerProperties server;
 
+		@Autowired(required = false)
+		private TransportConfigCallback transportConfigCallback;
+
 		@Bean
 		public MultipleJGitEnvironmentRepository defaultEnvironmentRepository() {
 			MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment);
+			repository.setTransportConfigCallback(this.transportConfigCallback);
 			if (this.server.getDefaultLabel()!=null) {
 				repository.setDefaultLabel(this.server.getDefaultLabel());
 			}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -444,8 +444,13 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	private void configureCommand(TransportCommand<?, ?> command) {
 		command.setTimeout(this.timeout);
-		command.setTransportConfigCallback(this.transportConfigCallback);
-		command.setCredentialsProvider(getCredentialsProvider());
+		if (this.transportConfigCallback != null) {
+			command.setTransportConfigCallback(this.transportConfigCallback);
+		}
+		CredentialsProvider credentialsProvider = getCredentialsProvider();
+		if (credentialsProvider != null) {
+			command.setCredentialsProvider(credentialsProvider);
+		}
 	}
 
 	private CredentialsProvider getCredentialsProvider() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -36,6 +36,7 @@ import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.StatusCommand;
 import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.lib.Ref;
@@ -97,6 +98,11 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	private CredentialsProvider gitCredentialsProvider;
 
 	/**
+	 * Transport configuration callback for JGit commands.
+	 */
+	private TransportConfigCallback transportConfigCallback;
+
+	/**
 	 * Flag to indicate that the repository should force pull. If true discard any local
 	 * changes and take from remote repository.
 	 */
@@ -120,6 +126,14 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
+	}
+
+	public TransportConfigCallback getTransportConfigCallback() {
+		return transportConfigCallback;
+	}
+
+	public void setTransportConfigCallback(TransportConfigCallback transportConfigCallback) {
+		this.transportConfigCallback = transportConfigCallback;
 	}
 
 	public JGitFactory getGitFactory() {
@@ -250,7 +264,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	}
 
 
-	public /*public for testing*/ boolean shouldPull(Git git) throws GitAPIException {
+	protected boolean shouldPull(Git git) throws GitAPIException {
 		boolean shouldPull;
 		Status gitStatus = git.status().call();
 		boolean isWorkingTreeClean = gitStatus.isClean();
@@ -292,14 +306,13 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		return isBranch(git, label) && !isLocalBranch(git, label);
 	}
 
-	private FetchResult fetch(Git git, String label) {
+	protected FetchResult fetch(Git git, String label) {
 		FetchCommand fetch = git.fetch();
 		fetch.setRemote("origin");
 		fetch.setTagOpt(TagOpt.FETCH_TAGS);
 
-		setTimeout(fetch);
+		configureCommand(fetch);
 		try {
-			setCredentialsProvider(fetch);
 			FetchResult result = fetch.call();
 			if(result.getTrackingRefUpdates() != null && result.getTrackingRefUpdates().size() > 0) {
 				logger.info("Fetched for remote " + label + " and found " + result.getTrackingRefUpdates().size()
@@ -396,8 +409,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	private Git cloneToBasedir() throws GitAPIException {
 		CloneCommand clone = this.gitFactory.getCloneCommandByCloneRepository()
 				.setURI(getUri()).setDirectory(getBasedir());
-		setTimeout(clone);
-		setCredentialsProvider(clone);
+		configureCommand(clone);
 		try {
 			return clone.call();
 		}
@@ -430,20 +442,26 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		}
 	}
 
-	private void setCredentialsProvider(TransportCommand<?, ?> cmd) {
-		if (gitCredentialsProvider != null) {
-			cmd.setCredentialsProvider(gitCredentialsProvider);
-		} else if (hasText(getUsername())) {
-			cmd.setCredentialsProvider(
-					new UsernamePasswordCredentialsProvider(getUsername(), getPassword()));
-		} else if (hasText(getPassphrase())) {
-			cmd.setCredentialsProvider(
-					new PassphraseCredentialsProvider(getPassphrase()));
-		}
+	private void configureCommand(TransportCommand<?, ?> command) {
+		command.setTimeout(this.timeout);
+		command.setTransportConfigCallback(this.transportConfigCallback);
+		command.setCredentialsProvider(getCredentialsProvider());
 	}
 
-	private void setTimeout(TransportCommand<?, ?> pull) {
-		pull.setTimeout(this.timeout);
+	private CredentialsProvider getCredentialsProvider() {
+		if (this.gitCredentialsProvider != null) {
+			return this.gitCredentialsProvider;
+		}
+
+		if (hasText(getUsername()) && hasText(getPassword())) {
+			return new UsernamePasswordCredentialsProvider(getUsername(), getPassword());
+		}
+
+		if (hasText(getPassphrase())) {
+			return new PassphraseCredentialsProvider(getPassphrase());
+		}
+
+		return null;
 	}
 
 	private boolean isClean(Git git) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
@@ -75,6 +75,9 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 			if (repo.getPattern() == null || repo.getPattern().length == 0) {
 				repo.setPattern(new String[] { name });
 			}
+			if (repo.getTransportConfigCallback() == null) {
+				repo.setTransportConfigCallback(getTransportConfigCallback());
+			}
 			if (getTimeout() != 0 && repo.getTimeout() == 0) {
 				repo.setTimeout(getTimeout());
 			}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jgit.api.TransportConfigCallback;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Andy Chan (iceycake)
@@ -167,6 +169,28 @@ public class MultipleJGitEnvironmentRepositoryTests {
 		assertEquals(getUri("*test1*") + "/test1-svc.properties",
 				environment.getPropertySources().get(0).getName());
 		assertVersion(environment);
+	}
+
+	@Test
+	public void shouldSetTransportConfigCallback() throws Exception {
+		TransportConfigCallback mockCallback1 = mock(TransportConfigCallback.class);
+		TransportConfigCallback mockCallback2 = mock(TransportConfigCallback.class);
+
+		PatternMatchingJGitEnvironmentRepository repo1 = createRepository("test1", "*test1*", "test1Uri");
+
+		PatternMatchingJGitEnvironmentRepository repo2 = createRepository("test2", "*test2*", "test2Uri");
+		repo2.setTransportConfigCallback(mockCallback2);
+
+		Map<String, PatternMatchingJGitEnvironmentRepository> repos = new HashMap<>();
+		repos.put("test1", repo1);
+		repos.put("test2", repo2);
+
+		this.repository.setRepos(repos);
+		this.repository.setTransportConfigCallback(mockCallback1);
+		this.repository.afterPropertiesSet();
+
+		assertEquals(repo1.getTransportConfigCallback(), mockCallback1);
+		assertEquals(repo2.getTransportConfigCallback(), mockCallback2);
 	}
 
 	private String getUri(String pattern) {


### PR DESCRIPTION
Hey guys,

I need to do some custom configuration for JGit's ```Transport``` object. And JGit provides configuration callback ```TransportConfigCallback``` for this case.

This pull request adds ability to set this ```TransportConfigCallback```.

Thank you,
Roman