### PR TITLE
Add docs for HTTP(S) proxy server configuration

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -506,6 +506,7 @@ Thus, the default behaviour with no placeholders is the same as adding a search 
 For example, `file:/tmp/config` is the same as `file:/tmp/config,file:/tmp/config/{label}`.
 This behavior can be disabled by setting `spring.cloud.config.server.native.addLabelLocations=false`.
 
+[[vault-backend]]
 ==== Vault Backend
 
 Spring Cloud Config Server also supports https://www.vaultproject.io[Vault] as a backend.
@@ -740,21 +741,22 @@ In the above example, the Subversion repository is listed first, so a value foun
 A value found in the `rex` Git repository will be used before a value found for the same property in the `walter` Git repository.
 
 If you want to pull configuration data only from repositories that are each of distinct types, you can enable the corresponding profiles, rather than the `composite` profile, in your configuration server's application properties or YAML file.
-If, for example, you want to pull configuration data from a single Git repository and a single Subversion repository, you can set the following properties for your configuration server:
+If, for example, you want to pull configuration data from a single Git repository and a single HashiCorp Vault server, you can set the following properties for your configuration server:
 
 [source,yaml]
 ----
 spring:
   profiles:
-    active: git, subversion
+    active: git, vault
   cloud:
     config:
       server:
         git:
           uri: file:///path/to/git/repo
           order: 2
-        svn:
-          uri: file:///path/to/svn/repo
+        vault:
+          host: 127.0.0.1
+          port: 8200
           order: 1
 ----
 
@@ -762,6 +764,8 @@ Using this configuration, precedence can be determined by an `order` property.
 You can use the `order` property to specify the priority order for all your repositories.
 The lower the numerical value of the `order` property, the higher priority it has.
 The priority order of a repository helps resolve any potential conflicts between repositories that contain values for the same properties.
+
+NOTE: If your composite environment includes a Vault server as in the previous example, you must include a Vault token in every request made to the configuration server. See <<vault-backend,Vault Backend>>.
 
 NOTE: Any type of failure when retrieving values from an environment repository results in a failure for the entire composite environment.
 

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -620,6 +620,53 @@ Properties written to `secret/application` are available to <<_vault_server,all 
 An application with the name, `myApp`, would have any properties written to `secret/myApp` and `secret/application` available to it.
 When `myApp` has the `dev` profile enabled, properties written to all of the above paths would be available to it, with properties in the first path in the list taking priority over the others.
 
+==== Accessing Backends Through a Proxy
+
+The configuration server can access a Git or Vault backend through an HTTP or HTTPS proxy. This behavior is controlled for either Git or Vault by settings under `proxy.http` and `proxy.https`. These settings are per repository, so if you are using a <<composite-environment-repositories,composite environment repository>> you must configure proxy settings for each backend in the composite individually. If using a network which requires separate proxy servers for HTTP and HTTPS URLs, you can configure both the HTTP and the HTTPS proxy settings for a single backend.
+
+The following table describes the proxy configuration properties for both HTTP and HTTPS proxies. All of these properties must be prefixed by `proxy.http` or `proxy.https`.
+
+.Proxy Configuration Properties
+|===
+|Property Name |Remarks
+
+|*host*
+|The host of the proxy.
+
+|*port*
+|The port with which to access the proxy.
+
+|*nonProxyHosts*
+|Any hosts which the configuration server should access outside the proxy. If values are provided for both `proxy.http.nonProxyHosts` and `proxy.https.nonProxyHosts`, the `proxy.http` value will be used.
+
+|*username*
+|The username with which to authenticate to the proxy. If values are provided for both `proxy.http.username` and `proxy.https.username`, the `proxy.http` value will be used.
+
+|*password*
+|The password with which to authenticate to the proxy. If values are provided for both `proxy.http.password` and `proxy.https.password`, the `proxy.http` value will be used.
+|===
+
+The following configuration uses an HTTPS proxy to access a Git repository.
+
+[source,yaml]
+----
+spring:
+  profiles:
+    active: git
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/spring-cloud-samples/config-repo
+          proxy:
+            https:
+              host: my-proxy.host.io
+              password: myproxypassword
+              port: '3128'
+              username: myproxyusername
+              nonProxyHosts: example.com
+----
+
 ==== Sharing Configuration With All Applications
 
 Sharing configuration between all applications varies according to which approach you take, as described in the following topics:
@@ -661,6 +708,7 @@ The database needs to have a table called `PROPERTIES` with columns called `APPL
 All fields are of type String in Java, so you can make them `VARCHAR` of whatever length you need.
 Property values behave in the same way as they would if they came from Spring Boot properties files named `{application}-{profile}.properties`, including all the encryption and decryption, which will be applied as post-processing steps (that is, not in the repository implementation directly).
 
+[[composite-environment-repositories]]
 ==== Composite Environment Repositories
 
 In some scenarios, you may wish to pull configuration data from multiple environment repositories.


### PR DESCRIPTION
Fixes #1038.

This also adds a note to the "Composite" section to clarify that a composite which includes a Vault server will always require a Vault token in the request (otherwise the entire request fails, as mentioned already in the docs).