### PR TITLE
Gitea and Gogs support + [Github|Gitlab|Gitee]PropertyPathNotificationExtractor refactor

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -124,6 +124,14 @@ To modify the startup behavior, you can change the location of the config server
 spring.cloud.config.uri: http://myconfigserver.com
 ----
 
+By default, if no application name is set, `application` will be used as the default. To modify the name, the following property can be added to the `bootstrap.properties` file:
+
+----
+spring.application.name: myapp
+----
+
+NOTE: When setting the property `${spring.application.name}` do not prefix your app name with the reserved word `application-` to prevent issues resolving the correct property source.
+
 The bootstrap properties show up in the `/env` endpoint as a high-priority property source, as shown in the following example.
 
 ----

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1224,6 +1224,8 @@ The Config Service serves property sources from `/{name}/{profile}/{label}`, whe
 * "profile" = `${spring.profiles.active}` (actually `Environment.getActiveProfiles()`)
 * "label" = "master"
 
+NOTE: When setting the property `${spring.application.name}` do not prefix your app name with the reserved word `application-` to prevent issues resolving the correct property source.
+
 You can override all of them by setting `spring.cloud.config.\*` (where `*` is `name`, `profile` or `label`).
 The `label` is useful for rolling back to previous versions of configuration.
 With the default Config Server implementation, it can be a git label, branch name, or commit ID.

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1135,7 +1135,7 @@ You can switch off the endpoints entirely by not using the `@EnableConfigServer`
 
 == Push Notifications and Spring Cloud Bus
 
-Many source code repository providers (such as Github, Gitlab, Gitee, or Bitbucket) notify you of changes in a repository through a webhook.
+Many source code repository providers (such as Github, Gitlab, Gitea, Gitee, Gogs, or Bitbucket) notify you of changes in a repository through a webhook.
 You can configure the webhook through the provider's user interface as a URL and a set of events in which you are interested.
 For instance, https://developer.github.com/v3/activity/events/types/#pushevent[Github] uses a POST to the webhook with a JSON body containing a list of commits and a header (`X-Github-Event`) set to `push`.
 If you add a dependency on the `spring-cloud-config-monitor` library and activate the Spring Cloud Bus in your Config Server, then a `/monitor` endpoint is enabled.
@@ -1145,7 +1145,7 @@ The change detection can be strategized.
 However, by default, it looks for changes in files that match the application name (for example, `foo.properties` is targeted at the `foo` application, while `application.properties` is targeted at all applications).
 The strategy to use when you want to override the behavior is `PropertyPathNotificationExtractor`, which accepts the request headers and body as parameters and returns a list of file paths that changed.
 
-The default configuration works out of the box with Github, Gitlab, Gitee, or Bitbucket.
+The default configuration works out of the box with Github, Gitlab, Gitea, Gitee, Gogs or Bitbucket.
 In addition to the JSON notifications from Github, Gitlab, Gitee, or Bitbucket, you can trigger a change notification by POSTing to `/monitor` with form-encoded body parameters in the pattern of `path={name}`.
 Doing so broadcasts to applications matching the `{name}` pattern (which can contain wildcards).
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-config</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.1.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Config</name>
 	<description>Spring Cloud Config</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>
@@ -22,7 +22,7 @@
 	</scm>
     <properties>
         <bintray.package>config</bintray.package>
-		<spring-cloud-commons.version>2.0.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
     </properties>
 	<modules>
 		<module>spring-cloud-config-dependencies</module>

