### PR TITLE
URL Cleanup

### DIFF
--- a/1.3.x/spring-cloud-config.xml
+++ b/1.3.x/spring-cloud-config.xml
@@ -386,14 +386,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -436,20 +436,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -577,15 +577,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -594,7 +594,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/1.4.x/spring-cloud-config.xml
+++ b/1.4.x/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -605,15 +605,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -644,7 +644,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/2.0.x/spring-cloud-config.xml
+++ b/2.0.x/spring-cloud-config.xml
@@ -398,14 +398,14 @@ at startup. For example at the top level:</simpara>
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In this example the server clones team-a&#8217;s config-repo on startup before it
 accepts any requests. All other repositories will not be cloned until
 configuration from the repository is requested.</simpara>
@@ -448,20 +448,20 @@ http.sslVerify false</literal>).</simpara>
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara><link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
+<simpara><link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication can also be
 done. AWS CodeCommit uses an authentication helper when using Git from the command line. This helper is not
 used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit will be created if the Git
 URI matches the AWS CodeCommit pattern. AWS CodeCommit URIs always look like
 <link xl:href="https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}">https://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}</link>.</simpara>
 <simpara>If you provide a username and password with an AWS CodeCommit URI, then these must be
-the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
+the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link>
 to be used to access the repository. If you do not specify a username and password,
 then the accessKeyId and secretAccessKey will be retrieved using the
-<link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (above) then you must provide
 valid AWS credentials in the username and password, or in one of the locations supported
 by the default credential provider chain. AWS EC2 instances may use
-<link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+<link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <simpara>Note: The aws-java-sdk-core jar is an optional dependency. If the aws-java-sdk-core jar is not on your
 classpath, then the AWS Code Commit credential provider will not be created regardless of the git server URI.</simpara>
 </section>
@@ -597,15 +597,15 @@ Example:</simpara>
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -614,7 +614,7 @@ Example:</simpara>
 <section xml:id="_version_control_backend_filesystem_use">
 <title>Version Control Backend Filesystem Use</title>
 <warning>
-<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
+<simpara>With VCS based backends (git, svn) files are checked out or cloned to the local filesystem. By default they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>. On linux, for example it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>. Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories. This can lead to unexpected behaviour such as missing properties. To avoid this problem, change the directory Config Server uses, by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>
 </section>
 <section xml:id="_file_system_backend">

--- a/2.1.x/spring-cloud-config.xml
+++ b/2.1.x/spring-cloud-config.xml
@@ -349,14 +349,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -390,14 +390,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -528,15 +528,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -578,7 +578,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-config.xml
+++ b/spring-cloud-config.xml
@@ -349,14 +349,14 @@ The server can be configured to clone the repositories at startup, as shown in t
             team-a:
                 pattern: team-a-*
                 cloneOnStart: true
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
             team-b:
                 pattern: team-b-*
                 cloneOnStart: false
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <simpara>In the preceding example, the server clones team-a&#8217;s config-repo on startup, before it
 accepts any requests.
 All other repositories are not cloned until configuration from the repository is requested.</simpara>
@@ -390,14 +390,14 @@ system properties (<literal>-Dhttps.proxyHost</literal> and <literal>-Dhttps.pro
 </section>
 <section xml:id="_authentication_with_aws_codecommit">
 <title>Authentication with AWS CodeCommit</title>
-<simpara>Spring Cloud Config Server also supports <link xl:href="http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
+<simpara>Spring Cloud Config Server also supports <link xl:href="https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html">AWS CodeCommit</link> authentication.
 AWS CodeCommit uses an authentication helper when using Git from the command line.
 This helper is not used with the JGit library, so a JGit CredentialProvider for AWS CodeCommit is created if the Git URI matches the AWS CodeCommit pattern.
 AWS CodeCommit URIs follow this pattern://git-codecommit.${AWS_REGION}.amazonaws.com/${repopath}.</simpara>
-<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
+<simpara>If you provide a username and password with an AWS CodeCommit URI, they must be the <link xl:href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html">AWS accessKeyId and secretAccessKey</link> that provide access to the repository.
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the <link xl:href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS Default Credential Provider Chain</link>.</simpara>
 <simpara>If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
-AWS EC2 instances may use <link xl:href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
+AWS EC2 instances may use <link xl:href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html">IAM Roles for EC2 Instances</link>.</simpara>
 <note>
 <simpara>The <literal>aws-java-sdk-core</literal> jar is an optional dependency.
 If the <literal>aws-java-sdk-core</literal> jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.</simpara>
@@ -528,15 +528,15 @@ folder content changes by an OS process) such that Spring Cloud Config Server ca
           repos:
             team-a:
                 pattern: team-a-*
-                uri: http://git/team-a/config-repo.git
+                uri: https://git/team-a/config-repo.git
                 force-pull: true
             team-b:
                 pattern: team-b-*
-                uri: http://git/team-b/config-repo.git
+                uri: https://git/team-b/config-repo.git
                 force-pull: true
             team-c:
                 pattern: team-c-*
-                uri: http://git/team-a/config-repo.git</programlisting>
+                uri: https://git/team-a/config-repo.git</programlisting>
 <note>
 <simpara>The default value for <literal>force-pull</literal> property is <literal>false</literal>.</simpara>
 </note>
@@ -578,7 +578,7 @@ is requested.</simpara>
 <simpara>With VCS-based backends (git, svn), files are checked out or cloned to the local filesystem.
 By default, they are put in the system temporary directory with a prefix of <literal>config-repo-</literal>.
 On linux, for example, it could be <literal>/tmp/config-repo-&lt;randomid&gt;</literal>.
-Some operating systems <link xl:href="http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
+Some operating systems <link xl:href="https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349#377349">routinely clean out</link> temporary directories.
 This can lead to unexpected behavior, such as missing properties.
 To avoid this problem, change the directory that Config Server uses by setting <literal>spring.cloud.config.server.git.basedir</literal> or <literal>spring.cloud.config.server.svn.basedir</literal> to a directory that does not reside in the system temp structure.</simpara>
 </warning>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://myconfigserver.com (200) with 5 occurrences could not be migrated:  
   ([https](https://myconfigserver.com) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://git/team-a/config-repo.git (UnknownHostException) with 20 occurrences migrated to:  
  https://git/team-a/config-repo.git ([https](https://git/team-a/config-repo.git) result UnknownHostException).
* [ ] http://git/team-b/config-repo.git (UnknownHostException) with 10 occurrences migrated to:  
  https://git/team-b/config-repo.git ([https](https://git/team-b/config-repo.git) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html with 5 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html ([https](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) result 200).
* [ ] http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html with 5 occurrences migrated to:  
  https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html ([https](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) result 200).
* [ ] http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html with 5 occurrences migrated to:  
  https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html ([https](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) result 200).
* [ ] http://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349 with 5 occurrences migrated to:  
  https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349 ([https](https://serverfault.com/questions/377348/when-does-tmp-get-cleared/377349) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html with 5 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8200 with 10 occurrences
* http://docbook.org/ns/docbook with 5 occurrences
* http://localhost:8888 with 5 occurrences
* http://localhost:8888/myapp/default with 5 occurrences
* http://user:password@localhost:8888 with 5 occurrences
* http://www.w3.org/1999/xlink with 5 occurrences
* http://www.w3.org/2000/svg with 1 occurrences