### PR TITLE
Add GogsPropertyPathNotificationExtractor

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Craig Walls
+ *
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 300)
+public class GogsPropertyPathNotificationExtractor
+    implements PropertyPathNotificationExtractor {
+
+  @Override
+  public PropertyPathNotification extract(MultiValueMap<String, String> headers,
+      Map<String, Object> request) {
+    if ("push".equals(headers.getFirst("X-Gogs-Event"))) {
+      if (request.get("commits") instanceof Collection) {
+        Set<String> paths = new HashSet<>();
+        @SuppressWarnings("unchecked")
+        Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
+            .get("commits");
+        for (Map<String, Object> commit : commits) {
+          addAllPaths(paths, commit, "added");
+          addAllPaths(paths, commit, "removed");
+          addAllPaths(paths, commit, "modified");
+        }
+        if (!paths.isEmpty()) {
+          return new PropertyPathNotification(paths.toArray(new String[0]));
+        }
+      }
+    }
+    return null;
+  }
+
+  private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
+    @SuppressWarnings("unchecked")
+    Collection<String> files = (Collection<String>) commit.get(name);
+    if (files != null) {
+      paths.addAll(files);
+    }
+  }
+
+}
+

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Craig Walls
+ *
+ */
+public class GogsPropertyPathNotificationExtractorTests {
+
+	private GogsPropertyPathNotificationExtractor extractor = new GogsPropertyPathNotificationExtractor();
+
+	private HttpHeaders headers = new HttpHeaders();
+
+	@Test
+	public void gogsSample() throws Exception {
+		// See https://gogs.io/docs/features/webhook
+		Map<String, Object> value = new ObjectMapper().readValue(
+				new ClassPathResource("gogs.json").getInputStream(),
+				new TypeReference<Map<String, Object>>() {
+				});
+		this.headers.set("X-Gogs-Event", "push");
+		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+		assertNotNull(extracted);
+		assertEquals("README.md", extracted.getPaths()[0]);
+	}
+
+	@Test
+	public void notAPushNotDetected() throws Exception {
+		Map<String, Object> value = new ObjectMapper().readValue(
+				new ClassPathResource("gogs.json").getInputStream(),
+				new TypeReference<Map<String, Object>>() {
+				});
+		this.headers.set("X-Gogs-Event", "issues");
+		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+		assertNull(extracted);
+	}
+
+}

--- a/spring-cloud-config-monitor/src/test/resources/gogs.json
+++ b/spring-cloud-config-monitor/src/test/resources/gogs.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/changes",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Add a new path notification extractor for Gogs (https://gogs.io/). Since Gogs behaves almost identical to GitHub and Gitlab, this is mostly a duplicate of the GitHub and Gitlab path notification extractor. The only difference is the name of the header to determine that the webhook request is a push.

Note that although I put my name as the author in the JavaDoc, @dsyer has credit for the GitHub and Gitlab work, which I just copied. He's welcome to add his name to the work if he wants, but I didn't want to put his name on it if (for some reason) he would be against having his name on it.

I also note that the GitHub and Gitlab notification extractors are also near-duplicates of each other. Perhaps a refactoring is in order to remove that duplication into some base class. I didn't take that step here because no such refactoring had been taken with the existing notification extractors. But it might be a good idea.