### PR TITLE
Read Gitee Push Hook contents as PropertyPathNotification

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.config.monitor;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -39,11 +41,29 @@ public class GiteePropertyPathNotificationExtractor
 	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
 			Map<String, Object> request) {
 		if (HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY))) {
-			if (request.get("commits") instanceof Collection &&
-					((Collection<Map<String, Object>>) request.get("commits")).size() > 0) {
-				return new PropertyPathNotification("application.yml");
+			if (request.get("commits") instanceof Collection) {
+				Set<String> paths = new HashSet<>();
+				@SuppressWarnings("unchecked")
+				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
+						.get("commits");
+				for (Map<String, Object> commit : commits) {
+					addAllPaths(paths, commit, "added");
+					addAllPaths(paths, commit, "removed");
+					addAllPaths(paths, commit, "modified");
+				}
+				if (!paths.isEmpty()) {
+					return new PropertyPathNotification(paths.toArray(new String[paths.size()]));
+				}
 			}
 		}
 		return null;
+	}
+
+	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
+		@SuppressWarnings("unchecked")
+		Collection<String> files = (Collection<String>) commit.get(name);
+		if (files != null) {
+			paths.addAll(files);
+		}
 	}
 }

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
@@ -38,7 +38,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 	private HttpHeaders headers = new HttpHeaders();
 
 	@Test
-	public void githubSample() throws Exception {
+	public void giteeExample() throws Exception {
 		// See http://git.mydoc.io/?t=154711
 		Map<String, Object> value = new ObjectMapper().readValue(
 				new ClassPathResource("gitee.json").getInputStream(),
@@ -47,7 +47,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 		this.headers.set("x-git-oschina-event", "Push Hook");
 		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
 		assertNotNull(extracted);
-		assertEquals("application.yml", extracted.getPaths()[0]);
+		assertEquals("d.txt", extracted.getPaths()[0]);
 	}
 
 	@Test

--- a/spring-cloud-config-monitor/src/test/resources/gitee.json
+++ b/spring-cloud-config-monitor/src/test/resources/gitee.json
@@ -24,7 +24,16 @@
       "name": "123",
       "email": "123@123.com",
       "time": "2016-12-09T17:28:02 08:00"
-    }
+    },
+    "added": [
+      "d.txt"
+    ],
+    "modified": [
+      "c.txt"
+    ],
+    "removed": [
+      "b.txt"
+    ]
   }],
   "total_commits_count": 1,
   "commits_more_than_ten": false,


### PR DESCRIPTION
Read Gitee Push Hook contents as PropertyPathNotification, instead of use the fixed `application.yml`

[Abount Gitee Web Hooks](http://git.mydoc.io/?t=154711)