### PR TITLE
Omit secret backend URL encoding for Vault.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
@@ -60,7 +60,7 @@ public class VaultKvAccessStrategyFactory {
 
 		@Override
 		public String getPath() {
-			return "/v1/{backend}/{key}";
+			return "{key}";
 		}
 
 		@Override
@@ -80,7 +80,7 @@ public class VaultKvAccessStrategyFactory {
 
 		@Override
 		public String getPath() {
-			return "/v1/{backend}/data/{key}";
+			return "data/{key}";
 		}
 
 		@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategySupport.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategySupport.java
@@ -39,7 +39,9 @@ abstract class VaultKvAccessStrategySupport implements VaultKvAccessStrategy {
 	}
 
 	/**
-	 * @return the context path to append to the {@code baseUrl}.
+	 * @return the relative context path template within a secret backend to append to a
+	 * URL containing the {@code baseURL}, API version segment and secret backend. May be
+	 * templated with {@literal {key}} to as template variable for the secret key.
 	 */
 	abstract String getPath();
 
@@ -60,9 +62,11 @@ abstract class VaultKvAccessStrategySupport implements VaultKvAccessStrategy {
 	@Override
 	public String getData(HttpHeaders headers, String backend, String key) {
 		try {
-			ResponseEntity<VaultResponse> response = rest.exchange(baseUrl + getPath(),
-					HttpMethod.GET, new HttpEntity<>(headers), VaultResponse.class,
-					backend, key);
+
+			String urlTemplate = String.format("%s/v1/%s/%s", baseUrl, backend, getPath());
+
+			ResponseEntity<VaultResponse> response = rest.exchange(urlTemplate, HttpMethod.GET,
+					new HttpEntity<>(headers), VaultResponse.class, key);
 			HttpStatus status = response.getStatusCode();
 			if (status == HttpStatus.OK) {
 				return extractDataFromBody(response.getBody());


### PR DESCRIPTION
We now construct the URL template from the base URL, API version prefix and secret backend upfront and apply templating only for the secret key. This bypasses URL encoding for the secret backend which allows for special characters such as slashes to be passed thru directly.

Fixes gh-1094.