### PR TITLE
Made sure configTokenProvider default bean will be overridden by more specific versions. Fixing Issue #1485

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -125,6 +125,13 @@ public class EnvironmentRepositoryConfiguration {
 		return new MultipleJGitEnvironmentProperties();
 	}
 
+	@Bean
+	@ConditionalOnMissingBean(ConfigTokenProvider.class)
+	public ConfigTokenProvider configTokenProvider(
+			ObjectProvider<HttpServletRequest> httpRequest) {
+		return new HttpRequestConfigTokenProvider(httpRequest);
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty("spring.cloud.config.server.consul.watch.enabled")
 	protected static class ConsulEnvironmentWatchConfiguration {
@@ -143,18 +150,6 @@ public class EnvironmentRepositoryConfiguration {
 		@Bean
 		public EnvironmentWatch environmentWatch() {
 			return new EnvironmentWatch.Default();
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingBean(ConfigTokenProvider.class)
-	protected static class DefaultConfigTokenProvider {
-
-		@Bean
-		public ConfigTokenProvider configTokenProvider(
-				ObjectProvider<HttpServletRequest> httpRequest) {
-			return new HttpRequestConfigTokenProvider(httpRequest);
 		}
 
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfigurationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfigurationTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.config;
+
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.config.server.environment.ConfigTokenProvider;
+import org.springframework.cloud.config.server.environment.EnvironmentConfigTokenProvider;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvironmentRepositoryConfigurationTests {
+
+	// create an ApplicationContextRunner that will create a context with the
+	// configuration under test.
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations
+					.of(EnvironmentRepositoryConfiguration.class, TestBeans.class));
+
+	@Test
+	public void configTokenProviderCanBeOverridden() {
+		contextRunner.withPropertyValues("spring.profiles.active=composite",
+				"spring.cloud.config.server.vault.authentication=TOKEN",
+				"spring.cloud.config.server.vault.token=testTokenValue",
+				"spring.cloud.config.server.composite[0].type=vault",
+				"spring.cloud.config.server.composite[1].type=git",
+				"spring.cloud.config.server.composite[1].uri=https://test.com/Some-Test-Repo.git")
+				.run((context) -> {
+					assertThat(context.getBean(ConfigTokenProvider.class)).isNotNull();
+					assertThat(context.getBean(ConfigTokenProvider.class))
+							.isInstanceOf(EnvironmentConfigTokenProvider.class);
+					EnvironmentConfigTokenProvider tokenProvider = context
+							.getBean(EnvironmentConfigTokenProvider.class);
+					assertThat(tokenProvider.getToken()).isEqualTo("testTokenValue");
+				});
+	}
+
+	@TestConfiguration
+	public static class TestBeans {
+
+		@Bean
+		public ConfigServerProperties vaultConfigServerProperties() {
+			ConfigServerProperties configServerProperties = new ConfigServerProperties();
+			return configServerProperties;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Made sure configTokenProvider default bean will be overridden by more specific versions (e.g. vault configTokenProvider, etc.)
- Added a test that checks the proper overriding behavior.

This fixes issue #1485 when the configuration of config server profile `composite` is used.
It does NOT fix the problem listed in #1485 that occurs if one uses "spring.profiles.active: git, vault" instead of composite. However, with this fix, the intended setup of #1485 is working.