### PR TITLE
Setting git.basedir to relative directory causes NPE

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
@@ -94,8 +94,8 @@ public abstract class AbstractScmAccessor implements ResourceLoaderAware {
 	public AbstractScmAccessor(ConfigurableEnvironment environment,
 			AbstractScmAccessorProperties properties) {
 		this.environment = environment;
-		this.basedir = properties.getBasedir() == null ? createBaseDir()
-				: properties.getBasedir();
+		this.setBasedir(properties.getBasedir() == null ? createBaseDir()
+				: properties.getBasedir());
 		this.passphrase = properties.getPassphrase();
 		this.password = properties.getPassword();
 		this.searchPaths = properties.getSearchPaths();

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
@@ -336,6 +336,18 @@ public class MultipleJGitEnvironmentRepositoryTests {
 		this.repository.afterPropertiesSet();
 	}
 
+	@Test
+	public void exceptionNotThrownIfRelativeBasedirIsPassedByProperties()
+			throws Exception {
+		MultipleJGitEnvironmentProperties props = new MultipleJGitEnvironmentProperties();
+		props.setBasedir(new File("relative"));
+		this.repository = new MultipleJGitEnvironmentRepository(this.environment, props);
+		String defaultUri = ConfigServerTestUtils.prepareLocalRepo("config-repo");
+		this.repository.setUri(defaultUri);
+		this.repository.setRepos(createRepositories());
+		this.repository.afterPropertiesSet();
+	}
+
 	private String getUri(String pattern) {
 		String uri = null;
 


### PR DESCRIPTION
Hi,

Right now setting `baseDir` to relative directory via properties...

```
spring:
  cloud:
    config:
      server:
        git:
          basedir: git-cache
```

...results in NPE being thrown.

The reason is that `AbstractScmAccessor` constructor... https://github.com/spring-cloud/spring-cloud-config/blob/2759ed4ba128257a20c1cd40b4cb50d2d434dffb/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java#L97 ...does not apply setter logic from `AbstractScmAccessor`...  https://github.com/spring-cloud/spring-cloud-config/blob/2759ed4ba128257a20c1cd40b4cb50d2d434dffb/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java#L163 As a result `MultipleJGitEnvironmentRepository` cannot read parent directory of `baseDir` and throwns NPE when attempt to read it... https://github.com/spring-cloud/spring-cloud-config/blob/2759ed4ba128257a20c1cd40b4cb50d2d434dffb/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepository.java#L103

I commited a test case demonstrating the issue and a fix (applying setter logic in `AbstractScmAccessor` constructor).