### PR TITLE
Fix s3client issue when using s3 endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<properties>
 		<bintray.package>config</bintray.package>
 		<spring-cloud-commons.version>3.0.0-SNAPSHOT</spring-cloud-commons.version>
-		<aws-java-sdk.version>1.11.52</aws-java-sdk.version>
+		<aws-java-sdk.version>1.11.79</aws-java-sdk.version>
 		<google-api-services-iam.version>v1-rev20191010-1.30.3</google-api-services-iam.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
@@ -35,12 +35,18 @@ public class AwsS3EnvironmentRepositoryFactory implements
 			AwsS3EnvironmentProperties environmentProperties) {
 		final AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard();
 		if (environmentProperties.getRegion() != null) {
-			clientBuilder.withRegion(environmentProperties.getRegion());
+			if (environmentProperties.getEndpoint() != null) {
+				AmazonS3ClientBuilder.EndpointConfiguration endpointConfiguration = new AmazonS3ClientBuilder.EndpointConfiguration(
+						environmentProperties.getEndpoint(),
+						environmentProperties.getRegion());
+				clientBuilder.withEndpointConfiguration(endpointConfiguration);
+			}
+			else {
+				clientBuilder.withRegion(environmentProperties.getRegion());
+			}
 		}
 		final AmazonS3 client = clientBuilder.build();
-		if (environmentProperties.getEndpoint() != null) {
-			client.setEndpoint(environmentProperties.getEndpoint());
-		}
+
 		AwsS3EnvironmentRepository repository = new AwsS3EnvironmentRepository(client,
 				environmentProperties.getBucket(), server);
 		return repository;


### PR DESCRIPTION
Client is immutable when created with the builder
```java.lang.UnsupportedOperationException: Client is immutable when created with the builder.
	at com.amazonaws.AmazonWebServiceClient.checkMutability(AmazonWebServiceClient.java:1057)
	at com.amazonaws.AmazonWebServiceClient.setEndpoint(AmazonWebServiceClient.java:316)
	at com.amazonaws.services.s3.AmazonS3Client.setEndpoint(AmazonS3Client.java:725)
	at org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepositoryFactory.build(AwsS3EnvironmentRepositoryFactory.java:42)