### PR TITLE
Fix GitCredentialsProviderFactory

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
@@ -96,12 +96,14 @@ public class GitCredentialsProviderFactory {
 			logger.debug("Constructing PassphraseCredentialsProvider for URI " + uri);
 			provider = new PassphraseCredentialsProvider(passphrase);
 		}
-		else if (skipSslValidation && GitSkipSslValidationCredentialsProvider.canHandle(uri)) {
+
+		if (skipSslValidation && GitSkipSslValidationCredentialsProvider.canHandle(uri)) {
 			logger.debug("Constructing GitSkipSslValidationCredentialsProvider for URI "
 					+ uri);
 			provider = new GitSkipSslValidationCredentialsProvider(provider);
 		}
-		else {
+
+		if (provider == null) {
 			logger.debug("No credentials provider required for URI " + uri);
 		}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
@@ -96,8 +96,7 @@ public class GitCredentialsProviderFactory {
 			logger.debug("Constructing PassphraseCredentialsProvider for URI " + uri);
 			provider = new PassphraseCredentialsProvider(passphrase);
 		}
-
-		if (skipSslValidation && GitSkipSslValidationCredentialsProvider.canHandle(uri)) {
+		else if (skipSslValidation && GitSkipSslValidationCredentialsProvider.canHandle(uri)) {
 			logger.debug("Constructing GitSkipSslValidationCredentialsProvider for URI "
 					+ uri);
 			provider = new GitSkipSslValidationCredentialsProvider(provider);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/GitCredentialsProviderFactoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/GitCredentialsProviderFactoryTests.java
@@ -90,6 +90,13 @@ public class GitCredentialsProviderFactoryTests {
 	}
 
 	@Test
+	public void testEmptyProvider(){
+		CredentialsProvider provider = factory.createFor(HTTPS_GIT_REPO, USER, PASSWORD,
+														 null, true);
+
+	}
+
+	@Test
 	public void testCreateForHttpsServerWithoutSpecifyingSkipSslValidation() {
 		CredentialsProvider provider = factory.createFor(HTTPS_GIT_REPO, USER, PASSWORD, null);
 		assertNotNull(provider);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/GitCredentialsProviderFactoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/GitCredentialsProviderFactoryTests.java
@@ -90,13 +90,6 @@ public class GitCredentialsProviderFactoryTests {
 	}
 
 	@Test
-	public void testEmptyProvider(){
-		CredentialsProvider provider = factory.createFor(HTTPS_GIT_REPO, USER, PASSWORD,
-														 null, true);
-
-	}
-
-	@Test
 	public void testCreateForHttpsServerWithoutSpecifyingSkipSslValidation() {
 		CredentialsProvider provider = factory.createFor(HTTPS_GIT_REPO, USER, PASSWORD, null);
 		assertNotNull(provider);


### PR DESCRIPTION
I Found wrong debug message During setting my spring cloud config server. 
The original source will output a unexpected debug message ("No credentials provider required For URI") if skipSslValidation is false or GitSkipSslValidationCredentialsProvider.canHandle (uri) is false.
Even if there are other provider like a PassphraseCredentialsProvider

