### PR TITLE
Add index regen if config server has force-pull

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -43,6 +43,7 @@ import org.eclipse.jgit.api.StatusCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.errors.NoRemoteRepositoryException;
 import org.eclipse.jgit.lib.BranchTrackingStatus;
@@ -424,7 +425,15 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 			return false;
 		}
 
-		Status gitStatus = git.status().call();
+		Status gitStatus;
+		try {
+			gitStatus = git.status().call();
+		}
+		catch (JGitInternalException e) {
+			onPullInvalidIndex(git, e);
+			gitStatus = git.status().call();
+		}
+
 		boolean isWorkingTreeClean = gitStatus.isClean();
 		String originUrl = git.getRepository().getConfig().getString("remote", "origin",
 				"url");
@@ -441,6 +450,23 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 					+ ", the working tree is not clean.");
 		}
 		return shouldPull;
+	}
+
+	protected void onPullInvalidIndex(Git git, JGitInternalException e) {
+		if (!e.getMessage().contains("Short read of block.")) {
+			throw e;
+		}
+		if (!this.forcePull) {
+			throw e;
+		}
+		try {
+			new File(getWorkingDirectory(), ".git/index").delete();
+			git.reset().setMode(ResetType.HARD).setRef("HEAD").call();
+		}
+		catch (GitAPIException ex) {
+			e.addSuppressed(ex);
+			throw e;
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
jGit may fail with 'JGitInternalException: Short read of block.'
Due to a truncated git index, which may happen due to external
reasons.
The index can be regenerated easily by deleting it and resetting
git working directory. For a pull force, resetting to HEAD is
more convenient since the info that may have been lost in the
index is the diff in a dirty copy that we are discarding in
any way.

This commits adds automates those steps when git-status fails
and `force-pull` flag is set for a given git config server.

Please see:
- https://github.com/spinnaker/spinnaker/issues/5153
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=531807
- https://www.devguerrilla.com/notes/2015/07/fuse-for-the-idle-fellow-short-read-of-block-errors-when-starting-a-container/
