### PR TITLE
Refactor String#replaceAll

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitSkipSslValidationCredentialsProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitSkipSslValidationCredentialsProvider.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.config.server.support;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.internal.JGitText;
@@ -36,6 +37,8 @@ import org.eclipse.jgit.transport.URIish;
  * @author Gareth Clay
  */
 public class GitSkipSslValidationCredentialsProvider extends CredentialsProvider {
+
+	private static final Pattern FORMAT_PLACEHOLDER_PATTERN = Pattern.compile("\\s*\\{\\d}\\s*");
 
 	private final CredentialsProvider delegate;
 
@@ -128,6 +131,6 @@ public class GitSkipSslValidationCredentialsProvider extends CredentialsProvider
 	}
 
 	private static String stripFormattingPlaceholders(String string) {
-		return string.replaceAll("\\s*\\{\\d}\\s*", "");
+		return FORMAT_PLACEHOLDER_PATTERN.matcher(string).replaceAll("");
 	}
 }


### PR DESCRIPTION
If we repeatedly call String#replaceAll, we internally repeatedly call the regular expression pattern compilation every time as following:

```java
    public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```
The modifications are to keep the compiled pattern.
Therefore, compiling a relatively expensive regular expression pattern does not have to be done every time.