### PR TITLE
add documentation to not use application as a prefix for your application name

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -124,6 +124,14 @@ To modify the startup behavior, you can change the location of the config server
 spring.cloud.config.uri: http://myconfigserver.com
 ----
 
+By default, if no application name is set, `application` will be used as the default. To modify the name, the following property can be added to the `bootstrap.properties` file:
+
+----
+spring.application.name: myapp
+----
+
+NOTE: When setting the property `${spring.application.name}` do not prefix your app name with the reserved word `application-` to prevent issues resolving the correct property source.
+
 The bootstrap properties show up in the `/env` endpoint as a high-priority property source, as shown in the following example.
 
 ----

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1224,6 +1224,8 @@ The Config Service serves property sources from `/{name}/{profile}/{label}`, whe
 * "profile" = `${spring.profiles.active}` (actually `Environment.getActiveProfiles()`)
 * "label" = "master"
 
+NOTE: When setting the property `${spring.application.name}` do not prefix your app name with the reserved word `application-` to prevent issues resolving the correct property source.
+
 You can override all of them by setting `spring.cloud.config.\*` (where `*` is `name`, `profile` or `label`).
 The `label` is useful for rolling back to previous versions of configuration.
 With the default Config Server implementation, it can be a git label, branch name, or commit ID.


### PR DESCRIPTION
add more documentation to not use application as a prefix for your application name as noted in issue #673 

add more info to the quickstart documentation to also mention how you configure your application name and the pitfalls

fixes gh-673