### PR TITLE
Ensures that config token provider has no overriding bean names

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -132,7 +132,7 @@ public class EnvironmentRepositoryConfiguration {
 	protected static class DefaultConfigTokenProvider {
 
 		@Bean
-		public ConfigTokenProvider configTokenProvider(
+		public ConfigTokenProvider defaultConfigTokenProvider(
 				ObjectProvider<HttpServletRequest> httpRequest) {
 			return new HttpRequestConfigTokenProvider(httpRequest);
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/VaultConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/VaultConfiguration.java
@@ -33,7 +33,7 @@ public class VaultConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(VAULT_TOKEN_PROPERTY_NAME)
-	public ConfigTokenProvider configTokenProvider(Environment environment) {
+	public ConfigTokenProvider vaultConfigTokenProvider(Environment environment) {
 		return new EnvironmentConfigTokenProvider(environment, VAULT_TOKEN_PROPERTY_NAME);
 	}
 


### PR DESCRIPTION
without this change when adding the vault token `spring.cloud.config.server.vault.token` we have 2 config token providers on the classpath, the `VaultConfiguration#configTokenProvider` and the `EnvironmentRepositoryConfiguration$DefaultConfigTokenProvider` both with the same bean name. Starting from Boot 2.2 (AFAIR) that's unacceptable by default.

with this change we're changing the bean name so that we don't override the other bean name.