### PR TITLE
Feature/organization project level enablement

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -87,12 +87,12 @@ public class ResourceController {
 
 	synchronized String retrieve(String name, String profile, String label, String path,
 			boolean resolvePlaceholders) throws IOException {
-	  if (name != null && name.contains("(_)")) {
-      // "(_)" is uncommon in a git repo name, but "/" cannot be matched
-      // by Spring MVC
-      name = name.replace("(_)", "/");
-    }
-    if (label != null && label.contains("(_)")) {
+		if (name != null && name.contains("(_)")) {
+			// "(_)" is uncommon in a git repo name, but "/" cannot be matched
+			// by Spring MVC
+			name = name.replace("(_)", "/");
+		}
+		if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");
@@ -122,11 +122,11 @@ public class ResourceController {
 	synchronized byte[] binary(String name, String profile, String label, String path)
 			throws IOException {
 		if (name != null && name.contains("(_)")) {
-      // "(_)" is uncommon in a git repo name, but "/" cannot be matched
-      // by Spring MVC
-      name = name.replace("(_)", "/");
-    }
-    if (label != null && label.contains("(_)")) {
+			// "(_)" is uncommon in a git repo name, but "/" cannot be matched
+			// by Spring MVC
+			name = name.replace("(_)", "/");
+		}
+		if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -87,7 +87,12 @@ public class ResourceController {
 
 	synchronized String retrieve(String name, String profile, String label, String path,
 			boolean resolvePlaceholders) throws IOException {
-		if (label != null && label.contains("(_)")) {
+	  if (name != null && name.contains("(_)")) {
+      // "(_)" is uncommon in a git repo name, but "/" cannot be matched
+      // by Spring MVC
+      name = name.replace("(_)", "/");
+    }
+    if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");
@@ -116,7 +121,12 @@ public class ResourceController {
 
 	synchronized byte[] binary(String name, String profile, String label, String path)
 			throws IOException {
-		if (label != null && label.contains("(_)")) {
+		if (name != null && name.contains("(_)")) {
+      // "(_)" is uncommon in a git repo name, but "/" cannot be matched
+      // by Spring MVC
+      name = name.replace("(_)", "/");
+    }
+    if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC
 			label = label.replace("(_)", "/");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -87,6 +87,14 @@ public class ResourceControllerTests {
 		assertEquals("foo: ${foo}", resource);
 	}
 
+  @Test
+  public void applicationPlaceholderWithSlash() throws Exception {
+    this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+    String resource = this.controller.retrieve("dev(_)spam", "bar", "", "foo.txt",
+        true);
+    assertEquals("foo: dev_bar/spam", resource);
+  }
+
 	@Test
 	public void labelWithSlash() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test");
@@ -143,6 +151,13 @@ public class ResourceControllerTests {
 		assertEquals("foo: dev_bar/spam", resource);
 	}
 	
+  @Test
+  public void applicationPlaceholderWithSlashForBinary() throws Exception {
+    this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+    byte[] resource = this.controller.binary("dev(_)spam", "bar", "", "foo.txt");
+    assertEquals("foo: dev_bar/spam", new String(resource));
+  }
+
 	@Test
 	public void labelWithSlashForBinary() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.config.server.resource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
@@ -121,6 +122,17 @@ public class ResourceControllerTests {
 		String resource = this.controller.retrieve("bar", "dev", null, "spam/foo.txt", true);
 		assertEquals("foo: dev_bar/spam", resource);
 	}
+	
+	@Test
+	public void nullNameAndLabel() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test");
+		try {
+			this.controller.retrieve(null, "foo", "bar", "spam/foo.txt", true);
+		}
+		catch (Exception e) {
+			assertNotNull(e);
+		}
+	}
 
 	@Test
 	public void labelWithSlash() throws Exception {
@@ -211,6 +223,17 @@ public class ResourceControllerTests {
 		this.environmentRepository.setSearchLocations("classpath:/test/{profile}");
 		byte[] resource = this.controller.binary("bar", "dev", null, "spam/foo.txt");
 		assertEquals("foo: dev_bar/spam", new String(resource));
+	}
+	
+	@Test
+	public void forBinaryNullName() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test");
+		try {
+			this.controller.binary(null, "foo", "bar", "spam/foo.txt");
+		}
+		catch (Exception e) {
+			assertNotNull(e);
+		}
 	}
 	
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -89,7 +89,7 @@ public class ResourceControllerTests {
 
 	@Test
 	public void applicationPlaceholderWithoutSlash() throws Exception {
-		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}/{label}");
 		String resource = this.controller.retrieve("dev", "bar", "spam", "foo.txt", true);
 		assertEquals("foo: dev_bar/spam", resource);
 	}	
@@ -159,7 +159,7 @@ public class ResourceControllerTests {
 	
 	@Test
 	public void applicationPlaceholderWithoutSlashForBinary() throws Exception {
-		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}/{label}");
 		byte[] resource = this.controller.binary("dev", "bar", "spam", "foo.txt");
 		assertEquals("foo: dev_bar/spam", new String(resource));
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -87,13 +87,12 @@ public class ResourceControllerTests {
 		assertEquals("foo: ${foo}", resource);
 	}
 
-  @Test
-  public void applicationPlaceholderWithSlash() throws Exception {
-    this.environmentRepository.setSearchLocations("classpath:/test/{application}");
-    String resource = this.controller.retrieve("dev(_)spam", "bar", "", "foo.txt",
-        true);
-    assertEquals("foo: dev_bar/spam", resource);
-  }
+	@Test
+	public void applicationPlaceholderWithSlash() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		String resource = this.controller.retrieve("dev(_)spam", "bar", "", "foo.txt", true);
+		assertEquals("foo: dev_bar/spam", resource);
+	}
 
 	@Test
 	public void labelWithSlash() throws Exception {
@@ -151,12 +150,12 @@ public class ResourceControllerTests {
 		assertEquals("foo: dev_bar/spam", resource);
 	}
 	
-  @Test
-  public void applicationPlaceholderWithSlashForBinary() throws Exception {
-    this.environmentRepository.setSearchLocations("classpath:/test/{application}");
-    byte[] resource = this.controller.binary("dev(_)spam", "bar", "", "foo.txt");
-    assertEquals("foo: dev_bar/spam", new String(resource));
-  }
+	@Test
+	public void applicationPlaceholderWithSlashForBinary() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		byte[] resource = this.controller.binary("dev(_)spam", "bar", "", "foo.txt");
+		assertEquals("foo: dev_bar/spam", new String(resource));
+	}
 
 	@Test
 	public void labelWithSlashForBinary() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -102,9 +102,23 @@ public class ResourceControllerTests {
 	}
 	
 	@Test
+	public void applicationPlaceholderWithSlashNullLabel() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		String resource = this.controller.retrieve("dev(_)spam", "bar", null, "foo.txt", true);
+		assertEquals("foo: dev_bar/spam", resource);
+	}
+	
+	@Test
 	public void labelPlaceholderWithSlash() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{label}");
 		String resource = this.controller.retrieve("dev", "bar", "dev(_)spam", "foo.txt", true);
+		assertEquals("foo: dev_bar/spam", resource);
+	}
+	
+	@Test
+	public void profilePlaceholderNullLabel() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{profile}");
+		String resource = this.controller.retrieve("bar", "dev", null, "spam/foo.txt", true);
 		assertEquals("foo: dev_bar/spam", resource);
 	}
 
@@ -177,11 +191,25 @@ public class ResourceControllerTests {
 		byte[] resource = this.controller.binary("dev(_)spam", "bar", "", "foo.txt");
 		assertEquals("foo: dev_bar/spam", new String(resource));
 	}
+	
+	@Test
+	public void applicationPlaceholderWithSlashForBinaryNullLabel() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		byte[] resource = this.controller.binary("dev(_)spam", "bar", null, "foo.txt");
+		assertEquals("foo: dev_bar/spam", new String(resource));
+	}
 
 	@Test
 	public void labelPlaceholderWithSlashForBinary() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{label}");
 		byte[] resource = this.controller.binary("dev", "bar", "dev(_)spam", "foo.txt");
+		assertEquals("foo: dev_bar/spam", new String(resource));
+	}
+	
+	@Test
+	public void profilePlaceholderForBinaryNullLabel() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{profile}");
+		byte[] resource = this.controller.binary("bar", "dev", null, "spam/foo.txt");
 		assertEquals("foo: dev_bar/spam", new String(resource));
 	}
 	

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -88,6 +88,13 @@ public class ResourceControllerTests {
 	}
 
 	@Test
+	public void applicationPlaceholderWithoutSlash() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		String resource = this.controller.retrieve("dev", "bar", "spam", "foo.txt", true);
+		assertEquals("foo: dev_bar/spam", resource);
+	}	
+	
+	@Test
 	public void applicationPlaceholderWithSlash() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
 		String resource = this.controller.retrieve("dev(_)spam", "bar", "", "foo.txt", true);
@@ -148,6 +155,13 @@ public class ResourceControllerTests {
 		request.setRequestURI("/foo/bar/dev/" + "spam/foo.txt");
 		String resource = this.controller.retrieve("foo", "bar", "dev", request, false);
 		assertEquals("foo: dev_bar/spam", resource);
+	}
+	
+	@Test
+	public void applicationPlaceholderWithoutSlashForBinary() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
+		byte[] resource = this.controller.binary("dev", "bar", "spam", "foo.txt");
+		assertEquals("foo: dev_bar/spam", new String(resource));
 	}
 	
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -88,7 +88,7 @@ public class ResourceControllerTests {
 	}
 
 	@Test
-	public void applicationPlaceholderWithoutSlash() throws Exception {
+	public void applicationAndLabelPlaceholdersWithoutSlash() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{application}/{label}");
 		String resource = this.controller.retrieve("dev", "bar", "spam", "foo.txt", true);
 		assertEquals("foo: dev_bar/spam", resource);
@@ -98,6 +98,13 @@ public class ResourceControllerTests {
 	public void applicationPlaceholderWithSlash() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
 		String resource = this.controller.retrieve("dev(_)spam", "bar", "", "foo.txt", true);
+		assertEquals("foo: dev_bar/spam", resource);
+	}
+	
+	@Test
+	public void labelPlaceholderWithSlash() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{label}");
+		String resource = this.controller.retrieve("dev", "bar", "dev(_)spam", "foo.txt", true);
 		assertEquals("foo: dev_bar/spam", resource);
 	}
 
@@ -158,7 +165,7 @@ public class ResourceControllerTests {
 	}
 	
 	@Test
-	public void applicationPlaceholderWithoutSlashForBinary() throws Exception {
+	public void applicationAndLabelPlaceholdersWithoutSlashForBinary() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{application}/{label}");
 		byte[] resource = this.controller.binary("dev", "bar", "spam", "foo.txt");
 		assertEquals("foo: dev_bar/spam", new String(resource));
@@ -171,6 +178,13 @@ public class ResourceControllerTests {
 		assertEquals("foo: dev_bar/spam", new String(resource));
 	}
 
+	@Test
+	public void labelPlaceholderWithSlashForBinary() throws Exception {
+		this.environmentRepository.setSearchLocations("classpath:/test/{label}");
+		byte[] resource = this.controller.binary("dev", "bar", "dev(_)spam", "foo.txt");
+		assertEquals("foo: dev_bar/spam", new String(resource));
+	}
+	
 	@Test
 	public void labelWithSlashForBinary() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test");


### PR DESCRIPTION
This aims to facilitate part of the desire from #779 . It allows the `{application}` replacements to include slashes utilizing the `(_)` approach that the `{label}` parameter already supported.