### PR TITLE
Feature request: Adding refresh rate to GIT repositories

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -93,6 +93,16 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	private int timeout = 5;
 
 	/**
+	 * Time (in seconds) between refresh of the git repository
+	 */
+	private int refreshRate = 0;
+
+	/**
+	 * Time of the last refresh of the git repository
+	 */
+	private long lastRefresh;
+
+	/**
 	 * Flag to indicate that the repository should be cloned on startup (not on demand).
 	 * Generally leads to slower startup but faster first query.
 	 */
@@ -143,6 +153,15 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
 	}
+
+	public int getRefreshRate() {
+		return refreshRate;
+	}
+
+	public void setRefreshRate(int refreshRate) {
+		this.refreshRate = refreshRate;
+	}
+
 
 	public TransportConfigCallback getTransportConfigCallback() {
 		return transportConfigCallback;
@@ -347,6 +366,11 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 	protected boolean shouldPull(Git git) throws GitAPIException {
 		boolean shouldPull;
+
+		if (this.refreshRate > 0 && System.currentTimeMillis() - this.lastRefresh < (this.refreshRate * 1000)) {
+			return false;
+		}
+
 		Status gitStatus = git.status().call();
 		boolean isWorkingTreeClean = gitStatus.isClean();
 		String originUrl = git.getRepository().getConfig().getString("remote", "origin",
@@ -392,6 +416,9 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		fetch.setRemote("origin");
 		fetch.setTagOpt(TagOpt.FETCH_TAGS);
 		fetch.setRemoveDeletedRefs(deleteUntrackedBranches);
+		if (this.refreshRate > 0) {
+			this.setLastRefresh(System.currentTimeMillis());
+		}
 
 		configureCommand(fetch);
 		try {
@@ -615,6 +642,14 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		if (logger.isDebugEnabled()) {
 			logger.debug("Stacktrace for: " + message, ex);
 		}
+	}
+
+	public void setLastRefresh(long lastRefresh) {
+		this.lastRefresh = lastRefresh;
+	}
+
+	public long getLastRefresh() {
+		return lastRefresh;
 	}
 
 	/**

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java
@@ -81,6 +81,9 @@ public class MultipleJGitEnvironmentRepository extends JGitEnvironmentRepository
 			if (getTimeout() != 0 && repo.getTimeout() == 0) {
 				repo.setTimeout(getTimeout());
 			}
+			if (getRefreshRate() != 0 && repo.getRefreshRate() == 0) {
+				repo.setRefreshRate(getRefreshRate());
+			}
 			String user = repo.getUsername();
 			String pass = repo.getPassword();
 			String passphrase = repo.getPassphrase();

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -326,6 +326,67 @@ public class JGitEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void shouldNotRefresh() throws Exception {
+		Git git = mock(Git.class);
+		StatusCommand statusCommand = mock(StatusCommand.class);
+		Status status = mock(Status.class);
+		Repository repository = mock(Repository.class);
+		StoredConfig storedConfig = mock(StoredConfig.class);
+
+		when(git.status()).thenReturn(statusCommand);
+		when(git.getRepository()).thenReturn(repository);
+		when(repository.getConfig()).thenReturn(storedConfig);
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(statusCommand.call()).thenReturn(status);
+		when(status.isClean()).thenReturn(true);
+
+		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(this.environment);
+
+		repo.setLastRefresh(System.currentTimeMillis() - 5000);
+		repo.setRefreshRate(2);
+
+		boolean shouldPull = repo.shouldPull(git);
+
+		assertThat("shouldPull was false", shouldPull, is(true));
+
+		repo.setRefreshRate(30);
+
+		shouldPull = repo.shouldPull(git);
+
+		assertThat("shouldPull was true", shouldPull, is(false));
+	}
+
+	@Test
+	public void shouldUpdateLastRefresh() throws Exception {
+		Git git = mock(Git.class);
+		StatusCommand statusCommand = mock(StatusCommand.class);
+		Status status = mock(Status.class);
+		Repository repository = mock(Repository.class);
+		StoredConfig storedConfig = mock(StoredConfig.class);
+		FetchCommand fetchCommand = mock(FetchCommand.class);
+		FetchResult fetchResult = mock(FetchResult.class);
+
+		when(git.status()).thenReturn(statusCommand);
+		when(git.getRepository()).thenReturn(repository);
+		when(fetchCommand.call()).thenReturn(fetchResult);
+		when(git.fetch()).thenReturn(fetchCommand);
+		when(repository.getConfig()).thenReturn(storedConfig);
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(statusCommand.call()).thenReturn(status);
+		when(status.isClean()).thenReturn(true);
+
+		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(this.environment);
+
+		repo.setRefreshRate(1000);
+		repo.setLastRefresh(0);
+		repo.fetch(git, "master");
+
+		long timeDiff = System.currentTimeMillis() - repo.getLastRefresh();
+
+		assertThat("time difference ("+timeDiff+") was longer than 1 second", timeDiff < 1000L, is(true));
+	}
+
+	@Test
 	public void testFetchException() throws Exception {
 
 		Git git = mock(Git.class);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
@@ -103,6 +103,26 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 	}
 
 	@Test
+	public void mappingRepoWithRefreshRate() throws IOException {
+		String defaultRepoUri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
+		String test1RepoUri = ConfigServerTestUtils.prepareLocalRepo("test1-config-repo");
+
+		Map<String, Object> repoMapping = new LinkedHashMap<String, Object>();
+		repoMapping.put("spring.cloud.config.server.git.repos[test1].pattern", "*test1*");
+		repoMapping.put("spring.cloud.config.server.git.repos[test1].uri", test1RepoUri);
+		repoMapping.put("spring.cloud.config.server.git.refreshRate", "30");
+		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri)
+				.properties(repoMapping).run();
+		EnvironmentRepository repository = this.context
+				.getBean(EnvironmentRepository.class);
+		repository.findOne("test1-svc", "staging", "master");
+		Environment environment = repository.findOne("test1-svc", "staging", "master");
+		assertEquals(2, environment.getPropertySources().size());
+		assertEquals(((MultipleJGitEnvironmentRepository) repository).getRepos().get("test1").getRefreshRate(), 30);
+	}
+
+	@Test
 	public void mappingRepoWithProfile() throws IOException {
 		String defaultRepoUri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
 		String test1RepoUri = ConfigServerTestUtils.prepareLocalRepo("test1-config-repo");


### PR DESCRIPTION
I'm spring cloud config (with git setup), but we are having performance issues because SCC always refreshes from the git repo(s).

I noticed there's a fix already for this issue on master for 2.x but not for 1.x - https://github.com/spring-cloud/spring-cloud-config/pull/749

I just cherry-picked the commit into the 1.4.x branch, but happy to the the same for other branches if necessary.

@spencergibb @ @ryanjbaxter any chance we can have a 1.4.4 release build with this?



