### PR TITLE
Use LinkedHashSet for deterministic iterations

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/BasePropertyPathNotificationExtractor.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.config.monitor;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,7 +35,7 @@ public abstract class BasePropertyPathNotificationExtractor
 			Map<String, Object> request) {
 		if (requestBelongsToGitRepoManager(headers)) {
 			if (request.get("commits") instanceof Collection) {
-				Set<String> paths = new HashSet<>();
+				Set<String> paths = new LinkedHashSet<>();
 				@SuppressWarnings("unchecked")
 				Collection<Map<String, Object>> commits = (Collection<Map<String, Object>>) request
 						.get("commits");


### PR DESCRIPTION
Test `org.springframework.cloud.config.monitor.GiteePropertyPathNotificationExtractorTests#giteeSample` depends on `extract` in `BasePropertyPathNotificationExtractor`. In the function, it converts a HashSet to an array. But HashSet does not guarantee any specific order of entries. Therefore, the assertion will fail if the iteration order differs.

This PR proposes to change the HashSet to LinkedHashSet for a deterministic iteration order (same as insertion order).