### PR TITLE
Gitea and Gogs support + [Github|Gitlab|Gitee]PropertyPathNotificationExtractor refactor

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1135,7 +1135,7 @@ You can switch off the endpoints entirely by not using the `@EnableConfigServer`
 
 == Push Notifications and Spring Cloud Bus
 
-Many source code repository providers (such as Github, Gitlab, Gitee, or Bitbucket) notify you of changes in a repository through a webhook.
+Many source code repository providers (such as Github, Gitlab, Gitea, Gitee, Gogs, or Bitbucket) notify you of changes in a repository through a webhook.
 You can configure the webhook through the provider's user interface as a URL and a set of events in which you are interested.
 For instance, https://developer.github.com/v3/activity/events/types/#pushevent[Github] uses a POST to the webhook with a JSON body containing a list of commits and a header (`X-Github-Event`) set to `push`.
 If you add a dependency on the `spring-cloud-config-monitor` library and activate the Spring Cloud Bus in your Config Server, then a `/monitor` endpoint is enabled.
@@ -1145,7 +1145,7 @@ The change detection can be strategized.
 However, by default, it looks for changes in files that match the application name (for example, `foo.properties` is targeted at the `foo` application, while `application.properties` is targeted at all applications).
 The strategy to use when you want to override the behavior is `PropertyPathNotificationExtractor`, which accepts the request headers and body as parameters and returns a list of file paths that changed.
 
-The default configuration works out of the box with Github, Gitlab, Gitee, or Bitbucket.
+The default configuration works out of the box with Github, Gitlab, Gitea, Gitee, Gogs or Bitbucket.
 In addition to the JSON notifications from Github, Gitlab, Gitee, or Bitbucket, you can trigger a change notification by POSTing to `/monitor` with form-encoded body parameters in the pattern of `path={name}`.
 Doing so broadcasts to applications matching the `{name}` pattern (which can contain wildcards).
 
@@ -1223,6 +1223,8 @@ The Config Service serves property sources from `/{name}/{profile}/{label}`, whe
 * "name" = `${spring.application.name}`
 * "profile" = `${spring.profiles.active}` (actually `Environment.getActiveProfiles()`)
 * "label" = "master"