--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
@@ -65,7 +65,7 @@ public class ConfigClientAutoConfiguration {
 	protected static class ConfigServerHealthIndicatorConfiguration {
 
 		@Bean
-		public ConfigServerHealthIndicator configServerHealthIndicator(
+		public ConfigServerHealthIndicator clientConfigServerHealthIndicator(
 				ConfigServicePropertySourceLocator locator,
 				ConfigClientHealthProperties properties, Environment environment) {
 			return new ConfigServerHealthIndicator(locator, environment, properties);

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/DiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.ServiceInstance;
@@ -29,11 +30,13 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.context.event.SmartApplicationListener;
 
 /**
  * Bootstrap configuration for a config client that wants to lookup the config server via
@@ -45,7 +48,7 @@ import org.springframework.context.event.EventListener;
 @Configuration
 @Import({ UtilAutoConfiguration.class })
 @EnableDiscoveryClient
-public class DiscoveryClientConfigServiceBootstrapConfiguration {
+public class DiscoveryClientConfigServiceBootstrapConfiguration implements SmartApplicationListener {
 
 	private static Log logger = LogFactory
 			.getLog(DiscoveryClientConfigServiceBootstrapConfiguration.class);
@@ -62,6 +65,21 @@ public class DiscoveryClientConfigServiceBootstrapConfiguration {
 	public ConfigServerInstanceProvider configServerInstanceProvider(
 			DiscoveryClient discoveryClient) {
 		return new ConfigServerInstanceProvider(discoveryClient);
+	}
+
+	@Override
+	public boolean supportsEventType(Class<? extends ApplicationEvent> eventType) {
+		return ContextRefreshedEvent.class.isAssignableFrom(eventType)
+				|| HeartbeatEvent.class.isAssignableFrom(eventType);
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		if (event instanceof ContextRefreshedEvent) {
+			startup((ContextRefreshedEvent) event);
+		} else if (event instanceof HeartbeatEvent) {
+			heartbeat((HeartbeatEvent) event);
+		}
 	}
 
 	@EventListener(ContextRefreshedEvent.class)

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/BaseDiscoveryClientConfigServiceBootstrapConfigurationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/BaseDiscoveryClientConfigServiceBootstrapConfigurationTests.java
@@ -9,7 +9,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -112,8 +112,8 @@ public abstract class BaseDiscoveryClientConfigServiceBootstrapConfigurationTest
 
 	void setup(String... env) {
 		this.context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(this.context, env);
-		EnvironmentTestUtils.addEnvironment(this.context, "eureka.client.enabled=false");
+		TestPropertyValues.of(env).applyTo(this.context);
+		TestPropertyValues.of("eureka.client.enabled=false").applyTo(this.context);
 		this.context.getDefaultListableBeanFactory().registerSingleton("discoveryClient",
 				this.client);
 		this.context.register(UtilAutoConfiguration.class,

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.config.client;
 
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.config.client.ConfigClientProperties.Credentials;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
@@ -122,7 +122,7 @@ public class ConfigClientPropertiesTests {
 	public void changeNameInOverride() {
 		locator.setName("one");
 		ConfigurableEnvironment environment = new StandardEnvironment();
-		EnvironmentTestUtils.addEnvironment(environment, "spring.application.name:two");
+		TestPropertyValues.of("spring.application.name:two").applyTo(environment);
 		ConfigClientProperties override = locator.override(environment);
 		assertEquals("two", override.getName());
 	}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfigurationTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServiceBootstrapConfigurationTest.java
@@ -20,7 +20,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,7 +54,7 @@ public class ConfigServiceBootstrapConfigurationTest {
 
     @Test
     public void overrideConfigServicePropertySourceLocatorWhenBeanIsProvided() {
-        EnvironmentTestUtils.addEnvironment(this.context, "spring.cloud.config.enabled=true");
+        TestPropertyValues.of("spring.cloud.config.enabled=true").applyTo(this.context);
         this.context.register(ConfigServicePropertySourceLocatorOverrideConfig.class);
         this.context.register(ConfigServiceBootstrapConfiguration.class);
         this.context.refresh();

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -1,10 +1,5 @@
 package org.springframework.cloud.config.client;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.HashMap;
@@ -12,13 +7,13 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hamcrest.core.IsInstanceOf;
-import org.hamcrest.core.IsNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator.GenericRequestHeaderInterceptor;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -34,12 +29,14 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.springframework.cloud.config.client.ConfigClientProperties.AUTHORIZATION;
 
 public class ConfigServicePropertySourceLocatorTests {
@@ -67,8 +64,8 @@ public class ConfigServicePropertySourceLocatorTests {
 		Environment body = new Environment("app", "master");
 		mockRequestResponseWithLabel(new ResponseEntity<>(body, HttpStatus.OK), "v1.0.0");
 		this.locator.setRestTemplate(this.restTemplate);
-		EnvironmentTestUtils.addEnvironment(this.environment,
-				"spring.cloud.config.label:v1.0.0");
+		TestPropertyValues.of("spring.cloud.config.label:v1.0.0")
+				.applyTo(this.environment);
 		assertNotNull(this.locator.locate(this.environment));
 	}
 
@@ -78,8 +75,8 @@ public class ConfigServicePropertySourceLocatorTests {
 		mockRequestResponseWithLabel(new ResponseEntity<>(body, HttpStatus.OK),
 				"release(_)v1.0.0");
 		this.locator.setRestTemplate(this.restTemplate);
-		EnvironmentTestUtils.addEnvironment(this.environment,
-				"spring.cloud.config.label:release/v1.0.0");
+		TestPropertyValues.of("spring.cloud.config.label:release/v1.0.0")
+				.applyTo(this.environment);
 		assertNotNull(this.locator.locate(this.environment));
 	}
 

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-config-dependencies</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.1.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-config-dependencies</name>
 	<description>Spring Cloud Config Dependencies</description>

--- a/spring-cloud-config-monitor/pom.xml
+++ b/spring-cloud-config-monitor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-config-monitor</artifactId>

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public abstract class BasePropertyPathNotificationExtractor
+		implements PropertyPathNotificationExtractor {
+
+	@Override
+	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
+			Map<String, Object> request) {
+		if (requestBelongsToGitRepoManager(headers)) {
+			if (request.get("commits") instanceof Collection) {
+				Set<String> paths = new HashSet<>();
+				@SuppressWarnings("unchecked")
+				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
+						.get("commits");
+				addPaths( paths, commits );
+				if (!paths.isEmpty()) {
+					return new PropertyPathNotification(paths.toArray(new String[0]));
+				}
+			}
+		}
+		return null;
+	}
+
+    protected void addPaths( Set< String > paths, Collection< Map< String, Object > > commits ) {
+        for (Map<String, Object> commit : commits) {
+        	addAllPaths(paths, commit, "added");
+        	addAllPaths(paths, commit, "removed");
+        	addAllPaths(paths, commit, "modified");
+        }
+    }
+
+	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
+		@SuppressWarnings("unchecked")
+		Collection<String> files = (Collection<String>) commit.get(name);
+		if (files != null) {
+			paths.addAll(files);
+		}
+	}
+    
+    protected abstract boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers);
+}

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfiguration.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfiguration.java
@@ -66,9 +66,21 @@ public class EnvironmentMonitorAutoConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gitea.enabled", havingValue="true", matchIfMissing=true)
+		public GiteaPropertyPathNotificationExtractor giteaPropertyPathNotificationExtractor() {
+			return new GiteaPropertyPathNotificationExtractor();
+		}
+
+		@Bean
 		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gitee.enabled", havingValue="true", matchIfMissing=true)
 		public GiteePropertyPathNotificationExtractor giteePropertyPathNotificationExtractor() {
 			return new GiteePropertyPathNotificationExtractor();
+		}
+
+		@Bean
+		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gogs.enabled", havingValue="true", matchIfMissing=true)
+		public GogsPropertyPathNotificationExtractor gogsPropertyPathNotificationExtractor() {
+			return new GogsPropertyPathNotificationExtractor();
 		}
 	}
 

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Juan Pablo Santos Rodríguez
+ *
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class GiteaPropertyPathNotificationExtractor
+		extends BasePropertyPathNotificationExtractor {
+
+	private static final String HEADERS_KEY = "X-Gitea-Event";
+
+	private static final String HEADERS_VALUE = "push";
+	
+	/**
+	 * gitea doesn't return which files have been added/modified/deleted yet.
+	 * 
+	 * @see https://github.com/go-gitea/gitea/issues/4313
+	 */
+	@Override
+	protected void addPaths(Set<String> paths, Collection<Map<String, Object>> commits) {
+	    paths.add( "application.yml" );
+	}
+
+	@Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
+}

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.Map;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -29,21 +26,14 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
 public class GiteePropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+		extends BasePropertyPathNotificationExtractor {
 
 	private static final String HEADERS_KEY = "x-git-oschina-event";
 
 	private static final String HEADERS_VALUE = "Push Hook";
 
 	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if (HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY))) {
-			if (request.get("commits") instanceof Collection &&
-					((Collection<Map<String, Object>>) request.get("commits")).size() > 0) {
-				return new PropertyPathNotification("application.yml");
-			}
-		}
-		return null;
-	}
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GithubPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GithubPropertyPathNotificationExtractor.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -31,36 +26,10 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 300)
 public class GithubPropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+		extends BasePropertyPathNotificationExtractor {
 
 	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if ("push".equals(headers.getFirst("X-Github-Event"))) {
-			if (request.get("commits") instanceof Collection) {
-				Set<String> paths = new HashSet<>();
-				@SuppressWarnings("unchecked")
-				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
-						.get("commits");
-				for (Map<String, Object> commit : commits) {
-					addAllPaths(paths, commit, "added");
-					addAllPaths(paths, commit, "removed");
-					addAllPaths(paths, commit, "modified");
-				}
-				if (!paths.isEmpty()) {
-					return new PropertyPathNotification(paths.toArray(new String[0]));
-				}
-			}
-		}
-		return null;
-	}
-
-	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
-		@SuppressWarnings("unchecked")
-		Collection<String> files = (Collection<String>) commit.get(name);
-		if (files != null) {
-			paths.addAll(files);
-		}
-	}
-
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return "push".equals(headers.getFirst("X-Github-Event"));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GitlabPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GitlabPropertyPathNotificationExtractor.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -31,35 +26,10 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
 public class GitlabPropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+		extends BasePropertyPathNotificationExtractor {
 
 	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if ("Push Hook".equals(headers.getFirst("X-Gitlab-Event"))) {
-			if (request.get("commits") instanceof Collection) {
-				Set<String> paths = new HashSet<>();
-				@SuppressWarnings("unchecked")
-				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
-						.get("commits");
-				for (Map<String, Object> commit : commits) {
-					addAllPaths(paths, commit, "added");
-					addAllPaths(paths, commit, "removed");
-					addAllPaths(paths, commit, "modified");
-				}
-				if (!paths.isEmpty()) {
-					return new PropertyPathNotification(paths.toArray(new String[0]));
-				}
-			}
-		}
-		return null;
-	}
-
-	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
-		@SuppressWarnings("unchecked")
-		Collection<String> files = (Collection<String>) commit.get(name);
-		if (files != null) {
-			paths.addAll(files);
-		}
-	}
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return "Push Hook".equals(headers.getFirst("X-Gitlab-Event"));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author lly835
+ *
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class GogsPropertyPathNotificationExtractor
+		extends BasePropertyPathNotificationExtractor {
+
+    private static final String HEADERS_KEY = "X-Gogs-Event";
+
+    private static final String HEADERS_VALUE = "push";
+
+    @Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
+}

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
@@ -47,7 +47,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1")
 						.run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
