### PR TITLE
Git Backup Repository by configuration parameter backup-uri *use a backup git repository*

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-config</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.0.2.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Config</name>
 	<description>Spring Cloud Config</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.0.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>
@@ -22,7 +22,7 @@
 	</scm>
     <properties>
         <bintray.package>config</bintray.package>
-		<spring-cloud-commons.version>2.0.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>2.0.2.RELEASE</spring-cloud-commons.version>
     </properties>
 	<modules>
 		<module>spring-cloud-config-dependencies</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-config</artifactId>
-	<version>2.0.2.RELEASE</version>
+	<version>2.0.2.HWL.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Config</name>
 	<description>Spring Cloud Config</description>

--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-config-dependencies</artifactId>
-	<version>2.0.2.RELEASE</version>
+	<version>2.0.2.HWL.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-config-dependencies</name>
 	<description>Spring Cloud Config Dependencies</description>

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.0.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-config-dependencies</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.0.2.RELEASE</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-config-dependencies</name>
 	<description>Spring Cloud Config Dependencies</description>

--- a/spring-cloud-config-monitor/pom.xml
+++ b/spring-cloud-config-monitor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-config-monitor</artifactId>
@@ -13,7 +13,7 @@
 	<description>Spring Cloud Config Monitor</description>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
-		<spring-cloud-bus.version>2.0.1.BUILD-SNAPSHOT</spring-cloud-bus.version>
+		<spring-cloud-bus.version>2.0.0.RELEASE</spring-cloud-bus.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-config-monitor/pom.xml
+++ b/spring-cloud-config-monitor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-config-monitor</artifactId>

--- a/spring-cloud-config-sample/pom.xml
+++ b/spring-cloud-config-sample/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-sample/pom.xml
+++ b/spring-cloud-config-sample/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -2,17 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
 	<artifactId>spring-cloud-config-server</artifactId>
 	<packaging>jar</packaging>
-
 	<name>spring-cloud-config-server</name>
 	<description>spring-cloud-config-server</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -93,6 +91,10 @@
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit.junit.http</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-config-client</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -98,7 +98,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-cloud.version>${project.version}</spring-cloud.version>
+		<spring-cloud.version>Finchley.SR2</spring-cloud.version>
 		<start-class>org.springframework.cloud.config.server.ConfigServerApplication</start-class>
 	</properties>
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -234,7 +234,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
     }
 
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public synchronized void afterPropertiesSet() throws Exception {
         Assert.state(getUri() != null,
                 MESSAGE);
         initialize();
@@ -702,7 +702,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
      * Wraps the static method calls to {@link org.eclipse.jgit.api.Git} and
      * {@link org.eclipse.jgit.api.CloneCommand} allowing for easier unit testing.
      */
-    static class JGitFactory {
+    public static class JGitFactory {
 
         public Git getGitByOpen(File file) throws IOException {
             Git git = Git.open(file);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -574,6 +574,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 			return clone.call();
 		}
 		catch (GitAPIException e) {
+			logger.warn("Error occured cloning to base directory.", e);
 			deleteBaseDirIfExists();
 			throw e;
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -62,18 +62,18 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
     private static final String LOCAL_BRANCH_REF_PREFIX = "refs/remotes/origin/";
 
-    /*
-    * Is the Backup Repository in use?
+    /**
+     * Is the Backup Repository in use?
      */
     private Boolean backupRepoInUse = false;
 
-    /*
-    *  Since when the backup repo is in usage
+    /**
+     *  Since when the backup repo is in usage
      */
     private long backupInUseTimestamp = 0;
 
-    /*
-    * Time to check if the main repo is available
+    /**
+     * Time to check if the main repo is available
      */
     private long mainRepoCheckCoolDown = 60 * 1000;
 
@@ -258,7 +258,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
                 // checkout after fetch so we can get any new branches, tags, ect.
                 checkout(git, label);
                 tryMerge(git, label);
-            } else {
+            }
+            else {
                 // nothing to update so just checkout and merge.
                 // Merge because remote branch could have been updated before
                 checkout(git, label);
@@ -266,21 +267,27 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
             }
             // always return what is currently HEAD as the version
             return git.getRepository().findRef("HEAD").getObjectId().getName();
-        } catch (RefNotFoundException e) {
+        }
+        catch (RefNotFoundException e) {
             throw new NoSuchLabelException("No such label: " + label, e);
-        } catch (NoRemoteRepositoryException e) {
+        }
+        catch (NoRemoteRepositoryException e) {
             throw new NoSuchRepositoryException("No such repository: " + getUri(), e);
-        } catch (GitAPIException e) {
+        }
+        catch (GitAPIException e) {
             throw new NoSuchRepositoryException(
                     "Cannot clone or checkout repository: " + getUri(), e);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new IllegalStateException("Cannot load environment", e);
-        } finally {
+        }
+        finally {
             try {
                 if (git != null) {
                     git.close();
                 }
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 this.logger.warn("Could not close git repository", e);
             }
         }
@@ -297,7 +304,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
                     resetHard(git, label, LOCAL_BRANCH_REF_PREFIX + label);
                 }
             }
-        } catch (GitAPIException e) {
+        }
+        catch (GitAPIException e) {
             throw new NoSuchRepositoryException(
                     "Cannot clone or checkout repository: " + getUri(), e);
         }
@@ -377,7 +385,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
         CheckoutCommand checkout = git.checkout();
         if (shouldTrack(git, label)) {
             trackBranch(git, checkout, label);
-        } else {
+        }
+        else {
             // works for tags and local branches
             checkout.setName(label);
         }
@@ -399,7 +408,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
         if (this.forcePull && !isWorkingTreeClean) {
             shouldPull = true;
             logDirty(gitStatus);
-        } else {
+        }
+        else {
             shouldPull = isWorkingTreeClean && originUrl != null;
         }
         if (!isWorkingTreeClean && !this.forcePull) {
@@ -448,7 +458,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
                         + result.getTrackingRefUpdates().size() + " updates");
             }
             return result;
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             String message = "Could not fetch remote for " + label + " remote: " + git
                     .getRepository().getConfig().getString("remote", "origin", "url");
             warn(message, ex);
@@ -466,7 +477,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
                         + result.getMergeStatus());
             }
             return result;
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             String message = "Could not merge remote for " + label + " remote: " + git
                     .getRepository().getConfig().getString("remote", "origin", "url");
             warn(message, ex);
@@ -485,7 +497,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
                         "Reset label " + label + " to version " + resetRef.getObjectId());
             }
             return resetRef;
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             String message = "Could not reset to remote for " + label + " (current ref="
                     + ref + "), remote: " + git.getRepository().getConfig()
                     .getString("remote", "origin", "url");
@@ -530,7 +543,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
         Assert.state(getBasedir().exists(), "Could not create basedir: " + getBasedir());
         if (getUri().startsWith(FILE_URI_PREFIX)) {
             return copyFromLocalRepository();
-        } else {
+        }
+        else {
             return cloneToBasedir();
         }
     }
