### PR TITLE
Fix symmetric encryption

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/SymmetricKeyEncryptorLocatorConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/SymmetricKeyEncryptorLocatorConfiguration.java
@@ -1,8 +1,10 @@
-package org.springframework.cloud.config.server.encryption;
+package org.springframework.cloud.config.server.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.config.server.encryption.SingleTextEncryptorLocator;
+import org.springframework.cloud.config.server.encryption.TextEncryptorLocator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
@@ -15,9 +17,9 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 */
 @Configuration
 @ConditionalOnProperty(value = "encrypt.key", matchIfMissing = false)
-public class SymmetricKeyEncryptor {
+public class SymmetricKeyEncryptorLocatorConfiguration {
 
-	@Autowired
+	@Autowired(required = false)
 	private TextEncryptor encryptor;
 
 	@Bean

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SymmetricKeyEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/SymmetricKeyEncryptor.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.config.server.encryption;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+/**
+ * Provide a default {@link TextEncryptorLocator} when a symmetric key is configured
+ *
+ * @author Ollie Hughes
+ *
+*/
+@Configuration
+@ConditionalOnProperty(value = "encrypt.key", matchIfMissing = false)
+public class SymmetricKeyEncryptor {
+
+	@Autowired
+	private TextEncryptor encryptor;
+
+	@Bean
+	@ConditionalOnMissingBean
+	public TextEncryptorLocator defaultTextEncryptorLocator() {
+		return new SingleTextEncryptorLocator(this.encryptor);
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/SymmetricEncryptionIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/SymmetricEncryptionIntegrationTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.config.server.ConfigServerApplication;
+import org.springframework.cloud.config.server.config.SymmetricKeyEncryptorLocatorConfiguration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -16,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 public class SymmetricEncryptionIntegrationTests {
 
 	@RunWith(SpringRunner.class)
-	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
+	@SpringBootTest(classes = {ConfigServerApplication.class, SymmetricKeyEncryptorLocatorConfiguration.class},
 			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 	@ActiveProfiles({"test", "native"})
 	public static class SpringAppJsonConfigSymmetricEncryptionIntegrationTests {
@@ -37,7 +38,7 @@ public class SymmetricEncryptionIntegrationTests {
 	}
 
 	@RunWith(SpringRunner.class)
-	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
+	@SpringBootTest(classes = {ConfigServerApplication.class, SymmetricKeyEncryptorLocatorConfiguration.class},
 		properties = "spring.cloud.bootstrap.name:symmetric-key-bootstrap",
 			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 	@ActiveProfiles({"test", "native"})
@@ -53,20 +54,4 @@ public class SymmetricEncryptionIntegrationTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
-	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
-		properties = "spring.config.name:symmetric-key-bootstrap",
-			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-	@ActiveProfiles({"test", "native"})
-	public static class ApplicationConfigSymmetricEncryptionIntegrationTests {
-
-		@Autowired
-		private TestRestTemplate testRestTemplate;
-
-		@Test
-		public void symmetricEncryptionCannotBeConfiguredInApplicationContext() throws Exception {
-			ResponseEntity<String> entity = testRestTemplate.getForEntity("/encrypt/status", String.class);
-			assertEquals(entity.getStatusCode().value(), 404);
-		}
-	}
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/SymmetricEncryptionIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/SymmetricEncryptionIntegrationTests.java
@@ -1,0 +1,72 @@
+package org.springframework.cloud.config.server.encryption;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.config.server.ConfigServerApplication;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+public class SymmetricEncryptionIntegrationTests {
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
+			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	@ActiveProfiles({"test", "native"})
+	public static class SpringAppJsonConfigSymmetricEncryptionIntegrationTests {
+
+		@BeforeClass
+		public static void setupEnvironmentProperties() {
+			System.setProperty("SPRING_APPLICATION_JSON", "{\"encrypt\": {\"key\": \"foobar\"}}");
+		}
+
+		@Autowired
+		private TestRestTemplate testRestTemplate;
+
+		@Test
+		public void symmetricEncryptionSpringAppJson() throws Exception {
+			ResponseEntity<String> entity = testRestTemplate.getForEntity("/encrypt/status", String.class);
+			assertEquals(entity.getStatusCode().value(), 200);
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
+		properties = "spring.cloud.bootstrap.name:symmetric-key-bootstrap",
+			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	@ActiveProfiles({"test", "native"})
+	public static class BoostrapConfigSymmetricEncryptionIntegrationTests {
+
+		@Autowired
+		private TestRestTemplate testRestTemplate;
+
+		@Test
+		public void symmetricEncryptionBootstrapConfig() throws Exception {
+			ResponseEntity<String> entity = testRestTemplate.getForEntity("/encrypt/status", String.class);
+			assertEquals(entity.getStatusCode().value(), 200);
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = {ConfigServerApplication.class,SymmetricKeyEncryptor.class},
+		properties = "spring.config.name:symmetric-key-bootstrap",
+			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	@ActiveProfiles({"test", "native"})
+	public static class ApplicationConfigSymmetricEncryptionIntegrationTests {
+
+		@Autowired
+		private TestRestTemplate testRestTemplate;
+
+		@Test
+		public void symmetricEncryptionCannotBeConfiguredInApplicationContext() throws Exception {
+			ResponseEntity<String> entity = testRestTemplate.getForEntity("/encrypt/status", String.class);
+			assertEquals(entity.getStatusCode().value(), 404);
+		}
+	}
+}

--- a/spring-cloud-config-server/src/test/resources/symmetric-key-bootstrap.yml
+++ b/spring-cloud-config-server/src/test/resources/symmetric-key-bootstrap.yml
@@ -1,0 +1,2 @@
+encrypt:
+  key: foobar


### PR DESCRIPTION
Setting property `encrypt.key` to enable symmetric encryption does not work since Dalston SR2.  This can be verified using the endpoint `/encrypt/status` Fixed by creating a default `TextEncryptorLocator` when the '`encrypt.key` is set