+
+NOTE: When setting the property `${spring.application.name}` do not prefix your app name with the reserved word `application-` to prevent issues resolving the correct property source.
 
 You can override all of them by setting `spring.cloud.config.\*` (where `*` is `name`, `profile` or `label`).
 The `label` is useful for rolling back to previous versions of configuration.

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public abstract class BasePropertyPathNotificationExtractor
+        implements PropertyPathNotificationExtractor {
+
+    @Override
+    public PropertyPathNotification extract(MultiValueMap<String, String> headers,
+            Map<String, Object> request) {
+        if (requestBelongsToGitRepoManager(headers)) {
+            if (request.get("commits") instanceof Collection) {
+                Set<String> paths = new HashSet<>();
+                @SuppressWarnings("unchecked")
+                Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
+                        .get("commits");
+                addPaths( paths, commits );
+                if (!paths.isEmpty()) {
+                    return new PropertyPathNotification(paths.toArray(new String[0]));
+                }
+            }
+        }
+        return null;
+    }
+
+    protected void addPaths(Set< String > paths, Collection< Map< String, Object > > commits) {
+        for (Map<String, Object> commit : commits) {
+            addAllPaths(paths, commit, "added");
+            addAllPaths(paths, commit, "removed");
+            addAllPaths(paths, commit, "modified");
+        }
+    }
+
+    private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
+        @SuppressWarnings("unchecked")
+        Collection<String> files = (Collection<String>) commit.get(name);
+        if (files != null) {
+            paths.addAll(files);
+        }
+    }
+    
+    protected abstract boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers);
+}

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfiguration.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfiguration.java
@@ -66,9 +66,21 @@ public class EnvironmentMonitorAutoConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gitea.enabled", havingValue="true", matchIfMissing=true)
+		public GiteaPropertyPathNotificationExtractor giteaPropertyPathNotificationExtractor() {
+			return new GiteaPropertyPathNotificationExtractor();
+		}
+
+		@Bean
 		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gitee.enabled", havingValue="true", matchIfMissing=true)
 		public GiteePropertyPathNotificationExtractor giteePropertyPathNotificationExtractor() {
 			return new GiteePropertyPathNotificationExtractor();
+		}
+
+		@Bean
+		@ConditionalOnProperty(value="spring.cloud.config.server.monitor.gogs.enabled", havingValue="true", matchIfMissing=true)
+		public GogsPropertyPathNotificationExtractor gogsPropertyPathNotificationExtractor() {
+			return new GogsPropertyPathNotificationExtractor();
 		}
 	}
 

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Juan Pablo Santos Rodríguez
+ *
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class GiteaPropertyPathNotificationExtractor
+        extends BasePropertyPathNotificationExtractor {
+
+    private static final String HEADERS_KEY = "X-Gitea-Event";
+
+    private static final String HEADERS_VALUE = "push";
+    
+    /**
+     * gitea doesn't return which files have been added/modified/deleted yet.
+     * 
+     * @see https://github.com/go-gitea/gitea/issues/4313
+     */
+    @Override
+    protected void addPaths(Set<String> paths, Collection<Map<String, Object>> commits) {
+        paths.add( "application.yml" );
+    }
+
+    @Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
+}

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractor.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.Map;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -29,21 +26,14 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
 public class GiteePropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+		extends BasePropertyPathNotificationExtractor {
 
 	private static final String HEADERS_KEY = "x-git-oschina-event";
 
 	private static final String HEADERS_VALUE = "Push Hook";
 
 	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if (HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY))) {
-			if (request.get("commits") instanceof Collection &&
-					((Collection<Map<String, Object>>) request.get("commits")).size() > 0) {
-				return new PropertyPathNotification("application.yml");
-			}
-		}
-		return null;
-	}
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GithubPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GithubPropertyPathNotificationExtractor.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -31,36 +26,10 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 300)
 public class GithubPropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+        extends BasePropertyPathNotificationExtractor {
 
-	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if ("push".equals(headers.getFirst("X-Github-Event"))) {
-			if (request.get("commits") instanceof Collection) {
-				Set<String> paths = new HashSet<>();
-				@SuppressWarnings("unchecked")
-				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
-						.get("commits");
-				for (Map<String, Object> commit : commits) {
-					addAllPaths(paths, commit, "added");
-					addAllPaths(paths, commit, "removed");
-					addAllPaths(paths, commit, "modified");
-				}
-				if (!paths.isEmpty()) {
-					return new PropertyPathNotification(paths.toArray(new String[0]));
-				}
-			}
-		}
-		return null;
-	}
-
-	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
-		@SuppressWarnings("unchecked")
-		Collection<String> files = (Collection<String>) commit.get(name);
-		if (files != null) {
-			paths.addAll(files);
-		}
-	}
-
+    @Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return "push".equals(headers.getFirst("X-Github-Event"));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GitlabPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GitlabPropertyPathNotificationExtractor.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.config.monitor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.MultiValueMap;
@@ -31,35 +26,10 @@ import org.springframework.util.MultiValueMap;
  */
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
 public class GitlabPropertyPathNotificationExtractor
-		implements PropertyPathNotificationExtractor {
+        extends BasePropertyPathNotificationExtractor {
 
-	@Override
-	public PropertyPathNotification extract(MultiValueMap<String, String> headers,
-			Map<String, Object> request) {
-		if ("Push Hook".equals(headers.getFirst("X-Gitlab-Event"))) {
-			if (request.get("commits") instanceof Collection) {
-				Set<String> paths = new HashSet<>();
-				@SuppressWarnings("unchecked")
-				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
-						.get("commits");
-				for (Map<String, Object> commit : commits) {
-					addAllPaths(paths, commit, "added");
-					addAllPaths(paths, commit, "removed");
-					addAllPaths(paths, commit, "modified");
-				}
-				if (!paths.isEmpty()) {
-					return new PropertyPathNotification(paths.toArray(new String[0]));
-				}
-			}
-		}
-		return null;
-	}
-
-	private void addAllPaths(Set<String> paths, Map<String, Object> commit, String name) {
-		@SuppressWarnings("unchecked")
-		Collection<String> files = (Collection<String>) commit.get(name);
-		if (files != null) {
-			paths.addAll(files);
-		}
-	}
+    @Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return "Push Hook".equals(headers.getFirst("X-Gitlab-Event"));
+    }
 }

--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author lly835
+ *
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class GogsPropertyPathNotificationExtractor
+        extends BasePropertyPathNotificationExtractor {
+
+    private static final String HEADERS_KEY = "X-Gogs-Event";
+
+    private static final String HEADERS_VALUE = "push";
+
+    @Override
+    protected boolean requestBelongsToGitRepoManager(MultiValueMap<String, String> headers) {
+        return HEADERS_VALUE.equals(headers.getFirst(HEADERS_KEY));
+    }
+}

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
@@ -47,7 +47,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1")
 						.run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