-		assertEquals(5,
+		assertEquals(7,
 				((Collection<?>) ReflectionTestUtils.getField(
 						ReflectionTestUtils.getField(endpoint, "extractor"),
 						"extractors")).size());
@@ -64,7 +64,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1")
 						.run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
-		assertEquals(6,
+		assertEquals(8,
 				((Collection<?>) ReflectionTestUtils.getField(
 						ReflectionTestUtils.getField(endpoint, "extractor"),
 						"extractors")).size());

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Juan Pablo Santos Rodríguez
+ *
+ */
+public class GiteaPropertyPathNotificationExtractorTests {
+
+	private GiteaPropertyPathNotificationExtractor extractor = new GiteaPropertyPathNotificationExtractor();
+
+	private HttpHeaders headers = new HttpHeaders();
+
+	@Test
+	public void giteaSample() throws Exception {
+	    // See https://docs.gitea.io/en-us/webhooks/
+        Map<String, Object> value = new ObjectMapper().readValue(
+				new ClassPathResource("gitea.json").getInputStream(),
+				new TypeReference<Map<String, Object>>() {
+				});
+		this.headers.set("X-Gitea-Event", "push");
+		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+		assertNotNull(extracted);
+		assertEquals("application.yml", extracted.getPaths()[0]);
+	}
+
+	@Test
+	public void notAPushNotDetected() throws Exception {
+		Map<String, Object> value = new ObjectMapper().readValue(
+				new ClassPathResource("gitea.json").getInputStream(),
+				new TypeReference<Map<String, Object>>() {
+				});
+		this.headers.set("X-Gitea-Event", "issues");
+		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+		assertNull(extracted);
+	}
+
+}

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
@@ -38,7 +38,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 	private HttpHeaders headers = new HttpHeaders();
 
 	@Test
-	public void githubSample() throws Exception {
+	public void giteeSample() throws Exception {
 		// See http://git.mydoc.io/?t=154711
 		Map<String, Object> value = new ObjectMapper().readValue(
 				new ClassPathResource("gitee.json").getInputStream(),

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
@@ -47,7 +47,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 		this.headers.set("x-git-oschina-event", "Push Hook");
 		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
 		assertNotNull(extracted);
-		assertEquals("application.yml", extracted.getPaths()[0]);
+		assertEquals("d.txt", extracted.getPaths()[0]);
 	}
 
 	@Test

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Craig Walls
+ *
+ */
+public class GogsPropertyPathNotificationExtractorTests {
+
+    private GogsPropertyPathNotificationExtractor extractor = new GogsPropertyPathNotificationExtractor();
+
+    private HttpHeaders headers = new HttpHeaders();
+
+    @Test
+    public void gogsSample() throws Exception {
+        // See https://gogs.io/docs/features/webhook
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gogs.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gogs-Event", "push");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNotNull(extracted);
+        assertEquals("README.md", extracted.getPaths()[0]);
+    }
+
+    @Test
+    public void notAPushNotDetected() throws Exception {
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gogs.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gogs-Event", "issues");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNull(extracted);
+    }
+
+}

--- a/spring-cloud-config-monitor/src/test/resources/gitea.json
+++ b/spring-cloud-config-monitor/src/test/resources/gitea.json
@@ -1,0 +1,81 @@
+{
+  "secret": "gitea_push",
+  "ref": "refs/heads/master",
+  "before": "70767b558d8f850eac3fead13dfc232d043646a0",
+  "after": "78b77379c448caf024c73fa280ca571449224590",
+  "compare_url": "http://gitea.lawyers.corp/internal/lawsuits/compare/70767b558d8f850eac3fead13dfc232d043646a0...78b77379c448caf024c73fa280ca571449224590",
+  "commits": [
+    {
+      "id": "78b77379c448caf024c73fa280ca571449224590",
+      "message": "SUPPORT-4765: urlencode\n",
+      "url": "http://gitea.lawyers.corp/internal/lawsuits/commit/78b77379c448caf024c73fa280ca571449224590",
+      "author": {
+        "name": "Perry Mason",
+        "email": "perrym@lawyers.corp",
+        "username": "git"
+      },
+      "committer": {
+        "name": "Perry Mason",
+        "email": "perrym@lawyers.corp",
+        "username": "git"
+      },
+      "verification": null,
+      "timestamp": "2018-08-27T11:18:34Z"
+    }
+  ],
+  "repository": {
+    "id": 480,
+    "owner": {
+      "id": 3,
+      "login": "internal",
+      "full_name": "",
+      "email": "",
+      "avatar_url": "http://gitea.lawyers.corp/avatars/dbc87f99ecd29cb0eb4447807ad73f9f",
+      "language": "",
+      "username": "internal"
+    },
+    "name": "lawsuits",
+    "full_name": "internal/lawsuits",
+    "description": "",
+    "empty": false,
+    "private": false,
+    "fork": false,
+    "parent": null,
+    "mirror": false,
+    "size": 5516,
+    "html_url": "http://gitea.lawyers.corp/internal/lawsuits",
+    "ssh_url": "git@localhost:internal/lawsuits.git",
+    "clone_url": "http://gitea.lawyers.corp/internal/lawsuits.git",
+    "website": "",
+    "stars_count": 1,
+    "forks_count": 20,
+    "watchers_count": 6,
+    "open_issues_count": 0,
+    "default_branch": "master",
+    "created_at": "2018-01-18T15:11:51Z",
+    "updated_at": "2018-08-27T11:18:34Z",
+    "permissions": {
+      "admin": false,
+      "push": false,
+      "pull": false
+    }
+  },
+  "pusher": {
+    "id": 2,
+    "login": "perrym",
+    "full_name": "Perry Mason",
+    "email": "perrym@lawyers.corp",
+    "avatar_url": "http://gitea.lawyers.corp/avatars/5868737ae078a4441031bf550d16e967",
+    "language": "en-US",
+    "username": "perrym"
+  },
+  "sender": {
+    "id": 2,
+    "login": "perrym",
+    "full_name": "Perry Mason",
+    "email": "perrym@lawyers.corp",
+    "avatar_url": "http://gitea.lawyers.corp/avatars/5868737ae078a4441031bf550d16e967",
+    "language": "en-US",
+    "username": "perrym"
+  }
+}

--- a/spring-cloud-config-monitor/src/test/resources/gitee.json
+++ b/spring-cloud-config-monitor/src/test/resources/gitee.json
@@ -24,7 +24,16 @@
       "name": "123",
       "email": "123@123.com",
       "time": "2016-12-09T17:28:02 08:00"
-    }
+    },
+    "added": [
+      "d.txt"
+    ],
+    "modified": [
+      "c.txt"
+    ],
+    "removed": [
+      "b.txt"
+    ]
   }],
   "total_commits_count": 1,
   "commits_more_than_ten": false,

