### PR TITLE
Feature/gh 1283 exception

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.EnvironmentMediaType;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -44,6 +48,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -28,12 +28,6 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.yaml.snakeyaml.DumperOptions.FlowStyle;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.nodes.Tag;
-
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.EnvironmentMediaType;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -47,9 +41,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
-import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
 
 /**
  * @author Dave Syer
@@ -273,6 +267,12 @@ public class EnvironmentController {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public void illegalArgument(HttpServletResponse response) throws IOException {
 		response.sendError(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@ExceptionHandler(EnvironmentException.class)
+	public void environmentException(HttpServletResponse response, EnvironmentException e)
+			throws IOException {
+		response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
 	}
 
 	private void validateProfiles(String profiles) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
-import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +28,11 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.EnvironmentMediaType;
@@ -46,11 +48,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.yaml.snakeyaml.DumperOptions.FlowStyle;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.nodes.Tag;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentException.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+/**
+ * @author Nicolas Homble
+ */
+@SuppressWarnings("serial")
+public class EnvironmentException extends RuntimeException {
+
+	public EnvironmentException(String string) {
+		super(string);
+	}
+
+	public EnvironmentException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/FailedToConstructEnvironmentException.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/FailedToConstructEnvironmentException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+/**
+ * @author Nicolas Homble
+ *
+ */
+@SuppressWarnings("serial")
+public class FailedToConstructEnvironmentException extends EnvironmentException {
+
+	public FailedToConstructEnvironmentException(String string) {
+		super(string);
+	}
+
+	public FailedToConstructEnvironmentException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -616,18 +616,15 @@ public class EnvironmentControllerTests {
 
 	@Test
 	public void handleEnvironmentException() throws Exception {
-	when(repository.findOne(eq("exception"), eq("bad-syntax.ext"), any(), eq(false)))
-	.thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
-		new RuntimeException("underlier")));
-	MockMvc mvc = MockMvcBuilders
-	.standaloneSetup(controller)
-	.setControllerAdvice(controller)
-	.build();
-	MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/exception/bad-syntax.ext"))
-	.andExpect(MockMvcResultMatchers
-		.status().is(500))
-	.andReturn();
-	assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
+		when(repository.findOne(eq("exception"), eq("bad-syntax.ext"), any(), eq(false)))
+				.thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
+						new RuntimeException("underlier")));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(controller).build();
+		MvcResult result = mvc
+				.perform(MockMvcRequestBuilders.get("/exception/bad-syntax.ext"))
+				.andExpect(MockMvcResultMatchers.status().is(500)).andReturn();
+		assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -37,7 +37,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -16,12 +16,6 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -32,6 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.http.MediaType;
@@ -40,6 +35,12 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -613,20 +614,20 @@ public class EnvironmentControllerTests {
 
 	}
 
-  @Test
-  public void handleEnvironmentException() throws Exception {
-    when(repository.findOne(eq("exception"), eq("bad-syntax.ext"), any(), eq(false)))
-        .thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
-            new RuntimeException("underlier")));
-    MockMvc mvc = MockMvcBuilders
-        .standaloneSetup(controller)
-        .setControllerAdvice(controller)
-        .build();
-    MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/exception/bad-syntax.ext"))
-        .andExpect(MockMvcResultMatchers
-            .status().is(500))
-        .andReturn();
-    assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
-  }
+	@Test
+	public void handleEnvironmentException() throws Exception {
+	when(repository.findOne(eq("exception"), eq("bad-syntax.ext"), any(), eq(false)))
+	.thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
+		new RuntimeException("underlier")));
+	MockMvc mvc = MockMvcBuilders
+	.standaloneSetup(controller)
+	.setControllerAdvice(controller)
+	.build();
+	MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/exception/bad-syntax.ext"))
+	.andExpect(MockMvcResultMatchers
+		.status().is(500))
+	.andReturn();
+	assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
+	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -16,28 +16,29 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Dave Syer
@@ -611,5 +612,21 @@ public class EnvironmentControllerTests {
 						.contentType(MediaType.APPLICATION_JSON));
 
 	}
+
+  @Test
+  public void handleEnvironmentException() throws Exception {
+    when(repository.findOne(eq("exception"), eq("bad-syntax.ext"), any(), eq(false)))
+        .thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
+            new RuntimeException("underlier")));
+    MockMvc mvc = MockMvcBuilders
+        .standaloneSetup(controller)
+        .setControllerAdvice(controller)
+        .build();
+    MvcResult result = mvc.perform(MockMvcRequestBuilders.get("/exception/bad-syntax.ext"))
+        .andExpect(MockMvcResultMatchers
+            .status().is(500))
+        .andReturn();
+    assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
+  }
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -37,10 +37,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
@@ -16,16 +16,17 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.server.environment.SearchPathLocator.Locations;
 import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
@@ -16,16 +16,16 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.server.environment.SearchPathLocator.Locations;
 import org.springframework.context.ConfigurableApplicationContext;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -217,6 +217,19 @@ public class NativeEnvironmentRepositoryTests {
 		this.repository.setDefaultLabel("test");
 		assertThat(this.repository.findOne("foo", "default", null).getPropertySources()
 				.get(0).getSource().get("foo")).isEqualTo("test_bar");
+	}
+
+	@Test
+	public void duplicateYamlKeys() {
+		this.repository.setSearchLocations("classpath:/test/bad-syntax");
+		NativeEnvironmentRepository repo = this.repository;
+		assertThatExceptionOfType(FailedToConstructEnvironmentException.class)
+				.isThrownBy(() -> repo.findOne("foo", "master", "default")).withMessage(
+						"Could not construct context for config=foo profile=master label=default includeOrigin=false; nested exception is while constructing a mapping\n"
+								+ " in 'reader', line 1, column 1:\n" + "    key: value\n"
+								+ "    ^\n" + "found duplicate key key\n"
+								+ " in 'reader', line 2, column 1:\n" + "    key: value\n"
+								+ "    ^\n");
 	}
 
 }

--- a/spring-cloud-config-server/src/test/resources/test/bad-syntax/application.yml
+++ b/spring-cloud-config-server/src/test/resources/test/bad-syntax/application.yml
@@ -1,0 +1,2 @@
+key: value
+key: value


### PR DESCRIPTION
Should help resolve GH-1283
When the configurable application context throws an error when constructing the properties (aka snake yml throws a syntax error underneath), then we can wrap the exception in a custom exception to catch upstream.