### PR TITLE
Add documentation for Authorization headers.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1518,6 +1518,8 @@ public class CustomConfigServiceBootstrapConfiguration {
 }
 ----
 
+NOTE: For a simplified approach to adding `Authorization` headers, the `spring.cloud.config.headers.*` property can be used instead.
+
 2. In `resources/META-INF`, create a file called
 `spring.factories` and specify your custom configuration, as shown in the following example:
 


### PR DESCRIPTION
### What does this PR do?

Adding a small amount of documentation regarding adding headers - specifically around authorization. Reason is while the existing documentation works just fine, it can be too complicated for some use cases. For example, I just needed to add a JWT token based on an environment variable. 

I found https://github.com/spring-cloud/spring-cloud-config/pull/474, through searching, but this turned out to be a deprecated feature in favor of the `spring.cloud.config.headers.*` property. I finally figured this out after a couple hours of debugging.

To help bring visibility to this feature, and imply the `spring.cloud.config.authorization` property is deprecated, I want to add this note to the documentation.