### PR TITLE
Fix for namespace not being propagated on Auth schemes (except Token)

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultClientConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultClientConfiguration.java
@@ -96,9 +96,7 @@ public class SpringVaultClientConfiguration extends AbstractVaultConfiguration {
 				endpointProvider, requestFactory);
 
 		if (vaultProperties.getNamespace() != null) {
-			restTemplateBuilder.customizers(
-					restTemplate -> restTemplate.getInterceptors().add(VaultClients
-							.createNamespaceInterceptor(vaultProperties.getNamespace())));
+			restTemplateBuilder.customizers(this::applyNamespaceInterceptor);
 		}
 
 		return restTemplateBuilder;
@@ -125,6 +123,13 @@ public class SpringVaultClientConfiguration extends AbstractVaultConfiguration {
 		return new SslConfiguration(keyStoreConfiguration, trustStoreConfiguration);
 	}
 
+	@Override
+	public RestOperations restOperations() {
+		RestTemplate restOperations = (RestTemplate) super.restOperations();
+		applyNamespaceInterceptor(restOperations);
+		return restOperations;
+	}
+
 	private SslConfiguration.KeyStoreConfiguration getKeyStoreConfiguration(
 			Resource resourceProperty, String passwordProperty) {
 
@@ -138,6 +143,15 @@ public class SpringVaultClientConfiguration extends AbstractVaultConfiguration {
 		}
 
 		return SslConfiguration.KeyStoreConfiguration.of(resourceProperty);
+	}
+
+	private RestOperations applyNamespaceInterceptor(RestTemplate restTemplate) {
+		if (vaultProperties.getNamespace() != null) {
+			restTemplate.getInterceptors().add(VaultClients
+					.createNamespaceInterceptor(vaultProperties.getNamespace()));
+		}
+
+		return restTemplate;
 	}
 
 	/**


### PR DESCRIPTION
Add X-Vault-Namespace also to auth requests. 
Would get 400 Bad Request - Invalid Role ID (for AppRole auth) otherwise.