### PR TITLE
Support both `encrypt.keyStore` and `encrypt.key-store` configuration properties

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.config.server.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -80,7 +79,7 @@ public class EncryptionAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnClass(RsaSecretEncryptor.class)
-	@ConditionalOnProperty(value = "encrypt.key-store.location", matchIfMissing = false)
+	@ConditionalOnProperty(prefix = "encrypt.keyStore", value = "location", matchIfMissing = false)
 	protected static class KeyStoreConfiguration {
 
 		@Autowired

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionIntegrationTests.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SymmetricEncryptionIntegrationTests {
+public class EncryptionIntegrationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = {
@@ -63,6 +63,25 @@ public class SymmetricEncryptionIntegrationTests {
 
 		@Test
 		public void symmetricEncryptionBootstrapConfig() throws Exception {
+			ResponseEntity<String> entity = testRestTemplate
+					.getForEntity("/encrypt/status", String.class);
+			assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = { ConfigServerApplication.class},
+			properties = "spring.cloud.bootstrap.name:keystore-bootstrap",
+			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	@ActiveProfiles({ "test", "native" })
+	@DirtiesContext
+	public static class KeystoreConfigurationIntegrationTests {
+
+		@Autowired
+		private TestRestTemplate testRestTemplate;
+
+		@Test
+		public void keystoreBootstrapConfig() throws Exception {
 			ResponseEntity<String> entity = testRestTemplate
 					.getForEntity("/encrypt/status", String.class);
 			assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/spring-cloud-config-server/src/test/resources/keystore-bootstrap.yml
+++ b/spring-cloud-config-server/src/test/resources/keystore-bootstrap.yml
@@ -1,0 +1,13 @@
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          uri: file:./target/repos/encrypt-repo
+        bootstrap: true
+encrypt:
+  key-store:
+    location: classpath:server.jks
+    password: letmein
+    alias: myKey
+  


### PR DESCRIPTION
Use prefix parameter when when matching `encrypt.keyStore` property so that relaxed naming will also `encrypt.key-store`