@@ -587,7 +601,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
             for (File file : getBasedir().listFiles()) {
                 try {
                     FileUtils.delete(file, FileUtils.RECURSIVE);
-                } catch (IOException e) {
+                }
+                catch (IOException e) {
                     throw new IllegalStateException("Failed to initialize base directory",
                             e);
                 }
@@ -630,7 +645,8 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
             BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(git.getRepository(), label);
             boolean isBranchAhead = trackingStatus != null && trackingStatus.getAheadCount() > 0;
             return status.call().isClean() && !isBranchAhead;
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             String message = "Could not execute status command on local repository. Cause: ("
                     + e.getClass().getSimpleName() + ") " + e.getMessage();
             warn(message, e);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -15,47 +15,19 @@
  */
 package org.springframework.cloud.config.server.environment;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.jcraft.jsch.Session;
-import org.eclipse.jgit.api.CheckoutCommand;
-import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode;
-import org.eclipse.jgit.api.DeleteBranchCommand;
-import org.eclipse.jgit.api.FetchCommand;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.ListBranchCommand.ListMode;
-import org.eclipse.jgit.api.MergeCommand;
-import org.eclipse.jgit.api.MergeResult;
-import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
-import org.eclipse.jgit.api.Status;
-import org.eclipse.jgit.api.StatusCommand;
-import org.eclipse.jgit.api.TransportCommand;
-import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.errors.NoRemoteRepositoryException;
 import org.eclipse.jgit.lib.BranchTrackingStatus;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.FetchResult;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.*;
 import org.eclipse.jgit.transport.OpenSshConfig.Host;
-import org.eclipse.jgit.transport.ReceiveCommand;
-import org.eclipse.jgit.transport.SshSessionFactory;
-import org.eclipse.jgit.transport.TagOpt;
-import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.util.FileUtils;
-
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.config.server.support.GitCredentialsProviderFactory;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -63,6 +35,10 @@ import org.springframework.core.io.UrlResource;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 import static java.lang.String.format;
 import static org.eclipse.jgit.transport.ReceiveCommand.Type.DELETE;
@@ -78,624 +54,648 @@ import static org.eclipse.jgit.transport.ReceiveCommand.Type.DELETE;
  * @author Gareth Clay
  */
 public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
-		implements EnvironmentRepository, SearchPathLocator, InitializingBean {
-
-	public static final String MESSAGE = "You need to configure a uri for the git repository.";
-
-	private static final String FILE_URI_PREFIX = "file:";
-
-	private static final String LOCAL_BRANCH_REF_PREFIX = "refs/remotes/origin/";
-
-	/**
-	 * Timeout (in seconds) for obtaining HTTP or SSH connection (if applicable). Default
-	 * 5 seconds.
-	 */
-	private int timeout;
-
-	/**
-	 * Time (in seconds) between refresh of the git repository
-	 */
-	private int refreshRate = 0;
-
-	/**
-	 * Time of the last refresh of the git repository
-	 */
-	private long lastRefresh;
-
-	/**
-	 * Flag to indicate that the repository should be cloned on startup (not on demand).
-	 * Generally leads to slower startup but faster first query.
-	 */
-	private boolean cloneOnStart;
-
-	private JGitEnvironmentRepository.JGitFactory gitFactory = new JGitEnvironmentRepository.JGitFactory();
-
-	private String defaultLabel;
-
-	/**
-	 * Factory used to create the credentials provider to use to connect to the Git
-	 * repository.
-	 */
-	private GitCredentialsProviderFactory gitCredentialsProviderFactory = new GitCredentialsProviderFactory();
-
-	/**
-	 * Transport configuration callback for JGit commands.
-	 */
-	private TransportConfigCallback transportConfigCallback;
-
-	/**
-	 * Flag to indicate that the repository should force pull. If true discard any local
-	 * changes and take from remote repository.
-	 */
-	private boolean forcePull;
-	private boolean initialized;
-
-	/**
-	 * Flag to indicate that the branch should be deleted locally if it's origin tracked branch was removed.
-	 */
-	private boolean deleteUntrackedBranches;
-
-	/**
-	 * Flag to indicate that SSL certificate validation should be bypassed when
-	 * communicating with a repository served over an HTTPS connection.
-	 */
-	private boolean skipSslValidation;
-
-	public JGitEnvironmentRepository(ConfigurableEnvironment environment, JGitEnvironmentProperties properties) {
-		super(environment, properties);
-		this.cloneOnStart = properties.isCloneOnStart();
-		this.defaultLabel = properties.getDefaultLabel();
-		this.forcePull = properties.isForcePull();
-		this.timeout = properties.getTimeout();
-		this.deleteUntrackedBranches = properties.isDeleteUntrackedBranches();
-		this.refreshRate = properties.getRefreshRate();
-		this.skipSslValidation = properties.isSkipSslValidation();
-	}
-
-	public boolean isCloneOnStart() {
-		return this.cloneOnStart;
-	}
-
-	public void setCloneOnStart(boolean cloneOnStart) {
-		this.cloneOnStart = cloneOnStart;
-	}
-
-	public int getTimeout() {
-		return this.timeout;
-	}
-
-	public void setTimeout(int timeout) {
-		this.timeout = timeout;
-	}
-
-	public int getRefreshRate() {
-		return refreshRate;
-	}
-
-	public void setRefreshRate(int refreshRate) {
-		this.refreshRate = refreshRate;
-	}
-
-
-	public TransportConfigCallback getTransportConfigCallback() {
-		return transportConfigCallback;
-	}
-
-	public void setTransportConfigCallback(
-			TransportConfigCallback transportConfigCallback) {
-		this.transportConfigCallback = transportConfigCallback;
-	}
-
-	public JGitFactory getGitFactory() {
-		return this.gitFactory;
-	}
-
-	public void setGitFactory(JGitFactory gitFactory) {
-		this.gitFactory = gitFactory;
-	}
-
-	public void setGitCredentialsProviderFactory(
-			GitCredentialsProviderFactory gitCredentialsProviderFactory) {
-		this.gitCredentialsProviderFactory = gitCredentialsProviderFactory;
-	}
-
-	public String getDefaultLabel() {
-		return this.defaultLabel;
-	}
-
-	public void setDefaultLabel(String defaultLabel) {
-		this.defaultLabel = defaultLabel;
-	}
-
-	public boolean isForcePull() {
-		return forcePull;
-	}
-
-	public void setForcePull(boolean forcePull) {
-		this.forcePull = forcePull;
-	}
-
-	public boolean isDeleteUntrackedBranches() {
-		return deleteUntrackedBranches;
-	}
-
-	public void setDeleteUntrackedBranches(boolean deleteUntrackedBranches) {
-		this.deleteUntrackedBranches = deleteUntrackedBranches;
-	}
-
-	public boolean isSkipSslValidation() {
-		return skipSslValidation;
-	}
-
-	public void setSkipSslValidation(boolean skipSslValidation) {
-		this.skipSslValidation = skipSslValidation;
-	}
-
-	@Override
-	public synchronized Locations getLocations(String application, String profile,
-			String label) {
-		if (label == null) {
-			label = this.defaultLabel;
-		}
-		String version = refresh(label);
-		return new Locations(application, profile, label, version,
-				getSearchLocations(getWorkingDirectory(), application, profile, label));
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		Assert.state(getUri() != null,
-				MESSAGE);
-		initialize();
-		if (this.cloneOnStart) {
-			initClonedRepository();
-		}
-	}
-
-	/**
-	 * Get the working directory ready.
-	 */
-	public String refresh(String label) {
-		Git git = null;
-		try {
-			git = createGitClient();
-			if (shouldPull(git)) {
-				FetchResult fetchStatus = fetch(git, label);
-				if (deleteUntrackedBranches && fetchStatus != null) {
-					deleteUntrackedLocalBranches(fetchStatus.getTrackingRefUpdates(), git);
-				}
-				// checkout after fetch so we can get any new branches, tags, ect.
-				checkout(git, label);
-				tryMerge(git, label);
-			}
-			else {
-				// nothing to update so just checkout and merge.
-				// Merge because remote branch could have been updated before
-				checkout(git, label);
-				tryMerge(git, label);
-			}
-			// always return what is currently HEAD as the version
-			return git.getRepository().findRef("HEAD").getObjectId().getName();
-		}
-		catch (RefNotFoundException e) {
-			throw new NoSuchLabelException("No such label: " + label, e);
-		}
-		catch (NoRemoteRepositoryException e) {
-			throw new NoSuchRepositoryException("No such repository: " + getUri(), e);
-		}
-		catch (GitAPIException e) {
-			throw new NoSuchRepositoryException(
-					"Cannot clone or checkout repository: " + getUri(), e);
-		}
-		catch (Exception e) {
-			throw new IllegalStateException("Cannot load environment", e);
-		}
-		finally {
-			try {
-				if (git != null) {
-					git.close();
-				}
-			}
-			catch (Exception e) {
-				this.logger.warn("Could not close git repository", e);
-			}
-		}
-	}
-	
-	private void tryMerge(Git git, String label) {
-		try {
-			if (isBranch(git, label)) {
-				// merge results from fetch
-				merge(git, label);
-				if (!isClean(git, label)) {
-					logger.warn("The local repository is dirty or ahead of origin. Resetting"
-							+ " it to origin/" + label + ".");
-					resetHard(git, label, LOCAL_BRANCH_REF_PREFIX + label);
-				}
-			}
-		} 
-		catch (GitAPIException e) {
-			throw new NoSuchRepositoryException(
-					"Cannot clone or checkout repository: " + getUri(), e);
-		}
-	}
-
-	/**
-	 * Clones the remote repository and then opens a connection to it.
-	 *
-	 * @throws GitAPIException
-	 * @throws IOException
-	 */
-	private void initClonedRepository() throws GitAPIException, IOException {
-		if (!getUri().startsWith(FILE_URI_PREFIX)) {
-			deleteBaseDirIfExists();
-			Git git = cloneToBasedir();
-			if (git != null) {
-				git.close();
-			}
-			git = openGitRepository();
-			if (git != null) {
-				git.close();
-			}
-		}
-
-	}
-
-	/**
-	 * Deletes local branches if corresponding remote branch was removed.
-	 *
-	 * @param trackingRefUpdates list of tracking ref updates
-	 * @param git                git instance
-	 * @return list of deleted branches
-	 */
-	private Collection<String> deleteUntrackedLocalBranches(Collection<TrackingRefUpdate> trackingRefUpdates, Git git) {
-		if (CollectionUtils.isEmpty(trackingRefUpdates)) {
-			return Collections.emptyList();
-		}
-
-		Collection<String> branchesToDelete = new ArrayList<>();
-		for (TrackingRefUpdate trackingRefUpdate : trackingRefUpdates) {
-			ReceiveCommand receiveCommand = trackingRefUpdate.asReceiveCommand();
-			if (receiveCommand.getType() == DELETE) {
-				String localRefName = trackingRefUpdate.getLocalName();
-				if (StringUtils.startsWithIgnoreCase(localRefName, LOCAL_BRANCH_REF_PREFIX)) {
-					String localBranchName = localRefName.substring(LOCAL_BRANCH_REF_PREFIX.length(), localRefName.length());
-					branchesToDelete.add(localBranchName);
-				}
-			}
-		}
-
-		if (CollectionUtils.isEmpty(branchesToDelete)) {
-			return Collections.emptyList();
-		}
-
-		try {
-			//make sure that deleted branch not a current one
-			checkout(git, defaultLabel);
-			return deleteBranches(git, branchesToDelete);
-		} catch (Exception ex) {
-			String message = format("Failed to delete %s branches.", branchesToDelete);
-			warn(message, ex);
-			return Collections.emptyList();
-		}
-	}
-
-	private List<String> deleteBranches(Git git, Collection<String> branchesToDelete) throws GitAPIException {
-		DeleteBranchCommand deleteBranchCommand = git.branchDelete()
-				.setBranchNames(branchesToDelete.toArray(new String[0]))
-				//local branch can contain data which is not merged to HEAD - force delete it anyway, since local copy should be R/O
-				.setForce(true);
-		List<String> resultList = deleteBranchCommand.call();
-		logger.info(format("Deleted %s branches from %s branches to delete.", resultList, branchesToDelete));
-		return resultList;
-	}
-
-	private Ref checkout(Git git, String label) throws GitAPIException {
-		CheckoutCommand checkout = git.checkout();
-		if (shouldTrack(git, label)) {
-			trackBranch(git, checkout, label);
-		}
-		else {
-			// works for tags and local branches
-			checkout.setName(label);
-		}
-		return checkout.call();
-	}
-
-	protected boolean shouldPull(Git git) throws GitAPIException {
-		boolean shouldPull;
-
-		if (this.refreshRate > 0 && System.currentTimeMillis() - this.lastRefresh < (this.refreshRate * 1000)) {
-			return false;
-		}
-
-		Status gitStatus = git.status().call();
-		boolean isWorkingTreeClean = gitStatus.isClean();
-		String originUrl = git.getRepository().getConfig().getString("remote", "origin",
-				"url");
-
-		if (this.forcePull && !isWorkingTreeClean) {
-			shouldPull = true;
-			logDirty(gitStatus);
-		}
-		else {
-			shouldPull = isWorkingTreeClean && originUrl != null;
-		}
-		if (!isWorkingTreeClean && !this.forcePull) {
-			this.logger.info("Cannot pull from remote " + originUrl
-					+ ", the working tree is not clean.");
-		}
-		return shouldPull;
-	}
-
-	@SuppressWarnings("unchecked")
-	private void logDirty(Status status) {
-		Set<String> dirties = dirties(status.getAdded(), status.getChanged(),
-				status.getRemoved(), status.getMissing(), status.getModified(),
-				status.getConflicting(), status.getUntracked());
-		this.logger.warn(format("Dirty files found: %s", dirties));
-	}
-
-	@SuppressWarnings("unchecked")
-	private Set<String> dirties(Set<String>... changes) {
-		Set<String> dirties = new HashSet<>();
-		for (Set<String> files : changes) {
-			dirties.addAll(files);
-		}
-		return dirties;
-	}
-
-	private boolean shouldTrack(Git git, String label) throws GitAPIException {
-		return isBranch(git, label) && !isLocalBranch(git, label);
-	}
-
-	protected FetchResult fetch(Git git, String label) {
-		FetchCommand fetch = git.fetch();
-		fetch.setRemote("origin");
-		fetch.setTagOpt(TagOpt.FETCH_TAGS);
-		fetch.setRemoveDeletedRefs(deleteUntrackedBranches);
-		if (this.refreshRate > 0) {
-			this.setLastRefresh(System.currentTimeMillis());
-		}
-
-		configureCommand(fetch);
-		try {
-			FetchResult result = fetch.call();
-			if (result.getTrackingRefUpdates() != null
-					&& result.getTrackingRefUpdates().size() > 0) {
-				logger.info("Fetched for remote " + label + " and found "
-						+ result.getTrackingRefUpdates().size() + " updates");
-			}
-			return result;
-		}
-		catch (Exception ex) {
-			String message = "Could not fetch remote for " + label + " remote: " + git
-					.getRepository().getConfig().getString("remote", "origin", "url");
-			warn(message, ex);
-			return null;
-		}
-	}
-
-	private MergeResult merge(Git git, String label) {
-		try {
-			MergeCommand merge = git.merge();
-			merge.include(git.getRepository().findRef("origin/" + label));
-			MergeResult result = merge.call();
-			if (!result.getMergeStatus().isSuccessful()) {
-				this.logger.warn("Merged from remote " + label + " with result "
-						+ result.getMergeStatus());
-			}
-			return result;
-		}
-		catch (Exception ex) {
-			String message = "Could not merge remote for " + label + " remote: " + git
-					.getRepository().getConfig().getString("remote", "origin", "url");
-			warn(message, ex);
-			return null;
-		}
-	}
-
-	private Ref resetHard(Git git, String label, String ref) {
-		ResetCommand reset = git.reset();
-		reset.setRef(ref);
-		reset.setMode(ResetType.HARD);
-		try {
-			Ref resetRef = reset.call();
-			if (resetRef != null) {
-				this.logger.info(
-						"Reset label " + label + " to version " + resetRef.getObjectId());
-			}
-			return resetRef;
-		}
-		catch (Exception ex) {
-			String message = "Could not reset to remote for " + label + " (current ref="
-					+ ref + "), remote: " + git.getRepository().getConfig()
-							.getString("remote", "origin", "url");
-			warn(message, ex);
-			return null;
-		}
-	}
-
-	private Git createGitClient() throws IOException, GitAPIException {
-		File lock = new File(getWorkingDirectory(), ".git/index.lock");
-		if (lock.exists()) {
-			// The only way this can happen is if another JVM (e.g. one that
-			// crashed earlier) created the lock. We can attempt to recover by
-			// wiping the slate clean.
-			logger.info("Deleting stale JGit lock file at " + lock);
-			lock.delete();
-		}
-		if (new File(getWorkingDirectory(), ".git").exists()) {
-			return openGitRepository();
-		}
-		else {
-			return copyRepository();
-		}
-	}
-
-	// Synchronize here so that multiple requests don't all try and delete the
-	// base dir
-	// together (this is a once only operation, so it only holds things up on
-	// the first
-	// request).
-	private synchronized Git copyRepository() throws IOException, GitAPIException {
-		deleteBaseDirIfExists();
-		getBasedir().mkdirs();
-		Assert.state(getBasedir().exists(), "Could not create basedir: " + getBasedir());
-		if (getUri().startsWith(FILE_URI_PREFIX)) {
-			return copyFromLocalRepository();
-		}
-		else {
-			return cloneToBasedir();
-		}
-	}
-
-	private Git openGitRepository() throws IOException {
-		Git git = this.gitFactory.getGitByOpen(getWorkingDirectory());
-		return git;
-	}
-
-	private Git copyFromLocalRepository() throws IOException {
-		Git git;
-		File remote = new UrlResource(StringUtils.cleanPath(getUri())).getFile();
-		Assert.state(remote.isDirectory(), "No directory at " + getUri());
-		File gitDir = new File(remote, ".git");
-		Assert.state(gitDir.exists(), "No .git at " + getUri());
-		Assert.state(gitDir.isDirectory(), "No .git directory at " + getUri());
-		git = this.gitFactory.getGitByOpen(remote);
-		return git;
-	}
-
-	private Git cloneToBasedir() throws GitAPIException {
-		CloneCommand clone = this.gitFactory.getCloneCommandByCloneRepository()
-				.setURI(getUri()).setDirectory(getBasedir());
-		configureCommand(clone);
-		try {
-			return clone.call();
-		}
-		catch (GitAPIException e) {
-			logger.warn("Error occured cloning to base directory.", e);
-			deleteBaseDirIfExists();
-			throw e;
-		}
-	}
-
-	private void deleteBaseDirIfExists() {
-		if (getBasedir().exists()) {
-			for (File file : getBasedir().listFiles()) {
-				try {
-					FileUtils.delete(file, FileUtils.RECURSIVE);
-				}
-				catch (IOException e) {
-					throw new IllegalStateException("Failed to initialize base directory",
-							e);
-				}
-			}
-		}
-	}
-
-	private void initialize() {
-		if (!this.initialized) {
-			SshSessionFactory.setInstance(new JschConfigSessionFactory() {
-				@Override
-				protected void configure(Host hc, Session session) {
-					session.setConfig("StrictHostKeyChecking",
-							isStrictHostKeyChecking() ? "yes" : "no");
-				}
-			});
-			this.initialized = true;
-		}
-	}
-
-	private void configureCommand(TransportCommand<?, ?> command) {
-		command.setTimeout(this.timeout);
-		if (this.transportConfigCallback != null) {
-			command.setTransportConfigCallback(this.transportConfigCallback);
-		}
-		CredentialsProvider credentialsProvider = getCredentialsProvider();
-		if (credentialsProvider != null) {
-			command.setCredentialsProvider(credentialsProvider);
-		}
-	}
-
-	private CredentialsProvider getCredentialsProvider() {
-		return this.gitCredentialsProviderFactory.createFor(this.getUri(), getUsername(),
-				getPassword(), getPassphrase(), isSkipSslValidation());
-	}
-
-	private boolean isClean(Git git, String label) {
-		StatusCommand status = git.status();
-		try {
-			BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(git.getRepository(), label);
-			boolean isBranchAhead = trackingStatus != null && trackingStatus.getAheadCount() > 0;
-			return status.call().isClean() && !isBranchAhead;
-		}
-		catch (Exception e) {
-			String message = "Could not execute status command on local repository. Cause: ("
-					+ e.getClass().getSimpleName() + ") " + e.getMessage();
-			warn(message, e);
-			return false;
-		}
-	}
-
-	private void trackBranch(Git git, CheckoutCommand checkout, String label) {
-		checkout.setCreateBranch(true).setName(label)
-				.setUpstreamMode(SetupUpstreamMode.TRACK)
-				.setStartPoint("origin/" + label);
-	}
-
-	private boolean isBranch(Git git, String label) throws GitAPIException {
-		return containsBranch(git, label, ListMode.ALL);
-	}
-
-	private boolean isLocalBranch(Git git, String label) throws GitAPIException {
-		return containsBranch(git, label, null);
-	}
-
-	private boolean containsBranch(Git git, String label, ListMode listMode)
-			throws GitAPIException {
-		ListBranchCommand command = git.branchList();
-		if (listMode != null) {
-			command.setListMode(listMode);
-		}
-		List<Ref> branches = command.call();
-		for (Ref ref : branches) {
-			if (ref.getName().endsWith("/" + label)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	protected void warn(String message, Exception ex) {
-		logger.warn(message);
-		if (logger.isDebugEnabled()) {
-			logger.debug("Stacktrace for: " + message, ex);
-		}
-	}
-
-	public void setLastRefresh(long lastRefresh) {
-		this.lastRefresh = lastRefresh;
-	}
-
-	public long getLastRefresh() {
-		return lastRefresh;
-	}
-
-	/**
-	 * Wraps the static method calls to {@link org.eclipse.jgit.api.Git} and
-	 * {@link org.eclipse.jgit.api.CloneCommand} allowing for easier unit testing.
-	 */
-	static class JGitFactory {
-
-		public Git getGitByOpen(File file) throws IOException {
-			Git git = Git.open(file);
-			return git;
-		}
-
-		public CloneCommand getCloneCommandByCloneRepository() {
-			CloneCommand command = Git.cloneRepository();
-			return command;
-		}
-	}
+        implements EnvironmentRepository, SearchPathLocator, InitializingBean {
+
+    public static final String MESSAGE = "You need to configure a uri for the git repository.";
+
+    private static final String FILE_URI_PREFIX = "file:";
+
+    private static final String LOCAL_BRANCH_REF_PREFIX = "refs/remotes/origin/";
+
+    /*
+    * Is the Backup Repository in use?
+     */
+    private Boolean backupRepoInUse = false;
+
+    /*
+    *  Since when the backup repo is in usage
+     */
+    private long backupInUseTimestamp = 0;
+
+    /*
+    * Time to check if the main repo is available
+     */
+    private long mainRepoCheckCoolDown = 60 * 1000;
+
+    /**
+     * Timeout (in seconds) for obtaining HTTP or SSH connection (if applicable). Default
+     * 5 seconds.
+     */
+    private int timeout;
+
+    /**
+     * Time (in seconds) between refresh of the git repository
+     */
+    private int refreshRate = 0;
+
+    /**
+     * Time of the last refresh of the git repository
+     */
+    private long lastRefresh;
+
+    /**
+     * Flag to indicate that the repository should be cloned on startup (not on demand).
+     * Generally leads to slower startup but faster first query.
+     */
+    private boolean cloneOnStart;
+
+    private JGitEnvironmentRepository.JGitFactory gitFactory = new JGitEnvironmentRepository.JGitFactory();
+
+    private String defaultLabel;
+
+    /**
+     * Factory used to create the credentials provider to use to connect to the Git
+     * repository.
+     */
+    private GitCredentialsProviderFactory gitCredentialsProviderFactory = new GitCredentialsProviderFactory();
+
+    /**
+     * Transport configuration callback for JGit commands.
+     */
+    private TransportConfigCallback transportConfigCallback;
+
+    /**
+     * Flag to indicate that the repository should force pull. If true discard any local
+     * changes and take from remote repository.
+     */
+    private boolean forcePull;
+    private boolean initialized;
+
+    /**
+     * Flag to indicate that the branch should be deleted locally if it's origin tracked branch was removed.
+     */
+    private boolean deleteUntrackedBranches;
+
+    /**
+     * Flag to indicate that SSL certificate validation should be bypassed when
+     * communicating with a repository served over an HTTPS connection.
+     */
+    private boolean skipSslValidation;
+
+    public JGitEnvironmentRepository(ConfigurableEnvironment environment, JGitEnvironmentProperties properties) {
+        super(environment, properties);
+        this.cloneOnStart = properties.isCloneOnStart();
+        this.defaultLabel = properties.getDefaultLabel();
+        this.forcePull = properties.isForcePull();
+        this.timeout = properties.getTimeout();
+        this.deleteUntrackedBranches = properties.isDeleteUntrackedBranches();
+        this.refreshRate = properties.getRefreshRate();
+        this.skipSslValidation = properties.isSkipSslValidation();
+    }
+
+    public boolean isCloneOnStart() {
+        return this.cloneOnStart;
+    }
+
+    public void setCloneOnStart(boolean cloneOnStart) {
+        this.cloneOnStart = cloneOnStart;
+    }
+
+    public int getTimeout() {
+        return this.timeout;
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    public int getRefreshRate() {
+        return refreshRate;
+    }
+
+    public void setRefreshRate(int refreshRate) {
+        this.refreshRate = refreshRate;
+    }
+
+
+    public TransportConfigCallback getTransportConfigCallback() {
+        return transportConfigCallback;
+    }
+
+    public void setTransportConfigCallback(
+            TransportConfigCallback transportConfigCallback) {
+        this.transportConfigCallback = transportConfigCallback;
+    }
+
+    public JGitFactory getGitFactory() {
+        return this.gitFactory;
+    }
+
+    public void setGitFactory(JGitFactory gitFactory) {
+        this.gitFactory = gitFactory;
+    }
+
+    public void setGitCredentialsProviderFactory(
+            GitCredentialsProviderFactory gitCredentialsProviderFactory) {
+        this.gitCredentialsProviderFactory = gitCredentialsProviderFactory;
+    }
+
+    public String getDefaultLabel() {
+        return this.defaultLabel;
+    }
+
+    public void setDefaultLabel(String defaultLabel) {
+        this.defaultLabel = defaultLabel;
+    }
+
+    public boolean isForcePull() {
+        return forcePull;
+    }
+
+    public void setForcePull(boolean forcePull) {
+        this.forcePull = forcePull;
+    }
+
+    public boolean isDeleteUntrackedBranches() {
+        return deleteUntrackedBranches;
+    }
+
+    public void setDeleteUntrackedBranches(boolean deleteUntrackedBranches) {
+        this.deleteUntrackedBranches = deleteUntrackedBranches;
+    }
+
+    public boolean isSkipSslValidation() {
+        return skipSslValidation;
+    }
+
+    public void setSkipSslValidation(boolean skipSslValidation) {
+        this.skipSslValidation = skipSslValidation;
+    }
+
+    @Override
+    public synchronized Locations getLocations(String application, String profile,
+                                               String label) {
+        if (label == null) {
+            label = this.defaultLabel;
+        }
+        String version = refresh(label);
+        return new Locations(application, profile, label, version,
+                getSearchLocations(getWorkingDirectory(), application, profile, label));
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.state(getUri() != null,
+                MESSAGE);
+        initialize();
+        if (this.cloneOnStart) {
+            initClonedRepository();
+        }
+    }
+
+    /**
+     * Get the working directory ready.
+     */
+    public String refresh(String label) {
+        Git git = null;
+        try {
+            git = createGitClient();
+            if (shouldPull(git)) {
+                FetchResult fetchStatus = fetch(git, label);
+                if (deleteUntrackedBranches && fetchStatus != null) {
+                    deleteUntrackedLocalBranches(fetchStatus.getTrackingRefUpdates(), git);
+                }
+                // checkout after fetch so we can get any new branches, tags, ect.
+                checkout(git, label);
+                tryMerge(git, label);
+            } else {
+                // nothing to update so just checkout and merge.
+                // Merge because remote branch could have been updated before
+                checkout(git, label);
+                tryMerge(git, label);
+            }
+            // always return what is currently HEAD as the version
+            return git.getRepository().findRef("HEAD").getObjectId().getName();
+        } catch (RefNotFoundException e) {
+            throw new NoSuchLabelException("No such label: " + label, e);
+        } catch (NoRemoteRepositoryException e) {
+            throw new NoSuchRepositoryException("No such repository: " + getUri(), e);
+        } catch (GitAPIException e) {
+            throw new NoSuchRepositoryException(
+                    "Cannot clone or checkout repository: " + getUri(), e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot load environment", e);
+        } finally {
+            try {
+                if (git != null) {
+                    git.close();
+                }
+            } catch (Exception e) {
+                this.logger.warn("Could not close git repository", e);
+            }
+        }
+    }
+
+    private void tryMerge(Git git, String label) {
+        try {
+            if (isBranch(git, label)) {
+                // merge results from fetch
+                merge(git, label);
+                if (!isClean(git, label)) {
+                    logger.warn("The local repository is dirty or ahead of origin. Resetting"
+                            + " it to origin/" + label + ".");
+                    resetHard(git, label, LOCAL_BRANCH_REF_PREFIX + label);
+                }
+            }
+        } catch (GitAPIException e) {
+            throw new NoSuchRepositoryException(
+                    "Cannot clone or checkout repository: " + getUri(), e);
+        }
+    }
+
+    /**
+     * Clones the remote repository and then opens a connection to it.
+     *
+     * @throws GitAPIException
+     * @throws IOException
+     */
+    private void initClonedRepository() throws GitAPIException, IOException {
+        if (!getUri().startsWith(FILE_URI_PREFIX)) {
+            deleteBaseDirIfExists();
+            Git git = cloneToBasedir();
+            if (git != null) {
+                git.close();
+            }
+            git = openGitRepository();
+            if (git != null) {
+                git.close();
+            }
+        }
+
+    }
+
+    /**
+     * Deletes local branches if corresponding remote branch was removed.
+     *
+     * @param trackingRefUpdates list of tracking ref updates
+     * @param git                git instance
+     * @return list of deleted branches
+     */
+    private Collection<String> deleteUntrackedLocalBranches(Collection<TrackingRefUpdate> trackingRefUpdates, Git git) {
+        if (CollectionUtils.isEmpty(trackingRefUpdates)) {
+            return Collections.emptyList();
+        }
+
+        Collection<String> branchesToDelete = new ArrayList<>();
+        for (TrackingRefUpdate trackingRefUpdate : trackingRefUpdates) {
+            ReceiveCommand receiveCommand = trackingRefUpdate.asReceiveCommand();
+            if (receiveCommand.getType() == DELETE) {
+                String localRefName = trackingRefUpdate.getLocalName();
+                if (StringUtils.startsWithIgnoreCase(localRefName, LOCAL_BRANCH_REF_PREFIX)) {
+                    String localBranchName = localRefName.substring(LOCAL_BRANCH_REF_PREFIX.length(), localRefName.length());
+                    branchesToDelete.add(localBranchName);
+                }
+            }
+        }
+
+        if (CollectionUtils.isEmpty(branchesToDelete)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            //make sure that deleted branch not a current one
+            checkout(git, defaultLabel);
+            return deleteBranches(git, branchesToDelete);
+        } catch (Exception ex) {
+            String message = format("Failed to delete %s branches.", branchesToDelete);
+            warn(message, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private List<String> deleteBranches(Git git, Collection<String> branchesToDelete) throws GitAPIException {
+        DeleteBranchCommand deleteBranchCommand = git.branchDelete()
+                .setBranchNames(branchesToDelete.toArray(new String[0]))
+                //local branch can contain data which is not merged to HEAD - force delete it anyway, since local copy should be R/O
+                .setForce(true);
+        List<String> resultList = deleteBranchCommand.call();
+        logger.info(format("Deleted %s branches from %s branches to delete.", resultList, branchesToDelete));
+        return resultList;
+    }
+
+    private Ref checkout(Git git, String label) throws GitAPIException {
+        CheckoutCommand checkout = git.checkout();
+        if (shouldTrack(git, label)) {
+            trackBranch(git, checkout, label);
+        } else {
+            // works for tags and local branches
+            checkout.setName(label);
+        }
+        return checkout.call();
+    }
+
+    protected boolean shouldPull(Git git) throws GitAPIException {
+        boolean shouldPull;
+
+        if (this.refreshRate > 0 && System.currentTimeMillis() - this.lastRefresh < (this.refreshRate * 1000)) {
+            return false;
+        }
+
+        Status gitStatus = git.status().call();
+        boolean isWorkingTreeClean = gitStatus.isClean();
+        String originUrl = git.getRepository().getConfig().getString("remote", "origin",
+                "url");
+
+        if (this.forcePull && !isWorkingTreeClean) {
+            shouldPull = true;
+            logDirty(gitStatus);
+        } else {
+            shouldPull = isWorkingTreeClean && originUrl != null;
+        }
+        if (!isWorkingTreeClean && !this.forcePull) {
+            this.logger.info("Cannot pull from remote " + originUrl
+                    + ", the working tree is not clean.");
+        }
+        return shouldPull;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void logDirty(Status status) {
+        Set<String> dirties = dirties(status.getAdded(), status.getChanged(),
+                status.getRemoved(), status.getMissing(), status.getModified(),
+                status.getConflicting(), status.getUntracked());
+        this.logger.warn(format("Dirty files found: %s", dirties));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> dirties(Set<String>... changes) {
+        Set<String> dirties = new HashSet<>();
+        for (Set<String> files : changes) {
+            dirties.addAll(files);
+        }
+        return dirties;
+    }
+
+    private boolean shouldTrack(Git git, String label) throws GitAPIException {
+        return isBranch(git, label) && !isLocalBranch(git, label);
+    }
+
+    protected FetchResult fetch(Git git, String label) {
+        FetchCommand fetch = git.fetch();
+        fetch.setRemote("origin");
+        fetch.setTagOpt(TagOpt.FETCH_TAGS);
+        fetch.setRemoveDeletedRefs(deleteUntrackedBranches);
+        if (this.refreshRate > 0) {
+            this.setLastRefresh(System.currentTimeMillis());
+        }
+
+        configureCommand(fetch);
+        try {
+            FetchResult result = fetch.call();
+            if (result.getTrackingRefUpdates() != null
+                    && result.getTrackingRefUpdates().size() > 0) {
+                logger.info("Fetched for remote " + label + " and found "
+                        + result.getTrackingRefUpdates().size() + " updates");
+            }
+            return result;
+        } catch (Exception ex) {
+            String message = "Could not fetch remote for " + label + " remote: " + git
+                    .getRepository().getConfig().getString("remote", "origin", "url");
+            warn(message, ex);
+            return null;
+        }
+    }
+
+    private MergeResult merge(Git git, String label) {
+        try {
+            MergeCommand merge = git.merge();
+            merge.include(git.getRepository().findRef("origin/" + label));
+            MergeResult result = merge.call();
+            if (!result.getMergeStatus().isSuccessful()) {
+                this.logger.warn("Merged from remote " + label + " with result "
+                        + result.getMergeStatus());
+            }
+            return result;
+        } catch (Exception ex) {
+            String message = "Could not merge remote for " + label + " remote: " + git
+                    .getRepository().getConfig().getString("remote", "origin", "url");
+            warn(message, ex);
+            return null;
+        }
+    }
+
+    private Ref resetHard(Git git, String label, String ref) {
+        ResetCommand reset = git.reset();
+        reset.setRef(ref);
+        reset.setMode(ResetType.HARD);
+        try {
+            Ref resetRef = reset.call();
+            if (resetRef != null) {
+                this.logger.info(
+                        "Reset label " + label + " to version " + resetRef.getObjectId());
+            }
+            return resetRef;
+        } catch (Exception ex) {
+            String message = "Could not reset to remote for " + label + " (current ref="
+                    + ref + "), remote: " + git.getRepository().getConfig()
+                    .getString("remote", "origin", "url");
+            warn(message, ex);
+            return null;
+        }
+    }
+
+    private Git createGitClient() throws IOException, GitAPIException {
+        File lock = new File(getWorkingDirectory(), ".git/index.lock");
+        if (lock.exists()) {
+            // The only way this can happen is if another JVM (e.g. one that
+            // crashed earlier) created the lock. We can attempt to recover by
+            // wiping the slate clean.
+            logger.info("Deleting stale JGit lock file at " + lock);
+            lock.delete();
+        }
+
+        if(backupRepoInUse){
+            logger.info("We are running on the backup repo origin...");
+        }
+
+        // When we use the backup repo we try to check out the main repo after the cool down
+        if (backupRepoInUse &&  (System.currentTimeMillis() - backupInUseTimestamp > mainRepoCheckCoolDown)) {
+            logger.info("Retry to get the main repo running...");
+            return copyRepository();
+        } else if (new File(getWorkingDirectory(), ".git").exists()) {
+            return openGitRepository();
+        } else {
+            return copyRepository();
+        }
+    }
+
+    // Synchronize here so that multiple requests don't all try and delete the
+    // base dir
+    // together (this is a once only operation, so it only holds things up on
+    // the first
+    // request).
+    private synchronized Git copyRepository() throws IOException, GitAPIException {
+        deleteBaseDirIfExists();
+        getBasedir().mkdirs();
+        Assert.state(getBasedir().exists(), "Could not create basedir: " + getBasedir());
+        if (getUri().startsWith(FILE_URI_PREFIX)) {
+            return copyFromLocalRepository();
+        } else {
+            return cloneToBasedir();
+        }
+    }
+
+    private Git openGitRepository() throws IOException {
+        Git git = this.gitFactory.getGitByOpen(getWorkingDirectory());
+        return git;
+    }
+
+    private Git copyFromLocalRepository() throws IOException {
+        Git git;
+        File remote = new UrlResource(StringUtils.cleanPath(getUri())).getFile();
+        Assert.state(remote.isDirectory(), "No directory at " + getUri());
+        File gitDir = new File(remote, ".git");
+        Assert.state(gitDir.exists(), "No .git at " + getUri());
+        Assert.state(gitDir.isDirectory(), "No .git directory at " + getUri());
+        git = this.gitFactory.getGitByOpen(remote);
+        return git;
+    }
+
+    private Git cloneToBasedir() throws GitAPIException {
+        CloneCommand clone = this.gitFactory.getCloneCommandByCloneRepository()
+                .setURI(getUri()).setDirectory(getBasedir());
+        configureCommand(clone);
+        try {
+            Git call = clone.call();
+            backupRepoInUse = false;
+            return call;
+        } catch (GitAPIException e) {
+            logger.warn("Error occured cloning to base directory.", e);
+            // try with backup uri
+            if (getBackupUri() == null || getBackupUri().isEmpty()) {
+                deleteBaseDirIfExists();
+                throw e;
+            }
+            clone = this.gitFactory.getCloneCommandByCloneRepository()
+                    .setURI(getBackupUri()).setDirectory(getBasedir());
+            configureCommand(clone);
+            try {
+                Git call = clone.call();
+                backupRepoInUse = true;
+                backupInUseTimestamp = System.currentTimeMillis();
+                return call;
+            } catch (GitAPIException e2) {
+                logger.warn("Error occured cloning backup to base directory.", e2);
+                deleteBaseDirIfExists();
+                throw e2;
+            }
+        }
+    }
+
+    private void deleteBaseDirIfExists() {
+        if (getBasedir().exists()) {
+            for (File file : getBasedir().listFiles()) {
+                try {
+                    FileUtils.delete(file, FileUtils.RECURSIVE);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to initialize base directory",
+                            e);
+                }
+            }
+        }
+    }
+
+    private void initialize() {
+        if (!this.initialized) {
+            SshSessionFactory.setInstance(new JschConfigSessionFactory() {
+                @Override
+                protected void configure(Host hc, Session session) {
+                    session.setConfig("StrictHostKeyChecking",
+                            isStrictHostKeyChecking() ? "yes" : "no");
+                }
+            });
+            this.initialized = true;
+        }
+    }
+
+    private void configureCommand(TransportCommand<?, ?> command) {
+        command.setTimeout(this.timeout);
+        if (this.transportConfigCallback != null) {
+            command.setTransportConfigCallback(this.transportConfigCallback);
+        }
+        CredentialsProvider credentialsProvider = getCredentialsProvider();
+        if (credentialsProvider != null) {
+            command.setCredentialsProvider(credentialsProvider);
+        }
+    }
+
+    private CredentialsProvider getCredentialsProvider() {
+        return this.gitCredentialsProviderFactory.createFor(this.getUri(), getUsername(),
+                getPassword(), getPassphrase(), isSkipSslValidation());
+    }
+
+    private boolean isClean(Git git, String label) {
+        StatusCommand status = git.status();
+        try {
+            BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(git.getRepository(), label);
+            boolean isBranchAhead = trackingStatus != null && trackingStatus.getAheadCount() > 0;
+            return status.call().isClean() && !isBranchAhead;
+        } catch (Exception e) {
+            String message = "Could not execute status command on local repository. Cause: ("
+                    + e.getClass().getSimpleName() + ") " + e.getMessage();
+            warn(message, e);
+            return false;
+        }
+    }
+
+    private void trackBranch(Git git, CheckoutCommand checkout, String label) {
+        checkout.setCreateBranch(true).setName(label)
+                .setUpstreamMode(SetupUpstreamMode.TRACK)
+                .setStartPoint("origin/" + label);
+    }
+
+    private boolean isBranch(Git git, String label) throws GitAPIException {
+        return containsBranch(git, label, ListMode.ALL);
+    }
+
+    private boolean isLocalBranch(Git git, String label) throws GitAPIException {
+        return containsBranch(git, label, null);
+    }
+
+    private boolean containsBranch(Git git, String label, ListMode listMode)
+            throws GitAPIException {
+        ListBranchCommand command = git.branchList();
+        if (listMode != null) {
+            command.setListMode(listMode);
+        }
+        List<Ref> branches = command.call();
+        for (Ref ref : branches) {
+            if (ref.getName().endsWith("/" + label)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected void warn(String message, Exception ex) {
+        logger.warn(message);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Stacktrace for: " + message, ex);
+        }
+    }
+
+    public void setLastRefresh(long lastRefresh) {
+        this.lastRefresh = lastRefresh;
+    }
+
+    public long getLastRefresh() {
+        return lastRefresh;
+    }
+
+    /**
+     * Wraps the static method calls to {@link org.eclipse.jgit.api.Git} and
+     * {@link org.eclipse.jgit.api.CloneCommand} allowing for easier unit testing.
+     */
+    static class JGitFactory {
+
+        public Git getGitByOpen(File file) throws IOException {
+            Git git = Git.open(file);
+            return git;
+        }
+
+        public CloneCommand getCloneCommandByCloneRepository() {
+            CloneCommand command = Git.cloneRepository();
+            return command;
+        }
+    }
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
@@ -16,18 +16,8 @@
 
 package org.springframework.cloud.config.server.support;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -37,6 +27,15 @@ import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * Base class for components that want to access a source control management system.
@@ -55,6 +54,11 @@ public abstract class AbstractScmAccessor implements ResourceLoaderAware {
 	 * URI of remote repository.
 	 */
 	private String uri;
+	/*
+	* BACKUP URI of remote repository.
+	 */
+	private String backupUri;
+
 	private ConfigurableEnvironment environment;
 	/**
 	 * Username for authentication with remote repository.
@@ -95,6 +99,7 @@ public abstract class AbstractScmAccessor implements ResourceLoaderAware {
 		this.strictHostKeyChecking = properties.isStrictHostKeyChecking();
 		this.uri = properties.getUri();
 		this.username = properties.getUsername();
+		this.backupUri = properties.getBackupUri();
 	}
 
 	@Override
@@ -190,6 +195,14 @@ public abstract class AbstractScmAccessor implements ResourceLoaderAware {
 
 	public boolean isStrictHostKeyChecking() {
 		return strictHostKeyChecking;
+	}
+
+	public String getBackupUri() {
+		return backupUri;
+	}
+
+	public void setBackupUri(String backupUri) {
+		this.backupUri = backupUri;
 	}
 
 	public void setStrictHostKeyChecking(boolean strictHostKeyChecking) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessorProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessorProperties.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.cloud.config.server.support;
 
-import java.io.File;
-
 import org.springframework.core.Ordered;
+
+import java.io.File;
 
 /**
  * @author Dylan Roberts
@@ -29,6 +29,10 @@ public class AbstractScmAccessorProperties implements EnvironmentRepositoryPrope
      * URI of remote repository.
      */
     private String uri;
+    /**
+     * BACKUP URI FOR FALLBACK
+     */
+    private String backupUri;
     /**
      * Base directory for local working copy of repository.
      */
@@ -131,5 +135,13 @@ public class AbstractScmAccessorProperties implements EnvironmentRepositoryPrope
 
     public void setDefaultLabel(String defaultLabel) {
         this.defaultLabel = defaultLabel;
+    }
+
+    public String getBackupUri() {
+        return backupUri;
+    }
+
+    public void setBackupUri(String backupUri) {
+        this.backupUri = backupUri;
     }
 }

--- a/spring-cloud-starter-config/pom.xml
+++ b/spring-cloud-starter-config/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.0.2.RELEASE</version>
 	</parent>
 	<artifactId>spring-cloud-starter-config</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.0.2.RELEASE</version>
 	<name>spring-cloud-starter-config</name>
 	<description>Spring Cloud Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>

--- a/spring-cloud-starter-config/pom.xml
+++ b/spring-cloud-starter-config/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-config</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.0.2.HWL.RELEASE</version>
 	</parent>
 	<artifactId>spring-cloud-starter-config</artifactId>
-	<version>2.0.2.RELEASE</version>
+	<version>2.0.2.HWL.RELEASE</version>
 	<name>spring-cloud-starter-config</name>
 	<description>Spring Cloud Starter</description>
 	<url>https://projects.spring.io/spring-cloud</url>


### PR DESCRIPTION
Hi! 

as already mentioned in the issue https://github.com/spring-cloud/spring-cloud-config/issues/617 we need a backup repository in worst case or if our bitbucket is not available and we do not already have a local copy of the remote repository.

We use the spring cloud Finchley SR2 release at the moment.

For that I created a new config param called *backup-uri*

![image](https://user-images.githubusercontent.com/3482021/50725684-82496b80-1101-11e9-94da-329900537416.png)

That uri is used if the base uri is not working for the git checkout. After that a flag called *backupRepoInUse* is set. After a cool down timeout of 1 min the checkout will be retried by clone base dir.

the retry is implemented by
```
clone = this.gitFactory.getCloneCommandByCloneRepository()
                    .setURI(getBackupUri()).setDirectory(getBasedir());
            configureCommand(clone);
```
if an exception happened.

This is certainly not the best solution and you have to make sure that the data in the backup repository is up to date but it helps us a lot in our case of emergency


```java
 private Git createGitClient() throws IOException, GitAPIException {
        File lock = new File(getWorkingDirectory(), ".git/index.lock");
        if (lock.exists()) {
            // The only way this can happen is if another JVM (e.g. one that
            // crashed earlier) created the lock. We can attempt to recover by
            // wiping the slate clean.
            logger.info("Deleting stale JGit lock file at " + lock);
            lock.delete();
        }

        if(backupRepoInUse){
            logger.info("We are running on the backup repo origin...");
        }

        // When we use the backup repo we try to check out the main repo after the cool down
        if (backupRepoInUse &&  (System.currentTimeMillis() - backupInUseTimestamp > mainRepoCheckCoolDown)) {
            logger.info("Retry to get the main repo running...");
            return copyRepository();
        } else if (new File(getWorkingDirectory(), ".git").exists()) {
            return openGitRepository();
        } else {
            return copyRepository();
        }
    }
```
```java
    private Git cloneToBasedir() throws GitAPIException {
        CloneCommand clone = this.gitFactory.getCloneCommandByCloneRepository()
                .setURI(getUri()).setDirectory(getBasedir());
        configureCommand(clone);
        try {
            Git call = clone.call();
            backupRepoInUse = false;
            return call;
        } catch (GitAPIException e) {
            logger.warn("Error occured cloning to base directory.", e);
            // try with backup uri
            if (getBackupUri() == null || getBackupUri().isEmpty()) {
                deleteBaseDirIfExists();
                throw e;
            }
            clone = this.gitFactory.getCloneCommandByCloneRepository()
                    .setURI(getBackupUri()).setDirectory(getBasedir());
            configureCommand(clone);
            try {
                Git call = clone.call();
                backupRepoInUse = true;
                backupInUseTimestamp = System.currentTimeMillis();
                return call;
            } catch (GitAPIException e2) {
                logger.warn("Error occured cloning backup to base directory.", e2);
                deleteBaseDirIfExists();
                throw e2;
            }
        }
    }

Maybe we can see a similar feature in the future or this helps others.

