### PR TITLE
Add error body with info when none of labels found

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -130,6 +130,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 					return composite;
 				}
 			}
+			errorBody = String.format("None of labels %s found", Arrays.toString(labels));
 		}
 		catch (HttpServerErrorException e) {
 			error = e;
@@ -147,8 +148,7 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 							+ (errorBody == null ? "" : ": " + errorBody),
 					error);
 		}
-		logger.warn("Could not locate PropertySource: " + (errorBody == null
-				? error == null ? "label not found" : error.getMessage() : errorBody));
+		logger.warn("Could not locate PropertySource: " + (error != null ? error.getMessage() : errorBody));
 		return null;
 
 	}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -111,10 +111,27 @@ public class ConfigServicePropertySourceLocatorTests {
 	@Test
 	public void sunnyDayWithNoSuchLabel() {
 		mockRequestResponseWithLabel(
-				new ResponseEntity<Void>((Void) null, HttpStatus.NOT_FOUND),
+				new ResponseEntity<>((Void) null, HttpStatus.NOT_FOUND),
 				"nosuchlabel");
 		this.locator.setRestTemplate(this.restTemplate);
 		assertThat(this.locator.locate(this.environment)).isNull();
+	}
+
+	@Test
+	public void sunnyDayWithNoSuchLabelAndFailFast() {
+		ConfigClientProperties defaults = new ConfigClientProperties(this.environment);
+		defaults.setFailFast(true);
+		this.locator = new ConfigServicePropertySourceLocator(defaults);
+		mockRequestResponseWithLabel(
+				new ResponseEntity<>((Void) null, HttpStatus.NOT_FOUND),
+				"release(_)v1.0.0");
+		this.locator.setRestTemplate(this.restTemplate);
+		TestPropertyValues.of("spring.cloud.config.label:release/v1.0.1")
+				.applyTo(this.environment);
+		this.expected.expect(IsInstanceOf.instanceOf(IllegalStateException.class));
+		this.expected.expectMessage(
+				"Could not locate PropertySource and the fail fast property is set, failing: None of labels [release/v1.0.1] found");
+		this.locator.locate(this.environment);
 	}
 
 	@Test


### PR DESCRIPTION
When fail fast is set to true and none of requested labels found, method will return exception with appreciate error body. When fail fast is set to false, there will be an info in warning.