### PR TITLE
Make CompositeConfiguration conditional on missing bean

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/CompositeConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/CompositeConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Primary;
  * @author Ryan Baxter
  */
 @Configuration
+@ConditionalOnMissingBean(CompositeEnvironmentRepository.class)
 public class CompositeConfiguration {
 
 	private List<EnvironmentRepository> environmentRepos = new ArrayList<>();


### PR DESCRIPTION
Previously, `CompositeConfiguration` (which is imported by `ConfigServerAutoConfiguration`) would unconditionally create a `CompositeEnvironmentRepository` bean marked as `@Primary`. This makes it difficult for users, in their code, to provide their own `CompositeEnvironmentRepository` bean to be used in various places. This adds a `ConditionalOnMissingBean` condition to the `Configuration` to make it easy to provide a primary `CompositeEnvironmentRepository` in user code.