### PR TITLE
Make 'JGitEnvironmentRepository.JGitFactory' public

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -686,7 +686,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	 * Wraps the static method calls to {@link org.eclipse.jgit.api.Git} and
 	 * {@link org.eclipse.jgit.api.CloneCommand} allowing for easier unit testing.
 	 */
-	static class JGitFactory {
+	public static class JGitFactory {
 
 		public Git getGitByOpen(File file) throws IOException {
 			Git git = Git.open(file);


### PR DESCRIPTION
I want to set 'CloneCommand.cloneSubmodules' to 'true', but I can not find any customizable points. There is a 'setGitFactory(JGitFactory)' method in the 'JGitEnvironmentRepository' class, but I can not create an instance of type 'JGitFactory' in my package.