### PR TITLE
Support ConfigClientWatch for 'config.client.version' property

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java
@@ -20,11 +20,13 @@ import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 
 /**
@@ -35,6 +37,7 @@ import org.springframework.core.env.Environment;
  *
  * @author Dave Syer
  * @author Marcos Barbero
+ * @author Ingyu Hwang
  *
  */
 @Configuration
@@ -79,9 +82,33 @@ public class ConfigClientAutoConfiguration {
 	@ConditionalOnProperty("spring.cloud.config.watch.enabled")
 	protected static class ConfigClientWatchConfiguration {
 
-		@Bean
-		public ConfigClientWatch configClientWatch(ContextRefresher contextRefresher) {
-			return new ConfigClientWatch(contextRefresher);
+		@Configuration
+		@ConditionalOnMissingBean(ConfigClientWatch.class)
+		static class DefaultWatchConfiguration {
+
+			@Bean
+			public ConfigClientVersionWatch configClientVersionWatch(
+					ContextRefresher contextRefresher) {
+				return new ConfigClientVersionWatch(contextRefresher);
+			}
+
+		}
+
+		@Configuration
+		@Profile("git")
+		static class VersionWatchConfiguration extends DefaultWatchConfiguration {
+		}
+
+		@Configuration
+		@Profile("vault")
+		static class StateWatchConfiguration {
+
+			@Bean
+			public ConfigClientStateWatch configClientStateWatch(
+					ContextRefresher contextRefresher) {
+				return new ConfigClientStateWatch(contextRefresher);
+			}
+
 		}
 
 	}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientStateWatch.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientStateWatch.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * @author Spencer Gibb
+ */
+public class ConfigClientStateWatch
+		implements ConfigClientWatch, Closeable, EnvironmentAware {
+
+	private static Log log = LogFactory.getLog(ConfigServicePropertySourceLocator.class);
+
+	private final AtomicBoolean running = new AtomicBoolean(false);
+
+	private final ContextRefresher refresher;
+
+	private Environment environment;
+
+	public ConfigClientStateWatch(ContextRefresher refresher) {
+		this.refresher = refresher;
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@PostConstruct
+	public void start() {
+		this.running.compareAndSet(false, true);
+	}
+
+	@Override
+	@Scheduled(initialDelayString = "${spring.cloud.config.watch.initialDelay:180000}",
+			fixedDelayString = "${spring.cloud.config.watch.delay:500}")
+	public void watchConfigServer() {
+		if (this.running.get()) {
+			String newState = this.environment.getProperty("config.client.state");
+			String oldState = ConfigClientStateHolder.getState();
+
+			// only refresh if state has changed
+			if (stateChanged(oldState, newState)) {
+				ConfigClientStateHolder.setState(newState);
+				this.refresher.refresh();
+			}
+		}
+	}
+
+	/* for testing */ boolean stateChanged(String oldState, String newState) {
+		return (!hasText(oldState) && hasText(newState))
+				|| (hasText(oldState) && !oldState.equals(newState));
+	}
+
+	@Override
+	public void close() {
+		this.running.compareAndSet(true, false);
+	}
+
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientVersionHolder.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientVersionHolder.java
@@ -16,23 +16,31 @@
 
 package org.springframework.cloud.config.client;
 
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
- * @author Spencer Gibb
+ * @author Ingyu Hwang
  */
-public class ConfigClientWatchTests {
+public final class ConfigClientVersionHolder {
 
-	@Test
-	public void stateChangedWorks() {
-		ConfigClientWatch watch = new ConfigClientWatch(null);
-		assertThat(watch.stateChanged(null, "1")).isTrue();
-		assertThat(watch.stateChanged("1", "2")).isTrue();
-		assertThat(watch.stateChanged("1", null)).isTrue();
-		assertThat(watch.stateChanged("1", "1")).isFalse();
-		watch.close();
+	private ConfigClientVersionHolder() {
+		throw new IllegalStateException("Can't instantiate a utility class");
+	}
+
+	private static ThreadLocal<String> version = new ThreadLocal<>();
+
+	public static void resetVersion() {
+		version.remove();
+	}
+
+	public static String getVersion() {
+		return version.get();
+	}
+
+	public static void setVersion(String newVersion) {
+		if (newVersion == null) {
+			resetVersion();
+			return;
+		}
+		version.set(newVersion);
 	}
 
 }

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientVersionWatch.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientVersionWatch.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * @author Ingyu Hwang
+ */
+public class ConfigClientVersionWatch
+		implements ConfigClientWatch, Closeable, EnvironmentAware {
+
+	private static Log log = LogFactory.getLog(ConfigServicePropertySourceLocator.class);
+
+	private final AtomicBoolean running = new AtomicBoolean(false);
+
+	private final ContextRefresher refresher;
+
+	private Environment environment;
+
+	public ConfigClientVersionWatch(ContextRefresher refresher) {
+		this.refresher = refresher;
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@PostConstruct
+	public void start() {
+		this.running.compareAndSet(false, true);
+	}
+
+	@Override
+	@Scheduled(initialDelayString = "${spring.cloud.config.watch.initialDelay:180000}",
+			fixedDelayString = "${spring.cloud.config.watch.delay:500}")
+	public void watchConfigServer() {
+		if (this.running.get()) {
+			String newVersion = this.environment.getProperty("config.client.version");
+			String oldVersion = ConfigClientVersionHolder.getVersion();
+
+			// only refresh if version has changed
+			if (versionChanged(oldVersion, newVersion)) {
+				ConfigClientVersionHolder.setVersion(newVersion);
+				this.refresher.refresh();
+			}
+		}
+	}
+
+	/* for testing */ boolean versionChanged(String oldVersion, String newVersion) {
+		return (!hasText(oldVersion) && hasText(newVersion))
+				|| (hasText(oldVersion) && !oldVersion.equals(newVersion));
+	}
+
+	@Override
+	public void close() {
+		this.running.compareAndSet(true, false);
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientStateWatchTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientStateWatchTests.java
@@ -16,11 +16,23 @@
 
 package org.springframework.cloud.config.client;
 
-/**
- * @author Ingyu Hwang
- */
-public interface ConfigClientWatch {
+import org.junit.Test;
 
-	void watchConfigServer();
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Spencer Gibb
+ */
+public class ConfigClientStateWatchTests {
+
+	@Test
+	public void stateChangedWorks() {
+		ConfigClientStateWatch watch = new ConfigClientStateWatch(null);
+		assertThat(watch.stateChanged(null, "1")).isTrue();
+		assertThat(watch.stateChanged("1", "2")).isTrue();
+		assertThat(watch.stateChanged("1", null)).isTrue();
+		assertThat(watch.stateChanged("1", "1")).isFalse();
+		watch.close();
+	}
 
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientVersionWatchTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientVersionWatchTests.java
@@ -16,11 +16,23 @@
 
 package org.springframework.cloud.config.client;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Ingyu Hwang
  */
-public interface ConfigClientWatch {
+public class ConfigClientVersionWatchTests {
 
-	void watchConfigServer();
+	@Test
+	public void versionChangedWorks() {
+		ConfigClientVersionWatch watch = new ConfigClientVersionWatch(null);
+		assertThat(watch.versionChanged(null, "1")).isTrue();
+		assertThat(watch.versionChanged("1", "2")).isTrue();
+		assertThat(watch.versionChanged("1", null)).isTrue();
+		assertThat(watch.versionChanged("1", "1")).isFalse();
+		watch.close();
+	}
 
 }


### PR DESCRIPTION
Fixes gh-1378

- `ConfigClientWatch` is renamed as `ConfigClientStateWatch`.
- `ConfigClientWatch` is added as interface.
- `ConfigClientVersionWatch` is watching `config.clientversion` property. it works well with git backend.
