### PR TITLE
Use jks as the default KeyStore type

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -983,6 +983,7 @@ keystore properties are `encrypt.keyStore.\*` with `*` equal to
 |`encrypt.keyStore.location`|Contains a `Resource` location
 |`encrypt.keyStore.password`|Holds the password that unlocks the keystore
 |`encrypt.keyStore.alias`|Identifies which key in the store to use
+|`encrypt.keyStore.type`|The type of KeyStore to create.  Defaults to `jks`.
 |===
 
 The encryption is done with the public key, and a private key is

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.0.5.BUILD-SNAPSHOT</version>
+		<version>2.0.6.BUILD-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<scm>
@@ -22,7 +22,7 @@
 	</scm>
     <properties>
         <bintray.package>config</bintray.package>
-		<spring-cloud-commons.version>2.0.3.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>2.0.4.BUILD-SNAPSHOT</spring-cloud-commons.version>
     </properties>
 	<modules>
 		<module>spring-cloud-config-dependencies</module>

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.0.5.BUILD-SNAPSHOT</version>
+		<version>2.0.6.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-config-dependencies</artifactId>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
@@ -97,7 +97,7 @@ public class EncryptionAutoConfiguration {
 			KeyStore keyStore = this.key.getKeyStore();
 			KeyStoreTextEncryptorLocator locator = new KeyStoreTextEncryptorLocator(
 					new KeyStoreKeyFactory(keyStore.getLocation(),
-							keyStore.getPassword().toCharArray(), "jks"),
+							keyStore.getPassword().toCharArray(), key.getKeyStore().getType()),
 					keyStore.getSecret(), keyStore.getAlias());
 			RsaAlgorithm algorithm = this.rsaProperties.getAlgorithm();
 			locator.setRsaAlgorithm(algorithm);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
@@ -97,7 +97,7 @@ public class EncryptionAutoConfiguration {
 			KeyStore keyStore = this.key.getKeyStore();
 			KeyStoreTextEncryptorLocator locator = new KeyStoreTextEncryptorLocator(
 					new KeyStoreKeyFactory(keyStore.getLocation(),
-							keyStore.getPassword().toCharArray()),
+							keyStore.getPassword().toCharArray(), "jks"),
 					keyStore.getSecret(), keyStore.getAlias());
 			RsaAlgorithm algorithm = this.rsaProperties.getAlgorithm();
 			locator.setRsaAlgorithm(algorithm);


### PR DESCRIPTION
There were changes in `KeyStoreKeyFactory` which now try to extract the keystore type from the resources extension.  Prior to these changes we always used `jks`.  This change just restores that functionality.  Fixes #1176