### PR TITLE
documented value of config.fail-fast value for retry is incorrect

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1339,7 +1339,7 @@ If this is the desired behavior, set the bootstrap configuration property `sprin
 === Config Client Retry
 
 If you expect that the config server may occasionally be unavailable when your application starts, you can make it keep trying after a failure.
-First, you need to set `spring.cloud.config.fail-fast=false`.
+First, you need to set `spring.cloud.config.fail-fast=true`.
 Then you need to add `spring-retry` and `spring-boot-starter-aop` to your classpath.
 The default behavior is to retry six times with an initial backoff interval of 1000ms and an exponential multiplier of 1.1 for subsequent backoffs.
 You can configure these properties (and others) by setting the `spring.cloud.config.retry.*` configuration properties.


### PR DESCRIPTION
The value of `config.fail-fast` must be set to non-false value in order to activate the `RetryConfiguration`.