### PR TITLE
Fix delete untracked branch feature if git repo unavailable

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -215,7 +215,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 			git = createGitClient();
 			if (shouldPull(git)) {
 				FetchResult fetchStatus = fetch(git, label);
-				if(deleteUntrackedBranches) {
+				if (deleteUntrackedBranches && fetchStatus != null) {
 					deleteUntrackedLocalBranches(fetchStatus.getTrackingRefUpdates(), git);
 				}
 				// checkout after fetch so we can get any new branches, tags, ect.
@@ -265,7 +265,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	/**
 	 * Clones the remote repository and then opens a connection to it.
-	 * 
+	 *
 	 * @throws GitAPIException
 	 * @throws IOException
 	 */

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -332,6 +332,7 @@ public class JGitEnvironmentRepositoryTests {
 		CloneCommand cloneCommand = mock(CloneCommand.class);
 		MockGitFactory factory = new MockGitFactory(git, cloneCommand);
 		this.repository.setGitFactory(factory);
+		this.repository.setDeleteUntrackedBranches(true);
 
 		// refresh()->shouldPull
 		StatusCommand statusCommand = mock(StatusCommand.class);


### PR DESCRIPTION
Root cause:
If git repository is not available - fetch command throws exception and null is returned instead of FetchResult object.
In this case enabled "delete untracked branch feature" will brake flow of retrieving local copy.
Resolution summary:
Added null check for fetch result.

PS: sorry, I've missed this earlier...