### PR TITLE
Add support for default label on native environment repository

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.web.client.RestTemplate;
 /**
  * @author Dave Syer
  * @author Ryan Baxter
+ * @author Daniel Lavoie
  *
  */
 @Configuration
@@ -109,10 +110,18 @@ class NativeRepositoryConfiguration {
 
 	@Autowired
 	private ConfigurableEnvironment environment;
+	
+	@Autowired
+	private ConfigServerProperties configServerProperties;
 
 	@Bean
 	public NativeEnvironmentRepository nativeEnvironmentRepository() {
-		return new NativeEnvironmentRepository(this.environment);
+		NativeEnvironmentRepository repository = new NativeEnvironmentRepository(
+				this.environment);
+
+		repository.setDefaultLabel(configServerProperties.getDefaultLabel());
+
+		return repository;
 	}
 }
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -49,13 +49,15 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Roy Clarkson
  * @author Venil Noronha
+ * @author Daniel Lavoie
  */
 @ConfigurationProperties("spring.cloud.config.server.native")
-public class NativeEnvironmentRepository implements EnvironmentRepository, SearchPathLocator, Ordered {
+public class NativeEnvironmentRepository
+		implements EnvironmentRepository, SearchPathLocator, Ordered {
 
 	private static Log logger = LogFactory.getLog(NativeEnvironmentRepository.class);
-
-	private static final String DEFAULT_LABEL = "master";
+	
+	private String defaultLabel = "master";
 
 	/**
 	 * Locations to search for configuration files. Defaults to the same as a Spring Boot
@@ -106,7 +108,11 @@ public class NativeEnvironmentRepository implements EnvironmentRepository, Searc
 	}
 
 	public String getDefaultLabel() {
-		return DEFAULT_LABEL;
+		return defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
 	}
 
 	@Override
@@ -143,6 +149,10 @@ public class NativeEnvironmentRepository implements EnvironmentRepository, Searc
 			locations = DEFAULT_LOCATIONS;
 		}
 		Collection<String> output = new LinkedHashSet<String>();
+
+		if (label == null) {
+			label = defaultLabel;
+		}
 		for (String location : locations) {
 			String[] profiles = new String[] { profile };
 			if (profile != null) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
@@ -29,6 +29,7 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @author Dave Syer
  * @author Spencer Gibb
  * @author Venil Noronha
+ * @author Daniel Lavoie
  */
 public class NativeEnvironmentRepositoryTests {
 
@@ -40,6 +41,7 @@ public class NativeEnvironmentRepositoryTests {
 				NativeEnvironmentRepositoryTests.class).web(false).run();
 		this.repository = new NativeEnvironmentRepository(context.getEnvironment());
 		this.repository.setVersion("myversion");
+		this.repository.setDefaultLabel(null);
 		context.close();
 	}
 
@@ -186,6 +188,13 @@ public class NativeEnvironmentRepositoryTests {
 		this.repository.setSearchLocations("classpath:/test/{profile}", "classpath:/test/dev");
 		Locations locations = this.repository.getLocations("foo", "dev", null);
 		assertEquals(1, locations.getLocations().length);
+	}
+	
+	@Test
+	public void testDefaultLabel() {
+		this.repository.setDefaultLabel("test");
+		assertEquals("test_bar", this.repository.findOne("foo", "default", null)
+				.getPropertySources().get(0).getSource().get("foo"));
 	}
 
 }


### PR DESCRIPTION
Brings support for `spring.cloud.config.server.defaultLabel` on the `NativeEnvironmentRepository`.