### PR TITLE
add placeholder support for {application} in EnvironmentController

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -99,6 +99,11 @@ public class EnvironmentController {
 	@RequestMapping("/{name}/{profiles}/{label:.*}")
 	public Environment labelled(@PathVariable String name, @PathVariable String profiles,
 			@PathVariable String label) {
+		if (name != null && name.contains("(_)")) {
+			// "(_)" is uncommon in a git repo name, but "/" cannot be matched
+			// by Spring MVC
+			name = name.replace("(_)", "/");
+		}
 		if (label != null && label.contains("(_)")) {
 			// "(_)" is uncommon in a git branch name, but "/" cannot be matched
 			// by Spring MVC

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -203,6 +203,20 @@ public class EnvironmentControllerTests {
 		assertThat(environment.getPropertySources().get(1).getSource().entrySet(),
 				hasSize(3));
 	}
+	
+	@Test
+	public void testNameWithSlash() {
+		this.controller.labelled("foo(_)spam", "bar", "two");
+		
+		Mockito.verify(this.repository).findOne("foo/spam", "bar", "two");
+	}
+
+	@Test
+	public void testLabelWithSlash() {
+		this.controller.labelled("foo", "bar", "two(_)spam");
+		
+		Mockito.verify(this.repository).findOne("foo", "bar", "two/spam");
+	}
 
 	@Test
 	public void arrayOverridenInYaml() throws Exception {


### PR DESCRIPTION
Issue https://github.com/spring-cloud/spring-cloud-config/issues/779 was implemented in ResourceController but not in EnvironmentController