### PR TITLE
add support for multiple vault secrets engines

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -559,7 +559,7 @@ To enable the config server to use a Vault backend, you can run your config serv
 For example, in your config server's `application.properties`, you can add `spring.profiles.active=vault`.
 
 By default, the config server assumes that your Vault server runs at `http://127.0.0.1:8200`.
-It also assumes that the name of backend is `secret` and the key is `application`.
+It also assumes that the use of a single backend named `secret` and a default key named `application`.
 All of these defaults can be configured in your config server's `application.properties`.
 The following table describes configurable Vault properties:
 
@@ -575,8 +575,8 @@ The following table describes configurable Vault properties:
 |scheme
 |http
 
-|backend
-|secret
+|backends
+|[secret]
 
 |defaultKey
 |application
@@ -636,13 +636,13 @@ You should see a response similar to the following:
    "state":null,
    "propertySources":[
       {
-         "name":"vault:myapp",
+         "name":"vault/secret:myapp",
          "source":{
             "foo":"myappsbar"
          }
       },
       {
-         "name":"vault:application",
+         "name":"vault/secret:application",
          "source":{
             "baz":"bam",
             "foo":"bar"

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.cloud.config.server.proxy.ProxyHostProperties;
 import org.springframework.cloud.config.server.support.HttpEnvironmentRepositoryProperties;
 import org.springframework.core.Ordered;
@@ -43,7 +44,7 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	/** Timeout (in seconds) for obtaining HTTP connection, defaults to 5 seconds. */
 	private int timeout = 5;
 
-	/** Vault backend. Defaults to secret. */
+	/** Vault backend. Defaults to a single backend named secret. */
 	private String[] backends = new String[] { "secret" };
 
 	/**
@@ -101,6 +102,18 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	public void setScheme(String scheme) {
 		this.scheme = scheme;
+	}
+
+	@DeprecatedConfigurationProperty(replacement = "spring.cloud.config.server.vault.backends")
+	@Deprecated
+	public String getBackend() {
+		return this.backends != null && this.backends.length > 0 ? this.backends[0]
+				: null;
+	}
+
+	@Deprecated
+	public void setBackend(String backend) {
+		setBackends(new String[] { backend });
 	}
 
 	public String[] getBackends() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -44,7 +44,7 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	private int timeout = 5;
 
 	/** Vault backend. Defaults to secret. */
-	private String backend = "secret";
+	private String[] backends = new String[] { "secret" };
 
 	/**
 	 * The key in vault shared by all applications. Defaults to application. Set to empty
@@ -74,7 +74,8 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	private int kvVersion = 1;
 
 	/**
-	 * The value of the Vault X-Vault-Namespace header. Defaults to null. This a Vault Enterprise feature only.
+	 * The value of the Vault X-Vault-Namespace header. Defaults to null. This a Vault
+	 * Enterprise feature only.
 	 */
 	private String namespace;
 
@@ -102,12 +103,12 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 		this.scheme = scheme;
 	}
 
-	public String getBackend() {
-		return this.backend;
+	public String[] getBackends() {
+		return this.backends;
 	}
 
-	public void setBackend(String backend) {
-		this.backend = backend;
+	public void setBackends(String[] backends) {
+		this.backends = backends;
 	}
 
 	public String getDefaultKey() {
@@ -172,7 +173,7 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	}
 
 	public String getNamespace() {
-		return namespace;
+		return this.namespace;
 	}
 
 	public void setNamespace(String namespace) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -112,6 +112,7 @@ public class VaultEnvironmentRepositoryTests {
 				.isEqualTo(secondResult);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBackendWithSlashes() {
 		MockHttpServletRequest configRequest = new MockHttpServletRequest();
@@ -123,7 +124,7 @@ public class VaultEnvironmentRepositoryTests {
 				"application");
 
 		VaultEnvironmentProperties properties = new VaultEnvironmentProperties();
-		properties.setBackends(new String[] { "foo/bar/secret" });
+		properties.setBackend("foo/bar/secret");
 
 		VaultEnvironmentRepository repo = new VaultEnvironmentRepository(
 				mockProvide(configRequest), new EnvironmentWatch.Default(), rest,
@@ -188,13 +189,13 @@ public class VaultEnvironmentRepositoryTests {
 		result.clear();
 		result.put("def-foo1", "def-bar1");
 		assertThat(e.getPropertySources().get(2).getSource()).as(
-				"Properties for default application with key 'application' and the first backend should be returned in third position")
+				"Properties for default application with key 'application' and first backend should be in third position")
 				.isEqualTo(result);
 
 		result.clear();
 		result.put("def-foo2", "def-bar2");
 		assertThat(e.getPropertySources().get(3).getSource()).as(
-				"Properties for default application with key 'application' and the second backend should be returned in fourth position")
+				"Properties for default application with key 'application' and second backend should be in fourth position")
 				.isEqualTo(result);
 	}
 


### PR DESCRIPTION
To address the issue #1270 

Changes the property backend to backends and makes it a string array. Leaves "secret" as the default.
Updates the name for the property source to be "vault/{backend}:{key}" instead of just "vault:{key}"