### PR TITLE
feat(#717): clone git submodules

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -711,7 +711,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		}
 
 		public CloneCommand getCloneCommandByCloneRepository() {
-			CloneCommand command = Git.cloneRepository();
+			CloneCommand command = Git.cloneRepository().setCloneSubmodules(true);
 			return command;
 		}
 


### PR DESCRIPTION
clone git repo with all submodules, this can greatly simplifies how to use a global config-repo in many separate child-config-repos.

fixed #717 