### PR TITLE
Include TransportConfiguration for server bootstrap case

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/bootstrap/ConfigServerBootstrapConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/bootstrap/ConfigServerBootstrapConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.cloud.config.server.config.EnvironmentRepositoryConfiguration;
+import org.springframework.cloud.config.server.config.TransportConfiguration;
 import org.springframework.cloud.config.server.environment.EnvironmentRepository;
 import org.springframework.cloud.config.server.environment.EnvironmentRepositoryPropertySourceLocator;
 import org.springframework.context.annotation.Bean;
@@ -44,7 +45,7 @@ import org.springframework.util.StringUtils;
 public class ConfigServerBootstrapConfiguration {
 
 	@EnableConfigurationProperties(ConfigServerProperties.class)
-	@Import(EnvironmentRepositoryConfiguration.class)
+	@Import({ EnvironmentRepositoryConfiguration.class, TransportConfiguration.class })
 	protected static class LocalPropertySourceLocatorConfiguration {
 
 		@Autowired


### PR DESCRIPTION
Previously, taking SSH configuration from properties (as opposed to the default SSH configuration files) was only possible when not bootstrapping the Config Server itself. This includes the `TransportationConfiguration` for the bootstrap case as well.

Related to #741

Sorry I didn't add a test case for this. I could not figure out a good/easy way to test this since bootstrapping will actually try to retrieve the config server's configuration from the git repository. The other `TransportConfigurationIntegrationTests` use a dummy URI that is never called; but in the bootstrap case it will be called and fail. If someone wants to point me at a similar test that handles this, I can take a stab at adding a test for this. Otherwise, feel free to merge as is or add a test.