### PR TITLE
fix svnKitEnvironmentRepository param order

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -307,8 +307,8 @@ class SvnRepositoryConfiguration {
 
 	@Bean
 	public SvnKitEnvironmentRepository svnKitEnvironmentRepository(
-			SvnKitEnvironmentProperties environmentProperties,
-			SvnEnvironmentRepositoryFactory factory) {
+			SvnEnvironmentRepositoryFactory factory,
+			SvnKitEnvironmentProperties environmentProperties) {
 		return factory.build(environmentProperties);
 	}
 


### PR DESCRIPTION
Fix svnKitEnvironmentRepository param in the same order as in all configuration