### PR TITLE
ResourceController support for server defined default label.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -49,6 +49,7 @@ import org.springframework.web.util.UrlPathHelper;
  * to replace placeholders in the resource text.
  *
  * @author Dave Syer
+ * @author Daniel Lavoie
  *
  */
 @RestController
@@ -77,9 +78,23 @@ public class ResourceController {
 		return retrieve(name, profile, label, path, resolvePlaceholders);
 	}
 
+	@RequestMapping(value = "/{name}/{profile}/**", params = "useDefaultLabel")
+	public String retrieve(@PathVariable String name, @PathVariable String profile,
+			HttpServletRequest request,
+			@RequestParam(defaultValue = "true") boolean resolvePlaceholders)
+			throws IOException {
+		String path = getFilePath(request, name, profile, null);
+		return retrieve(name, profile, null, path, resolvePlaceholders);
+	}
+
 	private String getFilePath(HttpServletRequest request, String name, String profile,
 			String label) {
-		String stem = String.format("/%s/%s/%s/", name, profile, label);
+		String stem;
+		if(label != null ) {
+			stem = String.format("/%s/%s/%s/", name, profile, label);
+		}else {
+			stem = String.format("/%s/%s/", name, profile);
+		}
 		String path = this.helper.getPathWithinApplication(request);
 		path = path.substring(path.indexOf(stem) + stem.length());
 		return path;


### PR DESCRIPTION
That is the first iteration. I've added a single test since it seems to cover our use case.

I can confirm that the `params` argument on `@RequestMapping` is used for mapping matching.

```
2017-10-19 12:39:55.956 TRACE 22849 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Found 3 matching mapping(s) for [/foo/default/foo.txt] : [{[/{name}/{profile}/**.*],methods=[GET],params=[useDefaultLabel]}, {[/{name}/{profiles}/{label:.*}],methods=[GET]}, {[/{name}/{profile}/{label}/**],methods=[GET]}]
2017-10-19 12:39:55.956 DEBUG 22849 --- [           main] s.w.s.m.m.a.RequestMappingHandlerMapping : Returning handler method [public java.lang.String org.springframework.cloud.config.server.resource.ResourceController.retrieve(java.lang.String,java.lang.String,javax.servlet.http.HttpServletRequest,boolean) throws java.io.IOException]
```

Fixes #824 