### PR TITLE
Add too weak custom encryption exception

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -226,7 +226,7 @@ public class EncryptionController {
 	public ResponseEntity<Map<String, Object>> encryptionTooWeak() {
 		Map<String, Object> body = new HashMap<String, Object>();
 		body.put("status", "INVALID");
-		body.put("description", "Encryption method provided too weak");
+		body.put("description", "The encryption algorithm is not strong enough");
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -223,7 +223,7 @@ public class EncryptionController {
 	
 	@ExceptionHandler(EncryptionTooWeakException.class)
 	@ResponseBody
-	public ResponseEntity<Map<String, Object>> notInstalled() {
+	public ResponseEntity<Map<String, Object>> encryptionTooWeak() {
 		Map<String, Object> body = new HashMap<String, Object>();
 		body.put("status", "INVALID");
 		body.put("description", "Encryption method provided too weak");

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -163,10 +163,12 @@ public class EncryptionController {
 	}
 
 	private void checkEncryptorInstalled(String name, String profiles) {
-		if (this.encryptor == null
-				|| this.encryptor.locate(this.helper.getEncryptorKeys(name, profiles, ""))
-						.encrypt("FOO").equals("FOO")) {
+		if (this.encryptor == null) {
 			throw new KeyNotInstalledException();
+		}
+		if (this.encryptor.locate(this.helper.getEncryptorKeys(name, profiles, ""))
+				.encrypt("FOO").equals("FOO")) {
+			throw new EncryptionTooWeakException();
 		}
 	}
 
@@ -218,6 +220,15 @@ public class EncryptionController {
 		body.put("description", "No key was installed for encryption service");
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
 	}
+	
+	@ExceptionHandler(EncryptionTooWeakException.class)
+	@ResponseBody
+	public ResponseEntity<Map<String, Object>> notInstalled() {
+		Map<String, Object> body = new HashMap<String, Object>();
+		body.put("status", "INVALID");
+		body.put("description", "Encryption method provided too weak");
+		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+	}
 
 	@ExceptionHandler(InvalidCipherException.class)
 	@ResponseBody
@@ -236,6 +247,10 @@ class KeyNotInstalledException extends RuntimeException {
 
 @SuppressWarnings("serial")
 class KeyNotAvailableException extends RuntimeException {
+}
+
+@SuppressWarnings("serial")
+class EncryptionTooWeakException extends RuntimeException {
 }
 
 @SuppressWarnings("serial")

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerMultiTextEncryptorTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerMultiTextEncryptorTests.java
@@ -35,7 +35,7 @@ public class EncryptionControllerMultiTextEncryptorTests {
 				encrypted, TEXT_PLAIN));
 	}
 
-	@Test(expected = KeyNotInstalledException.class)
+	@Test(expected = EncryptionTooWeakException.class)
 	public void shouldNotEncryptUsingNoOp() {
 		// given
 		String application = "unknown";
@@ -46,7 +46,7 @@ public class EncryptionControllerMultiTextEncryptorTests {
 		// then exception is thrown
 	}
 
-	@Test(expected = KeyNotInstalledException.class)
+	@Test(expected = EncryptionTooWeakException.class)
 	public void shouldNotDecryptUsingNoOp() {
 		// given
 		String application = "unknown";

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
@@ -45,12 +45,12 @@ public class EncryptionControllerTests {
 	private EncryptionController controller = new EncryptionController(
 			new SingleTextEncryptorLocator(Encryptors.noOpText()));
 
-	@Test(expected = KeyNotInstalledException.class)
+	@Test(expected = EncryptionTooWeakException.class)
 	public void cannotDecryptWithoutKey() {
 		this.controller.decrypt("foo", MediaType.TEXT_PLAIN);
 	}
 
-	@Test(expected = KeyNotInstalledException.class)
+	@Test(expected = EncryptionTooWeakException.class)
 	public void cannotDecryptWithNoopEncryptor() {
 		this.controller.decrypt("foo", MediaType.TEXT_PLAIN);
 	}


### PR DESCRIPTION
If the encrypt method used in a custom TextEncryptor returns the same unencrypted text then a dedicated exception is thrown