--- a/spring-cloud-config-monitor/src/test/resources/gogs.json
+++ b/spring-cloud-config-monitor/src/test/resources/gogs.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/changes",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/spring-cloud-config-sample/pom.xml
+++ b/spring-cloud-config-sample/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -191,7 +191,7 @@ public class EnvironmentRepositoryConfiguration {
 }
 
 @Configuration
-@ConditionalOnMissingBean(value = EnvironmentRepository.class, search = SearchStrategy.CURRENT)
+@ConditionalOnMissingBean(value = EnvironmentRepository.class)//, search = SearchStrategy.CURRENT)
 class DefaultRepositoryConfiguration {
 	@Autowired
 	private ConfigurableEnvironment environment;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptor.java
@@ -64,8 +64,8 @@ public class CipherEnvironmentEncryptor implements EnvironmentEncryptor {
 			for (Map.Entry<Object, Object> entry : new LinkedHashSet<>(map.entrySet())) {
 				Object key = entry.getKey();
 				String name = key.toString();
-				String value = entry.getValue().toString();
-				if (value.startsWith("{cipher}")) {
+				if(entry.getValue() != null && entry.getValue().toString().startsWith("{cipher}")){
+					String value = entry.getValue().toString();
 					map.remove(key);
 					try {
 						value = value.substring("{cipher}".length());

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptorTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/CipherEnvironmentEncryptorTests.java
@@ -90,5 +90,18 @@ public class CipherEnvironmentEncryptorTests {
 		assertEquals(secret, this.encryptor.decrypt(environment).getPropertySources()
 				.get(0).getSource().get(environment.getName()));
 	}
+	@Test
+	public void shouldBeAbleToUseNullAsPropertyValue() {
+
+		// when
+		Environment environment = new Environment("name", "profile", "label");
+		environment.add(new PropertySource("a",
+				Collections.<Object, Object>singletonMap(environment.getName(),
+						null)));
+
+		// then
+		assertEquals(null, this.encryptor.decrypt(environment).getPropertySources()
+				.get(0).getSource().get(environment.getName()));
+	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
@@ -217,7 +217,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 		String defaultRepoUri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
 		expected.expectCause(ThrowableMessageMatcher
 				.hasMessage(containsString("Cannot write parent")));
-		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(false)
+		this.context = new SpringApplicationBuilder(TestConfiguration.class).web(WebApplicationType.NONE)
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri,
 						"spring.cloud.config.server.git.basedir:/tmp")
 				.run();

--- a/spring-cloud-starter-config/pom.xml
+++ b/spring-cloud-starter-config/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-starter-config</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.1.0.BUILD-SNAPSHOT</version>
 	<name>spring-cloud-starter-config</name>
 	<description>Spring Cloud Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>


### PR DESCRIPTION
Following the spring-cloud#1003 PR, I went on a likewise PR to add support for [Gitea](https://gitea.io), a Gogs fork.

On that PR there's a comment asking for a small refactor regarding Github and Gitlab PropertyPathNotificationExtractors so, given the reduced scope of the change, also went for it. As spring-cloud#1003 also includes the appropiate files for Gogs support, I also threw them in. And, likewise, GiteePropertyPathNotificationExtractor's spring-cloud#1107 PR.

So this PR ended up having:
* `[Github|Gitlab|Gitee]PropertyPathNotificationExtractor` common behaviour refactored into a `BasePropertyPathNotificationExtractor` class
* spring-cloud#1003 PR (Gogs support), refactored to reuse the `BasePropertyPathNotificationExtractor` class
* spring-cloud#1107 PR (Gitee using webhook contents as PropertyPathNotification), refactored to reuse the `BasePropertyPathNotificationExtractor` class
* Gitea support, using the `BasePropertyPathNotificationExtractor` class

I've mantained author tags on files regarding those PRs, in order to respect code authorship as much as possible (if there's anything missing, I'll gladly add whatever commits necessary). Also, as Github notes that those PRs are already mergeable, their corresponding authors must've signed the corresponding ICLAs, I assume this PR should be safe to merge.

Finally, as noted by the commit history, first batch of commits has been made with an account we use at work for certain tests, so there are subsequent commits rewritting commits' authorship with a "real" account. If needed, I can provide another PR with one squashed commit, I've chosen to send all the individual commits because it seems to me that this way is easier for review.

best regards,
juan pablo