### PR TITLE
Send 404 if application not found

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -105,7 +105,7 @@ If there are profile-specific YAML (or properties) files, these are also applied
 Higher precedence translates to a `PropertySource` listed earlier in the `Environment`.
 (These same rules apply in a standalone Spring Boot application.)
 
-You can set spring.cloud.config.server.acceptEmtpy to false so that Server would return a HTTP 404 status, if the application is not found .By default, this flag is set to true.
+You can set spring.cloud.config.server.accept-empty to false so that Server would return a HTTP 404 status, if the application is not found.By default, this flag is set to true.
 ==== Git Backend
 
 The default implementation of `EnvironmentRepository` uses a Git backend, which is very convenient for managing upgrades and physical

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -105,6 +105,7 @@ If there are profile-specific YAML (or properties) files, these are also applied
 Higher precedence translates to a `PropertySource` listed earlier in the `Environment`.
 (These same rules apply in a standalone Spring Boot application.)
 
+Server would return a HTTP 404 status, if the application is not found
 ==== Git Backend
 
 The default implementation of `EnvironmentRepository` uses a Git backend, which is very convenient for managing upgrades and physical

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -105,7 +105,7 @@ If there are profile-specific YAML (or properties) files, these are also applied
 Higher precedence translates to a `PropertySource` listed earlier in the `Environment`.
 (These same rules apply in a standalone Spring Boot application.)
 
