### PR TITLE
Expansion of Vault Azure MSI Configuration properties and bug fix.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -525,8 +525,23 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 		 */
 		private String role = "";
 
+		/**
+		 * URI to the Azure MSI IdentityService.
+		 */
+		private String identityTokenService = "";
+
+		private String metadataService = "";
+
 		public String getAzurePath() {
 			return this.azurePath;
+		}
+
+		public String getIdentityTokenService() {
+			return identityTokenService;
+		}
+
+		public String getMetadataService() {
+			return metadataService;
 		}
 
 		public String getRole() {
@@ -535,6 +550,14 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 		public void setAzurePath(String azurePath) {
 			this.azurePath = azurePath;
+		}
+
+		public void setIdentityTokenService(String identityTokenService) {
+			this.identityTokenService = identityTokenService;
+		}
+
+		public void setMetadataService(String metadataService) {
+			this.metadataService = metadataService;
 		}
 
 		public void setRole(String role) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -526,10 +526,13 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 		private String role = "";
 
 		/**
-		 * URI to the Azure MSI IdentityService.
+		 * URI to the Azure MSI Identity Service.
 		 */
 		private String identityTokenService = "";
 
+		/**
+		 * URI to the Azure MSI Metadata Service.
+		 */
 		private String metadataService = "";
 
 		public String getAzurePath() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/authentication/AzureMsiClientAuthenticationProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/authentication/AzureMsiClientAuthenticationProvider.java
@@ -63,4 +63,5 @@ public class AzureMsiClientAuthenticationProvider
 		}
 		return URI.create(uriString);
 	}
+
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/authentication/AzureMsiClientAuthenticationProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/authentication/AzureMsiClientAuthenticationProvider.java
@@ -25,6 +25,8 @@ import org.springframework.vault.authentication.AzureMsiAuthenticationOptions;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.web.client.RestOperations;
 
+import java.net.URI;
+
 public class AzureMsiClientAuthenticationProvider
 		extends SpringVaultClientAuthenticationProvider {
 
@@ -44,10 +46,21 @@ public class AzureMsiClientAuthenticationProvider
 				AuthenticationMethod.AZURE_MSI));
 
 		AzureMsiAuthenticationOptions options = AzureMsiAuthenticationOptions.builder()
-				.role(azureMsi.getRole()).build();
+				.role(azureMsi.getRole()).path(azureMsi.getAzurePath())
+				.instanceMetadataUri(getUri(azureMsi.getMetadataService(),
+						AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI))
+				.identityTokenServiceUri(getUri(azureMsi.getIdentityTokenService(),
+						AzureMsiAuthenticationOptions.DEFAULT_IDENTITY_TOKEN_SERVICE_URI))
+				.build();
 
 		return new AzureMsiAuthentication(options, vaultRestOperations,
 				externalRestOperations);
 	}
 
+	private URI getUri(String uriString, URI defaultUri) {
+		if (uriString == null || uriString.isEmpty()) {
+			return defaultUri;
+		}
+		return URI.create(uriString);
+	}
 }


### PR DESCRIPTION
This merge request is to align Spring Cloud Config Server's Vault Repository using Azure MSI authentication with recent changes in Spring Cloud Vault (https://github.com/spring-projects/spring-vault/pull/542). It allows for expanded configuration of the Azure MSI Authentication Options for non-standard scenarios. 

I believe I've also fixed a bug that prevented the Azure Auth path from being configured via properties resulting in the authentication path always using the default in the AzureMsiAuthenticationOptions.