### PR TITLE
Sharing default application config in CredHub

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -757,6 +757,23 @@ For example, if you run the following Vault command, all applications using the 
 $ vault write secret/application foo=bar baz=bam
 ----
 
+===== CredHub Server
+
+When using CredHub as a backend, you can share configuration with all applications by placing configuration in `/application/` or by placing it in the `default` profile for the application.
+For example, if you run the following CredHub command, all applications using the config server will have the properties `shared.color1` and `shared.color2` available to them:
+
+[source,sh]
+----
+credhub set --name "/application/profile/master/shared" --type=json
+value: {"shared.color1": "blue", "shared.color": "red"}
+----
+
+[source,sh]
+----
+credhub set --name "/my-app/default/master/more-shared" --type=json
+value: {"shared.word1": "hello", "shared.word2": "world"}
+----
+
 ==== JDBC Backend
 
 Spring Cloud Config Server supports JDBC (relational database) as a backend for configuration properties.
@@ -868,6 +885,7 @@ All client applications with the name `spring.cloud.config.name=demo-app` will h
 ----
 
 NOTE: When no profile is specified `default` will be used and when no label is specified `master` will be used as a default value.
+NOTE: Values added to `application` will be shared by all the applications.
 
 ===== OAuth 2.0
 You can authenticate with link:https://oauth.net/2/[OAuth 2.0] using link:https://docs.cloudfoundry.org/concepts/architecture/uaa.html[UAA] as a provider.

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubCompositeConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubCompositeConfigServerIntegrationTests.java
@@ -50,7 +50,7 @@ public class CredhubCompositeConfigServerIntegrationTests extends CredhubIntegra
 
 		assertThat(environment.getPropertySources().isEmpty()).isFalse();
 		assertThat(environment.getPropertySources().get(0).getName())
-				.isEqualTo("credhub-myapp");
+				.isEqualTo("credhub-myapp-master-default");
 		assertThat(environment.getPropertySources().get(0).getSource().toString())
 				.isEqualTo("{key=value}");
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubConfigServerIntegrationTests.java
@@ -49,7 +49,7 @@ public class CredhubConfigServerIntegrationTests extends CredhubIntegrationTest 
 
 		assertThat(environment.getPropertySources().isEmpty()).isFalse();
 		assertThat(environment.getPropertySources().get(0).getName())
-				.isEqualTo("credhub-myapp");
+				.isEqualTo("credhub-myapp-master-default");
 		assertThat(environment.getPropertySources().get(0).getSource().toString())
 				.isEqualTo("{key=value}");
 	}


### PR DESCRIPTION
Always including application as default so that it can be shared across all applications to be consistent with other repository implementations.

Sharing secrets to the application from the default profile.

Updated the docs to reflect the changes