-Server would return a HTTP 404 status, if the application is not found
+You can set spring.cloud.config.server.acceptEmtpy to false so that Server would return a HTTP 404 status, if the application is not found .By default, this flag is set to true.
 ==== Git Backend
 
 The default implementation of `EnvironmentRepository` uses a Git backend, which is very convenient for managing upgrades and physical

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerMvcConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerMvcConfiguration.java
@@ -57,6 +57,7 @@ public class ConfigServerMvcConfiguration extends WebMvcConfigurerAdapter {
 	public EnvironmentController environmentController(EnvironmentRepository envRepository, ConfigServerProperties server) {
 		EnvironmentController controller = new EnvironmentController(encrypted(envRepository, server), this.objectMapper);
 		controller.setStripDocumentFromYaml(server.isStripDocumentFromYaml());
+		controller.setAcceptEmpty(server.isAcceptEmpty());
 		return controller;
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
@@ -59,7 +59,7 @@ public class ConfigServerProperties {
 	/**
 	 * Flag to indicate that If HTTP 404 needs to be sent if Application is not Found
 	 */
-	private boolean acceptEmtpy = true;
+	private boolean acceptEmpty = true;
 
 	/**
 	 * Default application name when incoming requests do not have a specific one.
@@ -121,11 +121,11 @@ public class ConfigServerProperties {
 	}
 	
 	public boolean isAcceptEmpty() {
-		return this.acceptEmtpy;
+		return this.acceptEmpty;
 	}
 
-	public void setAcceptEmtpy(boolean acceptEmpty) {
-		this.acceptEmtpy = acceptEmpty;
+	public void setAcceptEmpty(boolean acceptEmpty) {
+		this.acceptEmpty = acceptEmpty;
 	}
 	public String getDefaultApplicationName() {
 		return this.defaultApplicationName;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
@@ -56,6 +56,10 @@ public class ConfigServerProperties {
 	 * should be returned in "native" form.
 	 */
 	private boolean stripDocumentFromYaml = true;
+	/**
+	 * Flag to indicate that If HTTP 404 needs to be sent if Application is not Found
+	 */
+	private boolean acceptEmtpy = true;
 
 	/**
 	 * Default application name when incoming requests do not have a specific one.
@@ -115,7 +119,14 @@ public class ConfigServerProperties {
 	public void setStripDocumentFromYaml(boolean stripDocumentFromYaml) {
 		this.stripDocumentFromYaml = stripDocumentFromYaml;
 	}
+	
+	public boolean isAcceptEmpty() {
+		return this.acceptEmtpy;
+	}
 
+	public void setAcceptEmtpy(boolean acceptEmpty) {
+		this.acceptEmtpy = acceptEmpty;
+	}
 	public String getDefaultApplicationName() {
 		return this.defaultApplicationName;
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -110,6 +110,9 @@ public class EnvironmentController {
 			label = label.replace("(_)", "/");
 		}
 		Environment environment = this.repository.findOne(name, profiles, label);
+		if(environment == null || environment.getPropertySources().isEmpty()){
+			 throw new EnvironmentNotFoundException("Profile Not found");
+		}
 		return environment;
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -69,6 +69,7 @@ public class EnvironmentController {
 	private ObjectMapper objectMapper;
 
 	private boolean stripDocument = true;
+	private boolean acceptEmpty = true;
 
 	public EnvironmentController(EnvironmentRepository repository) {
 		this(repository, new ObjectMapper());
@@ -90,6 +91,15 @@ public class EnvironmentController {
 		this.stripDocument = stripDocument;
 	}
 
+	/**
+	 * Flag to indicate that If HTTP 404 needs to be sent if Application is not Found
+	 *
+	 * @param acceptEmpty the flag to set
+	 */
+	public void setAcceptEmpty(boolean acceptEmpty) {
+		this.acceptEmpty = acceptEmpty;
+	}
+	
 	@RequestMapping("/{name}/{profiles:.*[^-].*}")
 	public Environment defaultLabel(@PathVariable String name,
 			@PathVariable String profiles) {
@@ -110,7 +120,7 @@ public class EnvironmentController {
 			label = label.replace("(_)", "/");
 		}
 		Environment environment = this.repository.findOne(name, profiles, label);
-		if(environment == null || environment.getPropertySources().isEmpty()){
+		if(!acceptEmpty && (environment == null || environment.getPropertySources().isEmpty())){
 			 throw new EnvironmentNotFoundException("Profile Not found");
 		}
 		return environment;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentNotFoundException.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentNotFoundException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.config.server.environment;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * @author Chids
+ *
+ */
+@SuppressWarnings("serial")
+@ResponseStatus(code = HttpStatus.NOT_FOUND,  reason = "Application Not Found")
+public class EnvironmentNotFoundException extends RuntimeException {
+
+	public EnvironmentNotFoundException(String string) {
+		super(string);
+	}
+
+	public EnvironmentNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentNotFoundException.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentNotFoundException.java
@@ -30,7 +30,4 @@ public class EnvironmentNotFoundException extends RuntimeException {
 		super(string);
 	}
 
-	public EnvironmentNotFoundException(String message, Throwable cause) {
-		super(message, cause);
-	}
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -65,6 +65,7 @@ public class EnvironmentControllerTests {
 	@Before
 	public void init() {
 		this.controller = new EnvironmentController(this.repository);
+		environment.add(new PropertySource("foo", new HashMap<>()));
 	}
 
 	@After
@@ -195,27 +196,35 @@ public class EnvironmentControllerTests {
 		assertThat(environment.getProfiles(), equalTo(new String[] { "master" }));
 		assertThat(environment.getLabel(), equalTo("master"));
 		assertThat(environment.getVersion(), nullValue());
-		assertThat(environment.getPropertySources(), hasSize(2));
+		assertThat(environment.getPropertySources(), hasSize(3));
 		assertThat(environment.getPropertySources().get(0).getName(), equalTo("two"));
 		assertThat(environment.getPropertySources().get(0).getSource().entrySet(),
 				hasSize(2));
-		assertThat(environment.getPropertySources().get(1).getName(), equalTo("one"));
-		assertThat(environment.getPropertySources().get(1).getSource().entrySet(),
+		assertThat(environment.getPropertySources().get(2).getName(), equalTo("one"));
+		assertThat(environment.getPropertySources().get(2).getSource().entrySet(),
 				hasSize(3));
 	}
 	
 	@Test
 	public void testNameWithSlash() {
-		this.controller.labelled("foo(_)spam", "bar", "two");
-		
-		Mockito.verify(this.repository).findOne("foo/spam", "bar", "two");
+		Mockito.when(this.repository.findOne("foo/spam", "bar", "two")).thenReturn(this.environment);
+
+		Environment returnedEnvironment = this.controller.labelled("foo(_)spam", "bar", "two");
+
+		assertEquals(this.environment.getLabel(), returnedEnvironment.getLabel());
+		assertEquals(this.environment.getName(), returnedEnvironment.getName());
+
 	}
 
 	@Test
 	public void testLabelWithSlash() {
-		this.controller.labelled("foo", "bar", "two(_)spam");
 		
-		Mockito.verify(this.repository).findOne("foo", "bar", "two/spam");
+		Mockito.when(this.repository.findOne("foo", "bar", "two/spam")).thenReturn(this.environment);
+
+		Environment returnedEnvironment = this.controller.labelled("foo", "bar", "two(_)spam");
+
+		assertEquals(this.environment.getLabel(), returnedEnvironment.getLabel());
+		assertEquals(this.environment.getName(), returnedEnvironment.getName());
 	}
 
 	@Test
@@ -490,6 +499,14 @@ public class EnvironmentControllerTests {
 		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
 		mvc.perform(MockMvcRequestBuilders.get("/foo/bar/other"))
 				.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+	@Test
+	public void mappingForEnvironment_404_not_found() throws Exception {
+		Mockito.when(this.repository.findOne("foo1", "notfound", null))
+				.thenReturn(new Environment("foo", "master"));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
+		mvc.perform(MockMvcRequestBuilders.get("/foo1/notfound"))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -508,6 +508,14 @@ public class EnvironmentControllerTests {
 		mvc.perform(MockMvcRequestBuilders.get("/foo1/notfound"))
 				.andExpect(MockMvcResultMatchers.status().isNotFound());
 	}
+	@Test
+	public void environmentMissing() throws Exception {
+		Mockito.when(this.repository.findOne("foo1", "notfound", null))
+				.thenThrow(new EnvironmentNotFoundException("Missing Environment"));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
+		mvc.perform(MockMvcRequestBuilders.get("/foo1/notfound"))
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
 
 	@Test
 	public void mappingForYaml() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -215,7 +215,19 @@ public class EnvironmentControllerTests {
 		assertEquals(this.environment.getName(), returnedEnvironment.getName());
 
 	}
+	@Test(expected=EnvironmentNotFoundException.class)
+	public void testEnvironmentNotFound() {
+		this.controller.setAcceptEmpty(false);
+		this.controller.labelled("foo", "bar", null);
+	}
+	@Test
+	public void testwithValidEnvironment() {
+		Mockito.when(this.repository.findOne("foo", "bar",null))
+				.thenReturn(this.environment);
+		Environment environment = this.controller.labelled("foo", "bar", null);
+		assertThat(environment, not(nullValue()));
 
+	}
 	@Test
 	public void testLabelWithSlash() {
 		
@@ -500,14 +512,7 @@ public class EnvironmentControllerTests {
 		mvc.perform(MockMvcRequestBuilders.get("/foo/bar/other"))
 				.andExpect(MockMvcResultMatchers.status().isOk());
 	}
-	@Test
-	public void mappingForEnvironment_404_not_found() throws Exception {
-		Mockito.when(this.repository.findOne("foo1", "notfound", null))
-				.thenReturn(new Environment("foo", "master"));
-		MockMvc mvc = MockMvcBuilders.standaloneSetup(this.controller).build();
-		mvc.perform(MockMvcRequestBuilders.get("/foo1/notfound"))
-				.andExpect(MockMvcResultMatchers.status().isNotFound());
-	}
+	
 	@Test
 	public void environmentMissing() throws Exception {
 		Mockito.when(this.repository.findOne("foo1", "notfound", null))


### PR DESCRIPTION
Added a check to see if PropertySources is empty. If yes, Cloud Config server would return HTTP 404. 
Modified existing JUnit Testcases to send PropertySources in Environment
Fixes gh-155