### PR TITLE
auto configuration to allow for overriding the `ConfigServiePropertySourceLocator` bean

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1309,23 +1309,13 @@ the client.  Typically this involves passing special `Authorization` headers to
 authenticate requests to the server.  To provide a custom `RestTemplate` follow the
 steps below.
 
-1.  Set `spring.cloud.config.enabled=false` to disable the existing config server
-property source.
-
-2.  Create a new configuration bean with an implementation of `PropertySourceLocator`.
+1.  Create a new configuration bean with an implementation of `PropertySourceLocator`.
 
 .CustomConfigServiceBootstrapConfiguration.java
 [source,java]
 ----
 @Configuration
 public class CustomConfigServiceBootstrapConfiguration {
-    @Bean
-    public ConfigClientProperties configClientProperties() {
-        ConfigClientProperties client = new ConfigClientProperties(this.environment);
-        client.setEnabled(false);
-        return client;
-    }
-
     @Bean
     public ConfigServicePropertySourceLocator configServicePropertySourceLocator() {
         ConfigClientProperties clientProperties = configClientProperties();
@@ -1336,10 +1326,10 @@ public class CustomConfigServiceBootstrapConfiguration {
 }
 ----
 
-3.  In `resources/META-INF` create a file called
+2.  In `resources/META-INF` create a file called
 `spring.factories` and specify your custom configuration.
 
-.spring.factorties
+.spring.factories
 [source,properties]
 ----
 org.springframework.cloud.bootstrap.BootstrapConfiguration = com.my.config.client.CustomConfigServiceBootstrapConfiguration

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 
 /**
  * @author Dave Syer
+ * @author Tristan Hanson
  *
  */
 @Configuration
@@ -50,6 +51,7 @@ public class ConfigServiceBootstrapConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(ConfigServicePropertySourceLocator.class)
 	@ConditionalOnProperty(value = "spring.cloud.config.enabled", matchIfMissing = true)
 	public ConfigServicePropertySourceLocator configServicePropertySource(ConfigClientProperties properties) {
 		ConfigServicePropertySourceLocator locator = new ConfigServicePropertySourceLocator(

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfigurationTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfigurationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Tristan Hanson
+ *
+ */
+public class ConfigServiceBootstrapConfigurationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        this.context = new AnnotationConfigApplicationContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void overrideConfigServicePropertySourceLocatorWhenBeanIsProvided() {
+        EnvironmentTestUtils.addEnvironment(this.context, "spring.cloud.config.enabled=true");
+        this.context.register(ConfigServicePropertySourceLocatorOverrideConfig.class);
+        this.context.register(ConfigServiceBootstrapConfiguration.class);
+        this.context.refresh();
+
+        ConfigServicePropertySourceLocator locator = this.context.getBean(ConfigServicePropertySourceLocator.class);
+
+        Field restTemplateField = ReflectionUtils.findField(ConfigServicePropertySourceLocator.class, "restTemplate");
+        restTemplateField.setAccessible(true);
+
+        RestTemplate restTemplate = (RestTemplate) ReflectionUtils.getField(restTemplateField, locator);
+
+        assertThat(restTemplate).isNotNull();
+    }
+
+    @Configuration
+    protected static class ConfigServicePropertySourceLocatorOverrideConfig {
+
+        @Autowired
+        private Environment environment;
+
+        @Bean
+        public ConfigServicePropertySourceLocator locator() {
+            ConfigServicePropertySourceLocator locator = new ConfigServicePropertySourceLocator(new ConfigClientProperties(environment));
+            locator.setRestTemplate(new RestTemplate());
+            return locator;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Allow override of `ConfigServicePropertySourceLocator` bean to support the setting of a custom `RestTemplate` instance without the need to set `spring.cloud.config.enabled=false`