### PR TITLE
Fix encryption of string containing curly braces

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelper.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelper.java
@@ -117,7 +117,7 @@ class EnvironmentPrefixHelper {
 		if (value.contains(ESCAPE)) {
 			return value.substring(value.indexOf(ESCAPE) + ESCAPE.length());
 		}
-		return value.substring(value.lastIndexOf("}") + 1);
+		return value.replaceFirst("^(\\{.*?:.*?\\})+", "");
 	}
 
 	private String removeEnvironmentPrefix(String input) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
@@ -136,6 +136,20 @@ public class EncryptionControllerTests {
 	}
 
 	@Test
+	public void encryptDecyptTextWithCurlyBrace() {
+		this.controller = new EncryptionController(
+				new SingleTextEncryptorLocator(new RsaSecretEncryptor()));
+
+		String plain = "textwith}brace";
+
+		String cipher = this.controller.encrypt(plain,
+				MediaType.APPLICATION_FORM_URLENCODED);
+		String decrypt = this.controller.decrypt(cipher,
+				MediaType.APPLICATION_FORM_URLENCODED);
+		assertEquals(plain, decrypt);
+	}
+
+	@Test
 	public void addEnvironment() {
 		TextEncryptorLocator locator = new TextEncryptorLocator() {
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelperTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelperTests.java
@@ -81,4 +81,14 @@ public class EnvironmentPrefixHelperTests {
 		assertEquals("mykey", keys.get("key"));
 	}
 
+	@Test
+	public void testTextWithCurlyBracesNoPrefix() {
+		assertEquals("textwith}brac{es", this.helper.stripPrefix("textwith}brac{es"));
+	}
+
+	@Test
+	public void testTextWithCurlyBracesPrefix() {
+		assertEquals("textwith}brac{es{and}prefix", this.helper
+				.stripPrefix("{key:foo}{name:bar}textwith}brac{es{and}prefix"));
+	}
 }


### PR DESCRIPTION
Steps to reproduce:

- ecrypt a string with a single closing curly brace, e.g. "ab}cd"
- decrypt it
- the expected result would be the same string, however the result is "cd"

The root cause is the  `stripPrefix` method of `EnvironmentPrefixHelper` class called before the encryption which is currently removing all characters until the first closing curly brace including it. 

It seems the intent was to remove all `{foo:bar}` like expressions from the beginnig of the string, fix is looking for that pattern. Note, the implementation won't allow to enrypt texts starting with {foo:bar} sequence, where foo is not a prefix keyword. To make the implementation perfect all the known keyword:value pairs should be removed one by one.