### PR TITLE
Sharing default application config in CredHub

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -757,6 +757,17 @@ For example, if you run the following Vault command, all applications using the 
 $ vault write secret/application foo=bar baz=bam
 ----
 
+===== CredHub Server
+
+When using CredHub as a backend, you can share configuration with all applications by placing configuration in `/application/`.
+For example, if you run the following CredHub command, all applications using the config server will have the properties `shared.color1` and `shared.color2` available to them:
+
+[source,sh]
+----
+credhub set --name "/application/default/master/shared" --type=json
+value: {"shared.color1": "blue", "shared.color": "red"}
+----
+
 ==== JDBC Backend
 
 Spring Cloud Config Server supports JDBC (relational database) as a backend for configuration properties.
@@ -868,6 +879,7 @@ All client applications with the name `spring.cloud.config.name=demo-app` will h
 ----
 
 NOTE: When no profile is specified `default` will be used and when no label is specified `master` will be used as a default value.
+NOTE: Values added to `application` will be shared by all the applications.
 
 ===== OAuth 2.0
 You can authenticate with link:https://oauth.net/2/[OAuth 2.0] using link:https://docs.cloudfoundry.org/concepts/architecture/uaa.html[UAA] as a provider.

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
@@ -36,6 +36,12 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository {
 
 	private CredHubOperations credHubOperations;
 
+	private static final String DEFAULT_PROFILE = "default";
+
+	private static final String DEFAULT_LABEL = "master";
+
+	private static final String DEFAULT_APPLICATION = "application";
+
 	public CredhubEnvironmentRepository(CredHubOperations credHubOperations) {
 		this.credHubOperations = credHubOperations;
 	}
@@ -43,10 +49,10 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository {
 	@Override
 	public Environment findOne(String application, String profilesList, String label) {
 		if (StringUtils.isEmpty(profilesList)) {
-			profilesList = "default";
+			profilesList = DEFAULT_PROFILE;
 		}
 		if (StringUtils.isEmpty(label)) {
-			label = "master";
+			label = DEFAULT_LABEL;
 		}
 
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profilesList);
@@ -56,7 +62,11 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository {
 		Map<Object, Object> properties = new HashMap<>();
 		for (String profile : profiles) {
 			properties.putAll(findProperties(application, profile, label));
+			if (!DEFAULT_APPLICATION.equals(application)) {
+				properties.putAll(findProperties(DEFAULT_APPLICATION, profile, label));
+			}
 		}
+
 		environment.add(new PropertySource("credhub-" + application, properties));
 
 		return environment;

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -171,6 +171,27 @@ public class CredhubEnvironmentRepositoryTests {
 				.isEqualTo(expectedValues);
 	}
 
+	@Test
+	public void shouldIncludeDefaultApplicationWhenOtherProvided() {
+		stubCredentials("/my-application/production/mylabel", "toggles", "key1",
+				"value1");
+		stubCredentials("/application/production/mylabel", "abs", "key2", "value2");
+
+		Environment environment = this.credhubEnvironmentRepository
+				.findOne("my-application", "production", "mylabel");
+
+		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getProfiles()).containsExactly("production");
+		assertThat(environment.getName()).isEqualTo("my-application");
+		assertThat(environment.getPropertySources().get(0).getName())
+				.isEqualTo("credhub-my-application");
+		HashMap<Object, Object> expectedValues = new HashMap<>();
+		expectedValues.put("key1", "value1");
+		expectedValues.put("key2", "value2");
+		assertThat(environment.getPropertySources().get(0).getSource())
+				.isEqualTo(expectedValues);
+	}
+
 	private void stubCredentials(String expectedPath, String name, String key,
 			String value) {
 		SimpleCredentialName credentialsName = new SimpleCredentialName(


### PR DESCRIPTION
Always including application as default when reading properties so that it can be shared across all applications to be consistent with other repository implementations.

Updated the docs to reflect the changes.