### PR TITLE
Fix error in fail-fast doc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1237,7 +1237,7 @@ If this is the desired behavior, set the bootstrap configuration property `sprin
 === Config Client Retry
 
 If you expect that the config server may occasionally be unavailable when your application starts, you can make it keep trying after a failure.
-First, you need to set `spring.cloud.config.fail-fast=true`.
+First, you need to set `spring.cloud.config.fail-fast=false`.
 Then you need to add `spring-retry` and `spring-boot-starter-aop` to your classpath.
 The default behavior is to retry six times with an initial backoff interval of 1000ms and an exponential multiplier of 1.1 for subsequent backoffs.
 You can configure these properties (and others) by setting the `spring.cloud.config.retry.*` configuration properties.


### PR DESCRIPTION
I'm not familiar with the code base, but I believe that the value of fail-fast flag is documented incorrectly.
My understanding is that:
**fail-fast: true** - no retry
**fail-fast: false** - retry