### PR TITLE
Extract RequestTimeout property in `ConfigServicePropertySourceLocator`

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.config.client;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,6 +23,11 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Dave Syer
@@ -77,6 +77,12 @@ public class ConfigClientProperties {
 	 * The URI of the remote server (default http://localhost:8888).
 	 */
 	private String uri = "http://localhost:8888";
+
+    /**
+     * Timeout (in seconds) for obtaining HTTP response. Default
+     * 3m5s seconds.
+     */
+    private int requestTimeout = (60 * 1000 * 3) + 5000;
 
 	/**
 	 * Discovery properties.
@@ -133,6 +139,14 @@ public class ConfigClientProperties {
 	public void setUri(String url) {
 		this.uri = url;
 	}
+
+	public int getRequestTimeout() {
+	    return this.requestTimeout;
+    }
+
+    public void setRequestTimeout(int requestTimeout) {
+	    this.requestTimeout = requestTimeout;
+    }
 
 	public String getName() {
 		return this.name;

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -16,12 +16,6 @@
 
 package org.springframework.cloud.config.client;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
@@ -47,6 +41,12 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.springframework.cloud.config.client.ConfigClientProperties.STATE_HEADER;
 import static org.springframework.cloud.config.client.ConfigClientProperties.TOKEN_HEADER;
@@ -191,11 +191,11 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 
 	private RestTemplate getSecureRestTemplate(ConfigClientProperties client) {
 		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-		requestFactory.setReadTimeout((60 * 1000 * 3) + 5000); //TODO 3m5s, make configurable?
+		requestFactory.setReadTimeout(this.defaultProperties.getRequestTimeout());
 		RestTemplate template = new RestTemplate(requestFactory);
 		String username = client.getUsername();
 		String password = client.getPassword();
-		String authorization = client.getAuthorization();
+		String authorization = client.getHeaders().get(HttpHeaders.AUTHORIZATION);
 		Map<String, String> headers = new HashMap<>(client.getHeaders());
 
 		if (password != null && authorization != null) {
@@ -205,10 +205,10 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 
 		if (password != null) {
 			byte[] token = Base64Utils.encode((username + ":" + password).getBytes());
-			headers.put("Authorization", "Basic " + new String(token));
+			headers.put(HttpHeaders.AUTHORIZATION, "Basic " + new String(token));
 		}
 		else if (authorization != null) {
-			headers.put("Authorization", authorization);
+			headers.put(HttpHeaders.AUTHORIZATION, authorization);
 		}
 
 		if (!headers.isEmpty()) {

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -1,14 +1,5 @@
 package org.springframework.cloud.config.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.io.ByteArrayInputStream;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNull;
 import org.junit.Rule;
@@ -34,6 +25,15 @@ import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ConfigServicePropertySourceLocatorTests {
 
@@ -153,6 +153,7 @@ public class ConfigServicePropertySourceLocatorTests {
 		defaults.setUsername("username");
 		defaults.setPassword("password");
 		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQNCg==");
+		defaults.getHeaders().put(HttpHeaders.AUTHORIZATION, "Basic dXNlcm5hbWU6cGFzc3dvcmQNCg==");
 		this.locator = new ConfigServicePropertySourceLocator(defaults);
  		this.expected.expect(IllegalStateException.class);
 		this.expected.expectMessage("You must set either 'password' or 'authorization'");
@@ -192,6 +193,7 @@ public class ConfigServicePropertySourceLocatorTests {
 
 		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
 		defaults.setAuthorization("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
+		defaults.getHeaders().put(HttpHeaders.AUTHORIZATION, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
 		this.locator = new ConfigServicePropertySourceLocator(defaults);
 
 		RestTemplate restTemplate = ReflectionTestUtils.invokeMethod(this.locator,


### PR DESCRIPTION
Extract RequestTimeout property in `ConfigServicePropertySourceLocator` to allow for configuration of the timeout

- Extract RequestTimeout Property
- Refactor to remove call to deprecated method
- Move header name constants to use `HttpHeaders` constants