### PR TITLE
Remove @ResponseBody when using ResponseEntity

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -92,7 +92,6 @@ public class EncryptionController {
 	}
 
 	@ExceptionHandler(KeyFormatException.class)
-	@ResponseBody
 	public ResponseEntity<Map<String, Object>> keyFormat() {
 		Map<String, Object> body = new HashMap<>();
 		body.put("status", "BAD_REQUEST");
@@ -101,9 +100,8 @@ public class EncryptionController {
 	}
 
 	@ExceptionHandler(KeyNotAvailableException.class)
-	@ResponseBody
 	public ResponseEntity<Map<String, Object>> keyUnavailable() {
-		Map<String, Object> body = new HashMap<String, Object>();
+		Map<String, Object> body = new HashMap<>();
 		body.put("status", "NOT_FOUND");
 		body.put("description", "No public key available");
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
@@ -112,7 +110,7 @@ public class EncryptionController {
 	@RequestMapping(value = "encrypt/status", method = RequestMethod.GET)
 	public Map<String, Object> status() {
 		checkEncryptorInstalled("application", "default");
-		return Collections.<String, Object>singletonMap("status", "OK");
+		return Collections.singletonMap("status", "OK");
 	}
 
 	@RequestMapping(value = "encrypt", method = RequestMethod.POST)
@@ -213,27 +211,24 @@ public class EncryptionController {
 	}
 
 	@ExceptionHandler(KeyNotInstalledException.class)
-	@ResponseBody
 	public ResponseEntity<Map<String, Object>> notInstalled() {
-		Map<String, Object> body = new HashMap<String, Object>();
+		Map<String, Object> body = new HashMap<>();
 		body.put("status", "NO_KEY");
 		body.put("description", "No key was installed for encryption service");
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
 	}
 	
 	@ExceptionHandler(EncryptionTooWeakException.class)
-	@ResponseBody
 	public ResponseEntity<Map<String, Object>> encryptionTooWeak() {
-		Map<String, Object> body = new HashMap<String, Object>();
+		Map<String, Object> body = new HashMap<>();
 		body.put("status", "INVALID");
 		body.put("description", "The encryption algorithm is not strong enough");
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
 	}
 
 	@ExceptionHandler(InvalidCipherException.class)
-	@ResponseBody
 	public ResponseEntity<Map<String, Object>> invalidCipher() {
-		Map<String, Object> body = new HashMap<String, Object>();
+		Map<String, Object> body = new HashMap<>();
 		body.put("status", "INVALID");
 		body.put("description", "Text not encrypted with this key");
 		return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
This PR removes `@ResponseBody` when using `ResponseEntity` as it's not necessary AFAICT.

Along the way, this PR also changes to use diamond operators for brevity.