### PR TITLE
Support explicit file name definition for app properties

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -264,7 +264,7 @@ public class NativeEnvironmentRepository
 	private String[] getArgs(String application, String profile, String label) {
 		List<String> list = new ArrayList<String>();
 		String config = application;
-		String searchNames = this.environment.getProperty("spring.cloud.config.name");
+		String searchNames = this.environment.getProperty("spring.cloud.config.server.searchNames");
 		if (searchNames != null && !searchNames.isEmpty()) {
 			config += "," + searchNames;
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -264,6 +264,10 @@ public class NativeEnvironmentRepository
 	private String[] getArgs(String application, String profile, String label) {
 		List<String> list = new ArrayList<String>();
 		String config = application;
+		String searchNames = this.environment.getProperty("spring.cloud.config.name");
+		if (searchNames != null && !searchNames.isEmpty()) {
+			config += "," + searchNames;
+		}
 		if (!config.startsWith("application")) {
 			config = "application," + config;
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -264,9 +264,15 @@ public class NativeEnvironmentRepository
 	private String[] getArgs(String application, String profile, String label) {
 		List<String> list = new ArrayList<String>();
 		String config = application;
-		String searchNames = this.environment.getProperty("spring.cloud.config.server.searchNames");
-		if (searchNames != null && !searchNames.isEmpty()) {
-			config += "," + searchNames;
+		String globalSearchNames = this.environment
+			.getProperty("spring.cloud.config.server.searchNames");
+		if (globalSearchNames != null && !globalSearchNames.trim().isEmpty()) {
+			config += "," + globalSearchNames.trim();
+		}
+		String applicationSearchNames = this.environment
+			.getProperty("spring.cloud.config.server." + application + ".searchNames");
+		if (applicationSearchNames != null && !applicationSearchNames.trim().isEmpty()) {
+			config += "," + applicationSearchNames.trim();
 		}
 		if (!config.startsWith("application")) {
 			config = "application," + config;


### PR DESCRIPTION
spring-cloud-config-server now supports explicit definition of additional
file names that contain properties to be served, in either native or scm
operation mode. The file names are defined by means of the
"spring.cloud.config.name" environment property. Implementation is
applied on NativeEnvironmentRepository (native profile), which is also
used by AbstractScmEnvironmentRepository; it essentially appends the
file names, provided in the "spring.cloud.config.name" environment
property to those already computed by NativeEnvironmentRepository.
(Note that the latter leverages the ConfigFileApplicationListener
functionality by booting a mini app and passing these computed file names
as a value of the "spring.config.name" environment property, in order to
collect their properties).