### PR TITLE
Add abstraction for retrieving config token.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/VaultConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/VaultConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.config.server.environment.ConfigTokenProvider;
+import org.springframework.cloud.config.server.environment.EnvironmentConfigTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Scott Frederick
+ */
+@Configuration
+public class VaultConfiguration {
+
+	private static final String VAULT_TOKEN_PROPERTY_NAME = "spring.cloud.config.server.vault.token";
+
+	@Bean
+	@ConditionalOnProperty(VAULT_TOKEN_PROPERTY_NAME)
+	public ConfigTokenProvider configTokenProvider(Environment environment) {
+		return new EnvironmentConfigTokenProvider(environment, VAULT_TOKEN_PROPERTY_NAME);
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/ConfigTokenProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/ConfigTokenProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+/**
+ * @author Scott Frederick
+ */
+public interface ConfigTokenProvider {
+
+	String getToken();
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentConfigTokenProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentConfigTokenProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Scott Frederick
+ */
+public class EnvironmentConfigTokenProvider implements ConfigTokenProvider {
+
+	private final Environment environment;
+
+	private final String propertyName;
+
+	public EnvironmentConfigTokenProvider(Environment environment, String propertyName) {
+		this.environment = environment;
+		this.propertyName = propertyName;
+	}
+
+	@Override
+	public String getToken() {
+		return environment.getProperty(propertyName);
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.config.client.ConfigClientProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Scott Frederick
+ */
+public class HttpRequestConfigTokenProvider implements ConfigTokenProvider {
+
+	private ObjectProvider<HttpServletRequest> httpRequest;
+
+	public HttpRequestConfigTokenProvider(
+			ObjectProvider<HttpServletRequest> httpRequest) {
+		this.httpRequest = httpRequest;
+	}
+
+	@Override
+	public String getToken() {
+		HttpServletRequest request = httpRequest.getIfAvailable();
+		if (request == null) {
+			throw new IllegalStateException("No HttpServletRequest available");
+		}
+
+		String token = request.getHeader(ConfigClientProperties.TOKEN_HEADER);
+		if (!StringUtils.hasLength(token)) {
+			throw new IllegalArgumentException(
+					"Missing required header in HttpServletRequest: "
+							+ ConfigClientProperties.TOKEN_HEADER);
+		}
+
+		return token;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryFactory.java
@@ -25,15 +25,18 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Dylan Roberts
+ * @author Scott Frederick
  */
 public class VaultEnvironmentRepositoryFactory implements
 		EnvironmentRepositoryFactory<VaultEnvironmentRepository, VaultEnvironmentProperties> {
 
-	private ObjectProvider<HttpServletRequest> request;
+	private final ObjectProvider<HttpServletRequest> request;
 
-	private EnvironmentWatch watch;
+	private final EnvironmentWatch watch;
 
-	private Optional<VaultRestTemplateFactory> vaultRestTemplateFactory;
+	private final Optional<VaultRestTemplateFactory> vaultRestTemplateFactory;
+
+	private final ConfigTokenProvider tokenProvider;
 
 	public VaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request,
 			EnvironmentWatch watch,
@@ -41,6 +44,17 @@ public class VaultEnvironmentRepositoryFactory implements
 		this.request = request;
 		this.watch = watch;
 		this.vaultRestTemplateFactory = vaultRestTemplateFactory;
+		this.tokenProvider = new HttpRequestConfigTokenProvider(request);
+	}
+
+	public VaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request,
+			EnvironmentWatch watch,
+			Optional<VaultRestTemplateFactory> vaultRestTemplateFactory,
+			ConfigTokenProvider tokenProvider) {
+		this.request = request;
+		this.watch = watch;
+		this.vaultRestTemplateFactory = vaultRestTemplateFactory;
+		this.tokenProvider = tokenProvider;
 	}
 
 	@Override
@@ -50,10 +64,10 @@ public class VaultEnvironmentRepositoryFactory implements
 			RestTemplate restTemplate = this.vaultRestTemplateFactory.get()
 					.build(environmentProperties);
 			return new VaultEnvironmentRepository(this.request, this.watch, restTemplate,
-					environmentProperties);
+					environmentProperties, tokenProvider);
 		}
 		return new VaultEnvironmentRepository(this.request, this.watch,
-				new RestTemplate(), environmentProperties);
+				new RestTemplate(), environmentProperties, tokenProvider);
 	}
 
 	/**

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProviderTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Scott Frederick
+ */
+public class HttpRequestConfigTokenProviderTests {
+
+	private ObjectProvider<HttpServletRequest> httpRequestProvider;
+
+	private HttpRequestConfigTokenProvider tokenProvider;
+
+	@Before
+	@SuppressWarnings("unchecked")
+	public void setUp() {
+		httpRequestProvider = mock(ObjectProvider.class);
+		tokenProvider = new HttpRequestConfigTokenProvider(httpRequestProvider);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void missingHttpRequest() {
+		when(httpRequestProvider.getIfAvailable()).thenReturn(null);
+		tokenProvider.getToken();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void missingTokenHeader() {
+		when(httpRequestProvider.getIfAvailable())
+				.thenReturn(new MockHttpServletRequest());
+		tokenProvider.getToken();
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryIntegrationTests.java
@@ -58,9 +58,11 @@ public class VaultEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void withSslValidation() throws Exception {
+		ObjectProvider<HttpServletRequest> request = withRequest();
 		VaultEnvironmentRepositoryFactory vaultEnvironmentRepositoryFactory = new VaultEnvironmentRepositoryFactory(
-				withRequest(), new EnvironmentWatch.Default(),
-				Optional.of(new HttpClientVaultRestTemplateFactory()));
+				request, new EnvironmentWatch.Default(),
+				Optional.of(new HttpClientVaultRestTemplateFactory()),
+				withTokenProvider(request));
 		VaultEnvironmentRepository vaultEnvironmentRepository = vaultEnvironmentRepositoryFactory
 				.build(withEnvironmentProperties(false));
 		this.expectedException.expectCause(instanceOf(SSLHandshakeException.class));
@@ -70,9 +72,11 @@ public class VaultEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void skipSslValidation() throws Exception {
+		ObjectProvider<HttpServletRequest> request = withRequest();
 		VaultEnvironmentRepositoryFactory vaultEnvironmentRepositoryFactory = new VaultEnvironmentRepositoryFactory(
-				withRequest(), new EnvironmentWatch.Default(),
-				Optional.of(new HttpClientVaultRestTemplateFactory()));
+				request, new EnvironmentWatch.Default(),
+				Optional.of(new HttpClientVaultRestTemplateFactory()),
+				withTokenProvider(request));
 		VaultEnvironmentRepository vaultEnvironmentRepository = vaultEnvironmentRepositoryFactory
 				.build(withEnvironmentProperties(true));
 
@@ -97,6 +101,11 @@ public class VaultEnvironmentRepositoryIntegrationTests {
 		ObjectProvider<HttpServletRequest> requestProvider = mock(ObjectProvider.class);
 		when(requestProvider.getIfAvailable()).thenReturn(request);
 		return requestProvider;
+	}
+
+	private ConfigTokenProvider withTokenProvider(
+			ObjectProvider<HttpServletRequest> request) {
+		return new HttpRequestConfigTokenProvider(request);
 	}
 
 	@SpringBootConfiguration


### PR DESCRIPTION
The VaultEnvironmentRepository requires a token to be passed in a X-Config-Token header in an HttpServletRequest. This doesn't work well when config server is embedded in an application, as an HttpServletRequest is not available in that case.

These changes allows the Vault token to be provided in the HttpServletRequest header (the default behavior) or as a configuration property.

Fixes #1393