### PR TITLE
Prevent JGit from loading local configuration in tests

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/BootstrapConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/BootstrapConfigServerIntegrationTests.java
@@ -2,6 +2,8 @@ package org.springframework.cloud.config.server;
 
 import java.io.IOException;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +37,9 @@ public class BootstrapConfigServerIntegrationTests {
 
 	@BeforeClass
 	public static void init() throws IOException {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+
 		ConfigServerTestUtils.prepareLocalRepo("encrypt-repo");
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CompositeIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CompositeIntegrationTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.config.server;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +52,9 @@ public class CompositeIntegrationTests {
 
 		@BeforeClass
 		public static void init() throws Exception {
+			// mock Git configuration to make tests independent of local Git configuration
+			SystemReader.setInstance(new MockSystemReader());
+
 			ConfigServerTestUtils.prepareLocalRepo();
 			ConfigServerTestUtils.prepareLocalSvnRepo("src/test/resources/svn-config-repo",
 					"target/repos/svn-config-repo");
@@ -100,6 +105,9 @@ public class CompositeIntegrationTests {
 
 		@BeforeClass
 		public static void init() throws Exception {
+			// mock Git configuration to make tests independent of local Git configuration
+			SystemReader.setInstance(new MockSystemReader());
+
 			ConfigServerTestUtils.prepareLocalRepo();
 			ConfigServerTestUtils.prepareLocalSvnRepo("src/test/resources/svn-config-repo",
 					"target/repos/svn-config-repo");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
@@ -2,6 +2,8 @@ package org.springframework.cloud.config.server;
 
 import java.io.IOException;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +46,9 @@ public class ConfigClientOffIntegrationTests {
 
 	@BeforeClass
 	public static void init() throws IOException {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+
 		ConfigServerTestUtils.prepareLocalRepo();
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.config.server;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -66,6 +68,9 @@ public class ConfigClientOnIntegrationTests {
 
 	@BeforeClass
 	public static void init() throws IOException {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+
 		localRepo = ConfigServerTestUtils.prepareLocalRepo();
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/NativeConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/NativeConfigServerIntegrationTests.java
@@ -2,6 +2,8 @@ package org.springframework.cloud.config.server;
 
 import java.io.IOException;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,12 +28,15 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		webEnvironment = RANDOM_PORT)
 @ActiveProfiles({ "test", "native" })
 public class NativeConfigServerIntegrationTests {
-	
+
 	@LocalServerPort
 	private int port;
-	
+
 	@BeforeClass
 	public static void init() throws IOException{
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+
 		ConfigServerTestUtils.prepareLocalRepo();
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/VanillaConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/VanillaConfigServerIntegrationTests.java
@@ -3,6 +3,8 @@ package org.springframework.cloud.config.server;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +38,9 @@ public class VanillaConfigServerIntegrationTests {
 
 	@BeforeClass
 	public static void init() throws IOException {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+
 		ConfigServerTestUtils.prepareLocalRepo();
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomCompositeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomCompositeEnvironmentRepositoryTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.config.server.config;
 import java.util.HashMap;
 import java.util.List;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +67,9 @@ public class CustomCompositeEnvironmentRepositoryTests {
 
 		@BeforeClass
 		public static void init() throws Exception {
+			// mock Git configuration to make tests independent of local Git configuration
+			SystemReader.setInstance(new MockSystemReader());
+
 			ConfigServerTestUtils.prepareLocalRepo();
 		}
 
@@ -113,6 +118,9 @@ public class CustomCompositeEnvironmentRepositoryTests {
 
 		@BeforeClass
 		public static void init() throws Exception {
+			// mock Git configuration to make tests independent of local Git configuration
+			SystemReader.setInstance(new MockSystemReader());
+
 			ConfigServerTestUtils.prepareLocalRepo();
 		}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryConcurrencyTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryConcurrencyTests.java
@@ -32,12 +32,15 @@ import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.*;
+import org.eclipse.jgit.junit.MockSystemReader;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -64,6 +67,12 @@ public class JGitEnvironmentRepositoryConcurrencyTests {
 	private ConfigurableApplicationContext context;
 
 	private File basedir = new File("target/config");
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -41,6 +41,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.NotMergedException;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.junit.MockSystemReader;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -53,7 +54,9 @@ import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -93,6 +96,12 @@ public class JGitEnvironmentRepositoryTests {
 
 	@Rule
 	public final ExpectedException exception = ExpectedException.none();
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {
@@ -523,18 +532,18 @@ public class JGitEnvironmentRepositoryTests {
 
 		verify(git, times(0)).branchDelete();
     }
-	
+
 	@Test
 	public void testRefreshWithoutFetch() throws Exception {
 		Git git = mock(Git.class);
-		
+
 		CloneCommand cloneCommand = mock(CloneCommand.class);
 		when(cloneCommand.setURI(anyString())).thenReturn(cloneCommand);
 		when(cloneCommand.setDirectory(any(File.class))).thenReturn(cloneCommand);
 		when(cloneCommand.call()).thenReturn(git);
-		
+
 		MockGitFactory factory = new MockGitFactory(git, cloneCommand);
-		
+
 		StatusCommand statusCommand = mock(StatusCommand.class);
 		CheckoutCommand checkoutCommand = mock(CheckoutCommand.class);
 		Status status = mock(Status.class);
@@ -571,7 +580,7 @@ public class JGitEnvironmentRepositoryTests {
 		repo.setRefreshRate(2);
 
 		repo.refresh("master");
-		
+
 		// Verify no fetch but merge only.
 		verify(git, times(0)).fetch();
 		verify(git).merge();

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
@@ -18,7 +18,10 @@ package org.springframework.cloud.config.server.environment;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -41,6 +44,12 @@ public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 	private StandardEnvironment environment = new StandardEnvironment();
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment,
 			new MultipleJGitEnvironmentProperties());
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
@@ -16,7 +16,10 @@
  */
 package org.springframework.cloud.config.server.environment;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.cloud.config.environment.Environment;
@@ -38,6 +41,12 @@ public class MultipleJGitEnvironmentLabelPlaceholderRepositoryTests {
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment,
 			new MultipleJGitEnvironmentProperties());
 	private String defaultUri;
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
@@ -19,7 +19,10 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.cloud.config.environment.Environment;
@@ -46,6 +49,12 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 	private StandardEnvironment environment = new StandardEnvironment();
 	private MultipleJGitEnvironmentRepository repository = new MultipleJGitEnvironmentRepository(this.environment,
 			new MultipleJGitEnvironmentProperties());
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
@@ -25,9 +25,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.jgit.junit.MockSystemReader;
 import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
@@ -58,6 +61,12 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 
 	@Rule
 	public ExpectedException expected = ExpectedException.none();
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
@@ -23,7 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.junit.MockSystemReader;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,6 +61,12 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	private StandardEnvironment environment = new StandardEnvironment();
 	private MultipleJGitEnvironmentRepository repository;
 
+
+	@BeforeClass
+	public static void initClass() {
+		// mock Git configuration to make tests independent of local Git configuration
+		SystemReader.setInstance(new MockSystemReader());
+	}
 
 	@Before
 	public void init() throws Exception {


### PR DESCRIPTION
Without any preparations JGit defaults to read system / user / project
configuration from local file system. Users running tests locally
might see test failures due to their config diverging from the test
author config.

For me JGitEnvironmentRepositoryIntegrationTests.pullDirtyRepo() was
constantly failing, because JGit calculated a different hash for the
created commit than on the build server.