### PR TITLE
Update AwsCodeCommitCredentialProvider.java

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
@@ -326,7 +326,7 @@ public class AwsCodeCommitCredentialProvider extends CredentialsProvider {
 		}
 		
 		try {
-			URI u = new URI(uri.toLowerCase());
+			URI u = new URI(URLEncoder.encode(uri.toLowerCase(),"UTF-8"));
 			if (u.getScheme().equals("https")) {
 				String host = u.getHost();
 				if (host.endsWith(".amazonaws.com") && host.startsWith("git-codecommit.")) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
@@ -327,8 +327,8 @@ public class AwsCodeCommitCredentialProvider extends CredentialsProvider {
 		}
 		
 		try {
-		  URL url = new URL(uri);
-      URI u = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+		  	URL url = new URL(uri);
+      			URI u = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
 			if (u.getScheme().equals("https")) {
 				String host = u.getHost();
 				if (host.endsWith(".amazonaws.com") && host.startsWith("git-codecommit.")) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.config.server.support;
 import static org.springframework.util.StringUtils.hasText;
 
 import java.net.URI;
+import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
@@ -326,7 +327,8 @@ public class AwsCodeCommitCredentialProvider extends CredentialsProvider {
 		}
 		
 		try {
-			URI u = new URI(URLEncoder.encode(uri.toLowerCase(),"UTF-8"));
+		  URL url = new URL(uri);
+      URI u = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
 			if (u.getScheme().equals("https")) {
 				String host = u.getHost();
 				if (host.endsWith(".amazonaws.com") && host.startsWith("git-codecommit.")) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
@@ -44,74 +44,74 @@ import static org.junit.Assert.fail;
  *
  */
 public class AwsCodeCommitCredentialsProviderTests {
-  private static final String PASSWORD = "secret";
-  private static final String USER = "test";
-  private static final String AWS_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test";
-  private static final String BAD_REPO = "https://amazonaws.com/v1/repos/test";
+	private static final String PASSWORD = "secret";
+	private static final String USER = "test";
+	private static final String AWS_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test";
+	private static final String BAD_REPO = "https://amazonaws.com/v1/repos/test";
   private static final String CURLY_BRACES_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/{application}";
 
-  private AwsCodeCommitCredentialProvider provider;
-  
-  @Before
-  public void init() {
-    GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
-    provider = (AwsCodeCommitCredentialProvider) 
-        factory.createFor(AWS_REPO, USER, PASSWORD, null);
-  }
-  
-  @Test
-  public void basics() {
-    assertNotNull(provider);
-    assertEquals(USER, provider.getUsername());
-    assertEquals(PASSWORD, provider.getPassword());
-    assertFalse(provider.isInteractive());
-  }
+	private AwsCodeCommitCredentialProvider provider;
+	
+	@Before
+	public void init() {
+		GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
+		provider = (AwsCodeCommitCredentialProvider) 
+				factory.createFor(AWS_REPO, USER, PASSWORD, null);
+	}
+	
+	@Test
+	public void basics() {
+		assertNotNull(provider);
+		assertEquals(USER, provider.getUsername());
+		assertEquals(PASSWORD, provider.getPassword());
+		assertFalse(provider.isInteractive());
+	}
 
-  @Test
-  public void testSupportsUsernamePassword() {
-    assertTrue(provider.supports(new CredentialItem[] {
-      new CredentialItem.Username(),
-      new CredentialItem.Password()
-    }));
-  }
+	@Test
+	public void testSupportsUsernamePassword() {
+		assertTrue(provider.supports(new CredentialItem[] {
+			new CredentialItem.Username(),
+			new CredentialItem.Password()
+		}));
+	}
 
-  @Test
-  public void testNotSupportsOther() {
-    assertFalse(provider.supports(new CredentialItem[] {
-      new CredentialItem.YesNoType("OK To Login?")  // this is not ok
-    }));
-    assertFalse(provider.supports(new CredentialItem[] {
-      new CredentialItem.StringType("OK To Login?", true) // this is not ok
-    }));
-    assertFalse(provider.supports(new CredentialItem[] {
-        new CredentialItem.Username(),  // this is ok
-        new CredentialItem.Password(),  // this is ok
-        new CredentialItem.StringType("OK To Login?", true) // this is not ok
-    }));
-  }
-  
-  @Test
-  public void testAwsCredentialsProviderIsNullInitially() {
-    AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
-    assertNull(awsProvider);
-  }
+	@Test
+	public void testNotSupportsOther() {
+		assertFalse(provider.supports(new CredentialItem[] {
+			new CredentialItem.YesNoType("OK To Login?")	// this is not ok
+		}));
+		assertFalse(provider.supports(new CredentialItem[] {
+			new CredentialItem.StringType("OK To Login?", true)	// this is not ok
+		}));
+		assertFalse(provider.supports(new CredentialItem[] {
+				new CredentialItem.Username(),	// this is ok
+				new CredentialItem.Password(),	// this is ok
+				new CredentialItem.StringType("OK To Login?", true) // this is not ok
+		}));
+	}
+	
+	@Test
+	public void testAwsCredentialsProviderIsNullInitially() {
+		AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
+		assertNull(awsProvider);
+	}
 
-  @Test
-  public void testAwsCredentialsProviderIsDefinedAfterGet() throws URISyntaxException {
-    AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
-    assertNull(awsProvider);
-    assertTrue(provider.get(new URIish(AWS_REPO), makeCredentialItems()));
-    awsProvider = provider.getAwsCredentialProvider();
-    assertNotNull(awsProvider);
-    assertTrue(awsProvider instanceof AwsCodeCommitCredentialProvider.AWSStaticCredentialsProvider);
-  }
-  
-  @Test
-  public void testBadUriReturnsFalse() throws UnsupportedCredentialItem, URISyntaxException {
-    CredentialItem[] credentialItems = makeCredentialItems();
-    assertFalse(provider.get(new URIish(BAD_REPO), credentialItems));
-  }
-  
+	@Test
+	public void testAwsCredentialsProviderIsDefinedAfterGet() throws URISyntaxException {
+		AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
+		assertNull(awsProvider);
+		assertTrue(provider.get(new URIish(AWS_REPO), makeCredentialItems()));
+		awsProvider = provider.getAwsCredentialProvider();
+		assertNotNull(awsProvider);
+		assertTrue(awsProvider instanceof AwsCodeCommitCredentialProvider.AWSStaticCredentialsProvider);
+	}
+	
+	@Test
+	public void testBadUriReturnsFalse() throws UnsupportedCredentialItem, URISyntaxException {
+		CredentialItem[] credentialItems = makeCredentialItems();
+		assertFalse(provider.get(new URIish(BAD_REPO), credentialItems));
+	}
+	
   @Test
   public void testUriWithCurlyBracesReturnsTrue() throws UnsupportedCredentialItem, URISyntaxException {
     GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
@@ -121,44 +121,44 @@ public class AwsCodeCommitCredentialsProviderTests {
     assertTrue(provider.get(new URIish(CURLY_BRACES_REPO), credentialItems));
   }
   
-  @Test
-  public void testThrowsUnsupportedCredentialException() throws URISyntaxException {
-    CredentialItem[] goodCredentialItems = makeCredentialItems();
-    CredentialItem[] badCredentialItems = new CredentialItem[] {
-        goodCredentialItems[0],
-        goodCredentialItems[1],
-        new CredentialItem.YesNoType("OK?")
-    };
-    try {
-      provider.get(new URIish(AWS_REPO), badCredentialItems);
-      fail("Expected UnsupportedCredentialItem exception");
-    } catch (UnsupportedCredentialItem e) {
-      assertNotNull(e.getMessage());
-    }
-  }
-  
-  @Test
-  public void testReturnsCredentials() throws URISyntaxException {
-    CredentialItem[] credentialItems = makeCredentialItems();
-    assertTrue(provider.get(new URIish(AWS_REPO), credentialItems));
-    
-    String theUsername = ((CredentialItem.Username) credentialItems[0]).getValue();
-    char[] thePassword = ((CredentialItem.Password) credentialItems[1]).getValue();
-    
-    assertEquals(USER, theUsername);
-    assertNotNull(thePassword);
-    
-    // The password will always begin with a timestamp like
-    // 20161113T121314Z
-    assertTrue(thePassword.length > 16);
-    assertEquals('T', thePassword[8]);
-    assertEquals('Z', thePassword[15]);
-  }
+	@Test
+	public void testThrowsUnsupportedCredentialException() throws URISyntaxException {
+		CredentialItem[] goodCredentialItems = makeCredentialItems();
+		CredentialItem[] badCredentialItems = new CredentialItem[] {
+				goodCredentialItems[0],
+				goodCredentialItems[1],
+				new CredentialItem.YesNoType("OK?")
+		};
+		try {
+			provider.get(new URIish(AWS_REPO), badCredentialItems);
+			fail("Expected UnsupportedCredentialItem exception");
+		} catch (UnsupportedCredentialItem e) {
+			assertNotNull(e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testReturnsCredentials() throws URISyntaxException {
+		CredentialItem[] credentialItems = makeCredentialItems();
+		assertTrue(provider.get(new URIish(AWS_REPO), credentialItems));
+		
+		String theUsername = ((CredentialItem.Username) credentialItems[0]).getValue();
+		char[] thePassword = ((CredentialItem.Password) credentialItems[1]).getValue();
+		
+		assertEquals(USER, theUsername);
+		assertNotNull(thePassword);
+		
+		// The password will always begin with a timestamp like
+		// 20161113T121314Z
+		assertTrue(thePassword.length > 16);
+		assertEquals('T', thePassword[8]);
+		assertEquals('Z', thePassword[15]);
+	}
 
-  private CredentialItem[] makeCredentialItems() {
-    CredentialItem[] credentialItems = new CredentialItem[2];
-    credentialItems[0] = new CredentialItem.Username();
-    credentialItems[1] = new CredentialItem.Password();
-    return credentialItems;
-  }
+	private CredentialItem[] makeCredentialItems() {
+		CredentialItem[] credentialItems = new CredentialItem[2];
+		credentialItems[0] = new CredentialItem.Username();
+		credentialItems[1] = new CredentialItem.Password();
+		return credentialItems;
+	}
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
@@ -48,7 +48,7 @@ public class AwsCodeCommitCredentialsProviderTests {
 	private static final String USER = "test";
 	private static final String AWS_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test";
 	private static final String BAD_REPO = "https://amazonaws.com/v1/repos/test";
-  private static final String CURLY_BRACES_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/{application}";
+  	private static final String CURLY_BRACES_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/{application}";
 
 	private AwsCodeCommitCredentialProvider provider;
 	
@@ -112,14 +112,14 @@ public class AwsCodeCommitCredentialsProviderTests {
 		assertFalse(provider.get(new URIish(BAD_REPO), credentialItems));
 	}
 	
-  @Test
-  public void testUriWithCurlyBracesReturnsTrue() throws UnsupportedCredentialItem, URISyntaxException {
-    GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
-    provider = (AwsCodeCommitCredentialProvider) 
-        factory.createFor(CURLY_BRACES_REPO, USER, PASSWORD, null);
-    CredentialItem[] credentialItems = makeCredentialItems();
-    assertTrue(provider.get(new URIish(CURLY_BRACES_REPO), credentialItems));
-  }
+	@Test
+	public void testUriWithCurlyBracesReturnsTrue() throws UnsupportedCredentialItem, URISyntaxException {
+		GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
+		provider = (AwsCodeCommitCredentialProvider) 
+		factory.createFor(CURLY_BRACES_REPO, USER, PASSWORD, null);
+		CredentialItem[] credentialItems = makeCredentialItems();
+		assertTrue(provider.get(new URIish(CURLY_BRACES_REPO), credentialItems));
+	}
   
 	@Test
 	public void testThrowsUnsupportedCredentialException() throws URISyntaxException {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
@@ -44,111 +44,121 @@ import static org.junit.Assert.fail;
  *
  */
 public class AwsCodeCommitCredentialsProviderTests {
-	private static final String PASSWORD = "secret";
-	private static final String USER = "test";
-	private static final String AWS_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test";
-	private static final String BAD_REPO = "https://amazonaws.com/v1/repos/test";
+  private static final String PASSWORD = "secret";
+  private static final String USER = "test";
+  private static final String AWS_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test";
+  private static final String BAD_REPO = "https://amazonaws.com/v1/repos/test";
+  private static final String CURLY_BRACES_REPO = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/{application}";
 
-	private AwsCodeCommitCredentialProvider provider;
-	
-	@Before
-	public void init() {
-		GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
-		provider = (AwsCodeCommitCredentialProvider) 
-				factory.createFor(AWS_REPO, USER, PASSWORD, null);
-	}
-	
-	@Test
-	public void basics() {
-		assertNotNull(provider);
-		assertEquals(USER, provider.getUsername());
-		assertEquals(PASSWORD, provider.getPassword());
-		assertFalse(provider.isInteractive());
-	}
+  private AwsCodeCommitCredentialProvider provider;
+  
+  @Before
+  public void init() {
+    GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
+    provider = (AwsCodeCommitCredentialProvider) 
+        factory.createFor(AWS_REPO, USER, PASSWORD, null);
+  }
+  
+  @Test
+  public void basics() {
+    assertNotNull(provider);
+    assertEquals(USER, provider.getUsername());
+    assertEquals(PASSWORD, provider.getPassword());
+    assertFalse(provider.isInteractive());
+  }
 
-	@Test
-	public void testSupportsUsernamePassword() {
-		assertTrue(provider.supports(new CredentialItem[] {
-			new CredentialItem.Username(),
-			new CredentialItem.Password()
-		}));
-	}
+  @Test
+  public void testSupportsUsernamePassword() {
+    assertTrue(provider.supports(new CredentialItem[] {
+      new CredentialItem.Username(),
+      new CredentialItem.Password()
+    }));
+  }
 
-	@Test
-	public void testNotSupportsOther() {
-		assertFalse(provider.supports(new CredentialItem[] {
-			new CredentialItem.YesNoType("OK To Login?")	// this is not ok
-		}));
-		assertFalse(provider.supports(new CredentialItem[] {
-			new CredentialItem.StringType("OK To Login?", true)	// this is not ok
-		}));
-		assertFalse(provider.supports(new CredentialItem[] {
-				new CredentialItem.Username(),	// this is ok
-				new CredentialItem.Password(),	// this is ok
-				new CredentialItem.StringType("OK To Login?", true) // this is not ok
-		}));
-	}
-	
-	@Test
-	public void testAwsCredentialsProviderIsNullInitially() {
-		AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
-		assertNull(awsProvider);
-	}
+  @Test
+  public void testNotSupportsOther() {
+    assertFalse(provider.supports(new CredentialItem[] {
+      new CredentialItem.YesNoType("OK To Login?")  // this is not ok
+    }));
+    assertFalse(provider.supports(new CredentialItem[] {
+      new CredentialItem.StringType("OK To Login?", true) // this is not ok
+    }));
+    assertFalse(provider.supports(new CredentialItem[] {
+        new CredentialItem.Username(),  // this is ok
+        new CredentialItem.Password(),  // this is ok
+        new CredentialItem.StringType("OK To Login?", true) // this is not ok
+    }));
+  }
+  
+  @Test
+  public void testAwsCredentialsProviderIsNullInitially() {
+    AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
+    assertNull(awsProvider);
+  }
 
-	@Test
-	public void testAwsCredentialsProviderIsDefinedAfterGet() throws URISyntaxException {
-		AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
-		assertNull(awsProvider);
-		assertTrue(provider.get(new URIish(AWS_REPO), makeCredentialItems()));
-		awsProvider = provider.getAwsCredentialProvider();
-		assertNotNull(awsProvider);
-		assertTrue(awsProvider instanceof AwsCodeCommitCredentialProvider.AWSStaticCredentialsProvider);
-	}
-	
-	@Test
-	public void testBadUriReturnsFalse() throws UnsupportedCredentialItem, URISyntaxException {
-		CredentialItem[] credentialItems = makeCredentialItems();
-		assertFalse(provider.get(new URIish(BAD_REPO), credentialItems));
-	}
-	
-	@Test
-	public void testThrowsUnsupportedCredentialException() throws URISyntaxException {
-		CredentialItem[] goodCredentialItems = makeCredentialItems();
-		CredentialItem[] badCredentialItems = new CredentialItem[] {
-				goodCredentialItems[0],
-				goodCredentialItems[1],
-				new CredentialItem.YesNoType("OK?")
-		};
-		try {
-			provider.get(new URIish(AWS_REPO), badCredentialItems);
-			fail("Expected UnsupportedCredentialItem exception");
-		} catch (UnsupportedCredentialItem e) {
-			assertNotNull(e.getMessage());
-		}
-	}
-	
-	@Test
-	public void testReturnsCredentials() throws URISyntaxException {
-		CredentialItem[] credentialItems = makeCredentialItems();
-		assertTrue(provider.get(new URIish(AWS_REPO), credentialItems));
-		
-		String theUsername = ((CredentialItem.Username) credentialItems[0]).getValue();
-		char[] thePassword = ((CredentialItem.Password) credentialItems[1]).getValue();
-		
-		assertEquals(USER, theUsername);
-		assertNotNull(thePassword);
-		
-		// The password will always begin with a timestamp like
-		// 20161113T121314Z
-		assertTrue(thePassword.length > 16);
-		assertEquals('T', thePassword[8]);
-		assertEquals('Z', thePassword[15]);
-	}
+  @Test
+  public void testAwsCredentialsProviderIsDefinedAfterGet() throws URISyntaxException {
+    AWSCredentialsProvider awsProvider = provider.getAwsCredentialProvider();
+    assertNull(awsProvider);
+    assertTrue(provider.get(new URIish(AWS_REPO), makeCredentialItems()));
+    awsProvider = provider.getAwsCredentialProvider();
+    assertNotNull(awsProvider);
+    assertTrue(awsProvider instanceof AwsCodeCommitCredentialProvider.AWSStaticCredentialsProvider);
+  }
+  
+  @Test
+  public void testBadUriReturnsFalse() throws UnsupportedCredentialItem, URISyntaxException {
+    CredentialItem[] credentialItems = makeCredentialItems();
+    assertFalse(provider.get(new URIish(BAD_REPO), credentialItems));
+  }
+  
+  @Test
+  public void testUriWithCurlyBracesReturnsTrue() throws UnsupportedCredentialItem, URISyntaxException {
+    GitCredentialsProviderFactory factory = new GitCredentialsProviderFactory();
+    provider = (AwsCodeCommitCredentialProvider) 
+        factory.createFor(CURLY_BRACES_REPO, USER, PASSWORD, null);
+    CredentialItem[] credentialItems = makeCredentialItems();
+    assertTrue(provider.get(new URIish(CURLY_BRACES_REPO), credentialItems));
+  }
+  
+  @Test
+  public void testThrowsUnsupportedCredentialException() throws URISyntaxException {
+    CredentialItem[] goodCredentialItems = makeCredentialItems();
+    CredentialItem[] badCredentialItems = new CredentialItem[] {
+        goodCredentialItems[0],
+        goodCredentialItems[1],
+        new CredentialItem.YesNoType("OK?")
+    };
+    try {
+      provider.get(new URIish(AWS_REPO), badCredentialItems);
+      fail("Expected UnsupportedCredentialItem exception");
+    } catch (UnsupportedCredentialItem e) {
+      assertNotNull(e.getMessage());
+    }
+  }
+  
+  @Test
+  public void testReturnsCredentials() throws URISyntaxException {
+    CredentialItem[] credentialItems = makeCredentialItems();
+    assertTrue(provider.get(new URIish(AWS_REPO), credentialItems));
+    
+    String theUsername = ((CredentialItem.Username) credentialItems[0]).getValue();
+    char[] thePassword = ((CredentialItem.Password) credentialItems[1]).getValue();
+    
+    assertEquals(USER, theUsername);
+    assertNotNull(thePassword);
+    
+    // The password will always begin with a timestamp like
+    // 20161113T121314Z
+    assertTrue(thePassword.length > 16);
+    assertEquals('T', thePassword[8]);
+    assertEquals('Z', thePassword[15]);
+  }
 
-	private CredentialItem[] makeCredentialItems() {
-		CredentialItem[] credentialItems = new CredentialItem[2];
-		credentialItems[0] = new CredentialItem.Username();
-		credentialItems[1] = new CredentialItem.Password();
-		return credentialItems;
-	}
+  private CredentialItem[] makeCredentialItems() {
+    CredentialItem[] credentialItems = new CredentialItem[2];
+    credentialItems[0] = new CredentialItem.Username();
+    credentialItems[1] = new CredentialItem.Password();
+    return credentialItems;
+  }
 }


### PR DESCRIPTION
Uri must be encoded inside canhandle when instantiating URI object as uri can contains curly braces e.g.
https://git-codecommit.$AWS_REGION.amazonaws.com/v1/repos/$repo-name/{application}