### PR TITLE
Fix perf issue of KeyStoreTextEncryptorLocator

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/KeyStoreTextEncryptorLocator.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/KeyStoreTextEncryptorLocator.java
@@ -45,6 +45,8 @@ public class KeyStoreTextEncryptorLocator implements TextEncryptorLocator {
 
 	private String defaultAlias;
 
+	private RsaSecretEncryptor defaultEncryptor;
+
 	private SecretLocator secretLocator = new PassthruSecretLocator();
 
 	private RsaAlgorithm rsaAlgorithm = RsaAlgorithm.DEFAULT;
@@ -83,9 +85,20 @@ public class KeyStoreTextEncryptorLocator implements TextEncryptorLocator {
 	public TextEncryptor locate(Map<String, String> keys) {
 		String alias = keys.containsKey(KEY) ? keys.get(KEY) : this.defaultAlias;
 		String secret = keys.containsKey(SECRET) ? keys.get(SECRET) : this.defaultSecret;
-		return new RsaSecretEncryptor(
-				this.keys.getKeyPair(alias, this.secretLocator.locate(secret)),
-				this.rsaAlgorithm, this.salt, this.strong);
+		if (alias.equals(this.defaultAlias) && secret.equals(this.defaultSecret)) {
+			if (this.defaultEncryptor == null) {
+				this.defaultEncryptor = rsaSecretEncryptor(alias, secret);
+			}
+			return this.defaultEncryptor;
+		}
+		else {
+			return rsaSecretEncryptor(alias, secret);
+		}
 	}
 
+	private RsaSecretEncryptor rsaSecretEncryptor(String alias, String secret) {
+		return new RsaSecretEncryptor(
+			this.keys.getKeyPair(alias, this.secretLocator.locate(secret)),
+			this.rsaAlgorithm, this.salt, this.strong);
+	}
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/KeyStoreTextEncryptorLocatorTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/KeyStoreTextEncryptorLocatorTests.java
@@ -71,4 +71,10 @@ public class KeyStoreTextEncryptorLocatorTests {
 		assertThat(encryptor.decrypt(encryptor.encrypt("foo"))).isEqualTo("foo");
 	}
 
+	@Test
+	public void testDefaultEncryptor() {
+		TextEncryptor encryptor1 = this.locator.locate(Collections.<String, String>emptyMap());
+		TextEncryptor encryptor2 = this.locator.locate(Collections.<String, String>emptyMap());
+		assertThat(encryptor1).isEqualTo(encryptor2);
+	}
 }


### PR DESCRIPTION
CipherEnvironmentEncryptor.decrypt() gets a TextEncryptor for each
environment property by KeyStoreTextEncryptorLocator.locate() which
calls KeyStoreKeyFactory.getKeyPair() to create an instance of
RsaSecretEncrptor.

Unfortunately KeyStoreKeyFactory.getKeyPair() seems extremely slow for
jks files whose format is PKCS12. So we need not to repeat calling the
method if possible.

Reuse an intance of RsaSecretEncrptor to avoid the performance problem.