### PR TITLE
Feature Request: Entire folder as tar.gz and binary endpoints without…

### DIFF
--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.13</version>
+        </dependency>
 	</dependencies>
 
 	<properties>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerApplication.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ConfigServerApplication.java
@@ -2,7 +2,11 @@ package org.springframework.cloud.config.server;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.config.server.config.ConfigServerMvcConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @Configuration
 @EnableAutoConfiguration
@@ -12,6 +16,17 @@ public class ConfigServerApplication {
 	public static void main(String[] args) {
 		new SpringApplicationBuilder(ConfigServerApplication.class)
 				.properties("spring.config.name=configserver").run(args);
+	}
+    
+	@Bean
+	public WebMvcConfigurerAdapter ConfigServerMvcConfiguration() {
+		return new ConfigServerMvcConfiguration() {
+			@Override
+			public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+				configurer.favorPathExtension(false);
+                super.configureContentNegotiation(configurer);
+			}
+		};
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/GenericResourceRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/GenericResourceRepository.java
@@ -51,6 +51,11 @@ public class GenericResourceRepository
 	@Override
 	public synchronized Resource findOne(String application, String profile, String label,
 			String path) {
+		return findOne(application, profile, label, path, true);
+	}
+	@Override
+	public synchronized Resource findOne(String application, String profile, String label,
+			String path, boolean fileOnly) {
 		String[] locations = this.service.getLocations(application, profile, label).getLocations();
 		try {
 			for (int i = locations.length; i-- > 0;) {
@@ -59,6 +64,9 @@ public class GenericResourceRepository
 					Resource file = this.resourceLoader.getResource(location)
 							.createRelative(local);
 					if (file.exists() && file.isReadable()) {
+						return file;
+					}
+					if( !fileOnly  && file.exists() && file.getFile().isDirectory()) {
 						return file;
 					}
 				}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceRepository.java
@@ -25,5 +25,7 @@ import org.springframework.core.io.Resource;
 public interface ResourceRepository {
 
 	Resource findOne(String name, String profile, String label, String path);
+    
+	Resource findOne(String name, String profile, String label, String path, boolean fileOnly);
 
 }


### PR DESCRIPTION
Hi all,

We added these additional features and thought we would give back to the community if you guys are interested.

1. We use LOTS of docker images, most are based on alpine linux and only come with busybox version of wget.  This version does not allow us to pass content-type headers.  We write scripts that go directly to configserver to pull down files during application startup, so we added direct endpoints for binary files.  We also had issues pulling down camel XML files (that we did not want placeholders resolved by configserver) because there is no way to pass the content-type header from a spring configuration @ImportResource("URL")


2. Some of our apps we need download an entire configuration folder with nested folders, and expand that in our docker container before the app starts, so we added an endpoint for downloading an entire folder off the config server and returning it as a tar.gz file.  (binary or resolve placeholders).  This save us alot of time because each file request updates the svn/git repo, now we can grab 100 files in a single request.  (It was really slow with svn)

example URLs:

binary: 
http://localhost:8888/binary/app/default/master/subdir/test.txt

tar.gz (binary)
http://localhost:8888/binarytargz/app/default/master/subdir

tar.gz (resolved placeholders)
http://localhost:8888/targz/app/default/master/subdir


These are kinda special use cases so let me know what you think?  (if you guys like it i'll write some UTs)