### PR TITLE
Update docs on composite environment repositories

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -659,34 +659,61 @@ Property values behave in the same way as they would if they came from Spring Bo
 ==== Composite Environment Repositories
 
 In some scenarios, you may wish to pull configuration data from multiple environment repositories.
-To do so, you can enable multiple profiles in your config server's application properties or YAML file.
-If, for example, you want to pull configuration data from a Git repository as well as an SVN repository, you can set the following properties for your configuration server:
+To do so, you can enable the `composite` profile in your configuration server's application properties or YAML file.
+If, for example, you want to pull configuration data from a Subversion repository as well as two Git repositories, you can set the following properties for your configuration server:
 
 [source,yaml]
 ----
 spring:
   profiles:
-    active: git, svn
+    active: composite
   cloud:
     config:
       server:
-        svn:
+        composite:
+        -
+          type: svn
           uri: file:///path/to/svn/repo
-          order: 2
+        -
+          type: git
+          uri: file:///path/to/rex/git/repo
+        -
+          type: git
+          uri: file:///path/to/walter/git/repo
+----
+
+Using this configuration, precedence is determined by the order in which repositories are listed under the `composite` key.
+In the above example, the Subversion repository is listed first, so a value found in the Subversion repository will override values found for the same property in one of the Git repositories.
+A value found in the `rex` Git repository will be used before a value found for the same property in the `walter` Git repository.
+
+If you want to pull configuration data only from repositories that are each of distinct types, you can enable the corresponding profiles, rather than the `composite` profile, in your configuration server's application properties or YAML file.
+If, for example, you want to pull configuration data from a single Git repository and a single Subversion repository, you can set the following properties for your configuration server:
+
+[source,yaml]
+----
+spring:
+  profiles:
+    active: git, subversion
+  cloud:
+    config:
+      server:
         git:
           uri: file:///path/to/git/repo
+          order: 2
+        svn:
+          uri: file:///path/to/svn/repo
           order: 1
 ----
 
-In addition to each repository specifying a URI, you can also specify an `order` property.
-The `order` property lets you specify the priority order for all your repositories.
+Using this configuration, precedence can be determined by an `order` property.
+You can use the `order` property to specify the priority order for all your repositories.
 The lower the numerical value of the `order` property, the higher priority it has.
 The priority order of a repository helps resolve any potential conflicts between repositories that contain values for the same properties.
 
 NOTE: Any type of failure when retrieving values from an environment repository results in a failure for the entire composite environment.
 
 NOTE: When using a composite environment, it is important that all repositories contain the same labels.
-If you have an environment similar to the one in the preceding example and you request configuration data with the `master` label but the SVN repository does not contain a branch called `master`, the entire request fails.
+If you have an environment similar to the ones in the preceding examples and you request configuration data with the `master` label but the Subversion repository does not contain a branch called `master`, the entire request fails.
 
 ===== Custom Composite Environment Repositories
 

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -713,7 +713,7 @@ The priority order of a repository helps resolve any potential conflicts between
 NOTE: Any type of failure when retrieving values from an environment repository results in a failure for the entire composite environment.
 
 NOTE: When using a composite environment, it is important that all repositories contain the same labels.
-If you have an environment similar to the ones in the preceding examples and you request configuration data with the `master` label but the Subversion repository does not contain a branch called `master`, the entire request fails.
+If you have an environment similar to those in the preceding examples and you request configuration data with the `master` label but the Subversion repository does not contain a branch called `master`, the entire request fails.
 
 ===== Custom Composite Environment Repositories
 


### PR DESCRIPTION
Fixes #933

Note that there's no mention of deprecation regarding the existing composite method (using multiple profiles for distinct backend types). If we're deprecating that, we may want to include a notice in the docs here in addition to the Finchley release notes.