-		assertEquals(5,
+		assertEquals(7,
 				((Collection<?>) ReflectionTestUtils.getField(
 						ReflectionTestUtils.getField(endpoint, "extractor"),
 						"extractors")).size());
@@ -64,7 +64,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1")
 						.run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
-		assertEquals(6,
+		assertEquals(8,
 				((Collection<?>) ReflectionTestUtils.getField(
 						ReflectionTestUtils.getField(endpoint, "extractor"),
 						"extractors")).size());

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteaPropertyPathNotificationExtractorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Juan Pablo Santos Rodríguez
+ *
+ */
+public class GiteaPropertyPathNotificationExtractorTests {
+
+    private GiteaPropertyPathNotificationExtractor extractor = new GiteaPropertyPathNotificationExtractor();
+
+    private HttpHeaders headers = new HttpHeaders();
+
+    @Test
+    public void giteaSample() throws Exception {
+        // See https://docs.gitea.io/en-us/webhooks/
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gitea.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gitea-Event", "push");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNotNull(extracted);
+        assertEquals("application.yml", extracted.getPaths()[0]);
+    }
+
+    @Test
+    public void notAPushNotDetected() throws Exception {
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gitea.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gitea-Event", "issues");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNull(extracted);
+    }
+
+}

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GiteePropertyPathNotificationExtractorTests.java
@@ -38,7 +38,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 	private HttpHeaders headers = new HttpHeaders();
 
 	@Test
-	public void githubSample() throws Exception {
+	public void giteeSample() throws Exception {
 		// See http://git.mydoc.io/?t=154711
 		Map<String, Object> value = new ObjectMapper().readValue(
 				new ClassPathResource("gitee.json").getInputStream(),
@@ -47,7 +47,7 @@ public class GiteePropertyPathNotificationExtractorTests {
 		this.headers.set("x-git-oschina-event", "Push Hook");
 		PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
 		assertNotNull(extracted);
-		assertEquals("application.yml", extracted.getPaths()[0]);
+		assertEquals("d.txt", extracted.getPaths()[0]);
 	}
 
 	@Test

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/GogsPropertyPathNotificationExtractorTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.monitor;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Craig Walls
+ *
+ */
+public class GogsPropertyPathNotificationExtractorTests {
+
+    private GogsPropertyPathNotificationExtractor extractor = new GogsPropertyPathNotificationExtractor();
+
+    private HttpHeaders headers = new HttpHeaders();
+
+    @Test
+    public void gogsSample() throws Exception {
+        // See https://gogs.io/docs/features/webhook
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gogs.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gogs-Event", "push");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNotNull(extracted);
+        assertEquals("README.md", extracted.getPaths()[0]);
+    }
+
+    @Test
+    public void notAPushNotDetected() throws Exception {
+        Map<String, Object> value = new ObjectMapper().readValue(
+                new ClassPathResource("gogs.json").getInputStream(),
+                new TypeReference<Map<String, Object>>() {
+                });
+        this.headers.set("X-Gogs-Event", "issues");
+        PropertyPathNotification extracted = this.extractor.extract(this.headers, value);
+        assertNull(extracted);
+    }
+
+}

--- a/spring-cloud-config-monitor/src/test/resources/gitea.json
+++ b/spring-cloud-config-monitor/src/test/resources/gitea.json
@@ -1,0 +1,81 @@
+{
+  "secret": "gitea_push",
+  "ref": "refs/heads/master",
+  "before": "70767b558d8f850eac3fead13dfc232d043646a0",
+  "after": "78b77379c448caf024c73fa280ca571449224590",
+  "compare_url": "http://gitea.lawyers.corp/internal/lawsuits/compare/70767b558d8f850eac3fead13dfc232d043646a0...78b77379c448caf024c73fa280ca571449224590",
+  "commits": [
+    {
+      "id": "78b77379c448caf024c73fa280ca571449224590",
+      "message": "SUPPORT-4765: urlencode\n",
+      "url": "http://gitea.lawyers.corp/internal/lawsuits/commit/78b77379c448caf024c73fa280ca571449224590",
+      "author": {
+        "name": "Perry Mason",
+        "email": "perrym@lawyers.corp",
+        "username": "git"
+      },
+      "committer": {
+        "name": "Perry Mason",
+        "email": "perrym@lawyers.corp",
+        "username": "git"
+      },
+      "verification": null,
+      "timestamp": "2018-08-27T11:18:34Z"
+    }
+  ],
+  "repository": {
+    "id": 480,
+    "owner": {
+      "id": 3,
+      "login": "internal",
+      "full_name": "",
+      "email": "",
+      "avatar_url": "http://gitea.lawyers.corp/avatars/dbc87f99ecd29cb0eb4447807ad73f9f",
+      "language": "",
+      "username": "internal"
+    },
+    "name": "lawsuits",
+    "full_name": "internal/lawsuits",
+    "description": "",
+    "empty": false,
+    "private": false,
+    "fork": false,
+    "parent": null,
+    "mirror": false,
+    "size": 5516,
+    "html_url": "http://gitea.lawyers.corp/internal/lawsuits",
+    "ssh_url": "git@localhost:internal/lawsuits.git",
+    "clone_url": "http://gitea.lawyers.corp/internal/lawsuits.git",
+    "website": "",
+    "stars_count": 1,
+    "forks_count": 20,
+    "watchers_count": 6,
+    "open_issues_count": 0,
+    "default_branch": "master",
+    "created_at": "2018-01-18T15:11:51Z",
+    "updated_at": "2018-08-27T11:18:34Z",
+    "permissions": {
+      "admin": false,
+      "push": false,
+      "pull": false
+    }
+  },
+  "pusher": {
+    "id": 2,
+    "login": "perrym",
+    "full_name": "Perry Mason",
+    "email": "perrym@lawyers.corp",
+    "avatar_url": "http://gitea.lawyers.corp/avatars/5868737ae078a4441031bf550d16e967",
+    "language": "en-US",
+    "username": "perrym"
+  },
+  "sender": {
+    "id": 2,
+    "login": "perrym",
+    "full_name": "Perry Mason",
+    "email": "perrym@lawyers.corp",
+    "avatar_url": "http://gitea.lawyers.corp/avatars/5868737ae078a4441031bf550d16e967",
+    "language": "en-US",
+    "username": "perrym"
+  }
+}

--- a/spring-cloud-config-monitor/src/test/resources/gitee.json
+++ b/spring-cloud-config-monitor/src/test/resources/gitee.json
@@ -24,7 +24,16 @@
       "name": "123",
       "email": "123@123.com",
       "time": "2016-12-09T17:28:02 08:00"
-    }
+    },
+    "added": [
+      "d.txt"
+    ],
+    "modified": [
+      "c.txt"
+    ],
+    "removed": [
+      "b.txt"
+    ]
   }],
   "total_commits_count": 1,
   "commits_more_than_ten": false,

--- a/spring-cloud-config-monitor/src/test/resources/gogs.json
+++ b/spring-cloud-config-monitor/src/test/resources/gogs.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/changes",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
(new, clean PR from required changes on [#1120](https://github.com/spring-cloud/spring-cloud-config/pull/1120#issuecomment-419998469), also having a clean history for merge)

Following the spring-cloud#1003 PR, I went on a likewise PR to add support for [Gitea](https://gitea.io), a Gogs fork.

On that PR there's a comment asking for a small refactor regarding Github and Gitlab PropertyPathNotificationExtractors so, given the reduced scope of the change, also went for it. As spring-cloud#1003 also includes the appropiate files for Gogs support, I also threw them in. And, likewise, GiteePropertyPathNotificationExtractor's spring-cloud#1107 PR.

So this PR ended up having:
* `[Github|Gitlab|Gitee]PropertyPathNotificationExtractor` common behaviour refactored into a `BasePropertyPathNotificationExtractor` class
* spring-cloud#1003 PR (Gogs support), refactored to reuse the `BasePropertyPathNotificationExtractor` class
* spring-cloud#1107 PR (Gitee using webhook contents as PropertyPathNotification), refactored to reuse the `BasePropertyPathNotificationExtractor` class
* Gitea support, using the `BasePropertyPathNotificationExtractor` class

I've mantained author tags on files regarding those PRs, in order to respect code authorship as much as possible (if there's anything missing, I'll gladly add whatever commits necessary). Also, as Github notes that those PRs are already mergeable, their corresponding authors must've signed the corresponding ICLAs, I assume this PR should be safe to merge.


best regards,
juan pablo