### PR TITLE
Placeholder Replacement At End Of URL Is Broken

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
@@ -117,7 +117,9 @@ public class HttpClientConfigurableHttpConnectionFactory
 	private String getUrlWithPlaceholders(URL url, String key) {
 		String spec = url.toString();
 		String[] tokens = key.split(PLACEHOLDER_PATTERN);
-		if (tokens.length > 1) {
+		// if token[0] equals url then there was no placeholder in the the url, so
+		// matching needed
+		if (tokens.length >= 1 && !tokens[0].equals(url.toString())) {
 			List<String> placeholders = getPlaceholders(key);
 			List<String> values = getValues(spec, tokens);
 			if (placeholders.size() == values.size()) {
@@ -140,6 +142,9 @@ public class HttpClientConfigurableHttpConnectionFactory
 			if (valueTokens.length > 1) {
 				spec = valueTokens[1];
 			}
+		}
+		if (tokens.length == 1 && !StringUtils.isEmpty(spec)) {
+			values.add(spec);
 		}
 		return values;
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactoryTest.java
@@ -105,6 +105,23 @@ public class HttpClientConfigurableHttpConnectionFactoryTest {
 	}
 
 	@Test
+	public void urlWithPlaceholdersAtEnd() throws Exception {
+		MultipleJGitEnvironmentProperties properties = new MultipleJGitEnvironmentProperties();
+		properties.setUri("https://localhost/v1/repos/pvvts_configs-{application}");
+		this.connectionFactory.addConfiguration(properties);
+
+		HttpConnection actualConnection = this.connectionFactory.create(
+				new URL("https://localhost/v1/repos/pvvts_configs-applicationPasswords"
+						+ "/some/path.properties"));
+
+		HttpClientBuilder expectedHttpClientBuilder = this.connectionFactory.httpClientBuildersByUri
+				.values().stream().findFirst().get();
+		HttpClientBuilder actualHttpClientBuilder = getActualHttpClientBuilder(
+				actualConnection);
+		assertThat(actualHttpClientBuilder).isSameAs(expectedHttpClientBuilder);
+	}
+
+	@Test
 	public void composite_sameHost() throws Exception {
 		MultipleJGitEnvironmentProperties properties1 = new MultipleJGitEnvironmentProperties();
 		properties1.setUri("http://localhost/test1.git");


### PR DESCRIPTION
If there is a git URL like `https://localhost/v1/repos/pvvts_configs-{application}` where the placeholder is at the end of the URL our parsing logic breaks.  We assume that there will be something after the placeholder, but in the case above there is not.