### PR TITLE
Integration with AWS Secrets Manager

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@ Manual changes to this file will be lost when it is generated again.
 Edit the files in the src/main/asciidoc/ directory instead.
 ////
 
+
 image::https://circleci.com/gh/spring-cloud/spring-cloud-config/tree/master.svg?style=svg["CircleCI", link="https://circleci.com/gh/spring-cloud/spring-cloud-config/tree/master"]
 image::https://codecov.io/gh/spring-cloud/spring-cloud-config/branch/master/graph/badge.svg["Codecov", link="https://codecov.io/gh/spring-cloud/spring-cloud-config/branch/master"]
 image::https://api.codacy.com/project/badge/Grade/f064024a072c477e97dca6ed5a70fccd?branch=master["Codacy code quality", link="https://www.codacy.com/app/Spring-Cloud/spring-cloud-config?branch=master&utm_source=github.com&utm_medium=referral&utm_content=spring-cloud/spring-cloud-config&utm_campaign=Badge_Grade"]
@@ -107,38 +108,38 @@ There is also a parent pom and BOM (`spring-cloud-starter-parent`) for Maven use
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>{spring-cloud-version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>{spring-cloud-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
+    <build>
+        <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 
     <!-- repositories also needed for snapshots and milestones -->
 ----

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,19 +18,10 @@
 	<properties>
 		<docs.main>spring-cloud-config</docs.main>
 		<main.basedir>${basedir}/..</main.basedir>
-		<docs.whitelisted.branches>2.1.x,2.2.x</docs.whitelisted.branches>
 		<upload-docs-zip.phase>deploy</upload-docs-zip.phase>
-	</properties>
+	</properties>	
 	<build>
-		<plugins>
-			<plugin>
-				<!--skip deploy (this is just a test module) -->
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-		</plugins>
+		<sourceDirectory>src/main/asciidoc</sourceDirectory>
 	</build>
 	<profiles>
 		<profile>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>..</relativePath>
 	</parent>
 
-	<packaging>pom</packaging>
+	<packaging>jar</packaging>
 	<name>Spring Cloud Config Docs</name>
 	<description>Spring Cloud Docs</description>
 	<properties>

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -797,6 +797,16 @@ credhub set --name "/my-app/default/master/more-shared" --type=json
 value: {"shared.word1": "hello", "shared.word2": "world"}
 ----
 
+==== AWS Secrets Manager
+When using AWS Secrets Manager as a backend, you can share configuration with all applications by placing configuration in `/application/` or by placing it in the `default` profile for the application.
+For example, if you add secrets with the following keys, all application using the config server will have the properties `shared.foo` and `shared.bar` available to them:
+
+[source]
+----
+/secret/application-default/shared.foo
+/secret/application/shared.bar
+----
+
 ==== JDBC Backend
 
 Spring Cloud Config Server supports JDBC (relational database) as a backend for configuration properties.
@@ -892,6 +902,46 @@ Credentials are found using the link:https://docs.aws.amazon.com/sdk-for-java/v1
 Configuration files are stored in your bucket as `{application}-{profile}.properties`, `{application}-{profile}.yml` or `{application}-{profile}.json`. An optional label can be provided to specify a directory path to the file.
 
 NOTE: When no profile is specified `default` will be used.
+
+==== AWS Secrets Manager Backend
+
+Spring Cloud Config Server supports link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager] as a backend for configuration properties.
+You can enable this feature by adding a dependency to link:https://github.com/aws/aws-sdk-java/tree/master/aws-java-sdk-secretsmanager[AWS Java SDK for Secrets Manager].
+
+[source,xml,indent=0]
+.pom.xml
+----
+<dependency>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-java-sdk-secretsmanager</artifactId>
+</dependency>
+----
+
+The following configuration uses the AWS Secrets Manager client to access secrets.
+
+[source,yaml]
+----
+spring:
+  profiles:
+  	active: awssecretsmanager
+  cloud:
+    config:
+      server:
+        awssecretsmanager:
+          region: us-east-1
+          endpoint: https://amazonaws.com
+          origin: asw:secrets:
+          prefix: /secret/foo
+          profileSeparator: _
+
+----
+
+AWS Secrets Manager API credentials are determined using link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[Default Credential Provider Chain].
+
+[NOTE]
+====
+- When no application is specified `application` is the default, and when no profile is specified `default` is used.
+====
 
 ==== CredHub Backend
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<properties>
 		<bintray.package>config</bintray.package>
 		<spring-cloud-commons.version>3.0.0-SNAPSHOT</spring-cloud-commons.version>
-		<aws-java-sdk.version>1.11.52</aws-java-sdk.version>
+		<aws-java-sdk.version>1.11.787</aws-java-sdk.version>
 		<google-api-services-iam.version>v1-rev20191010-1.30.3</google-api-services-iam.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true
@@ -75,6 +75,11 @@
 			<dependency>
 				<groupId>com.amazonaws</groupId>
 				<artifactId>aws-java-sdk-s3</artifactId>
+				<version>${aws-java-sdk.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-secretsmanager</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-config-monitor/pom.xml
+++ b/spring-cloud-config-monitor/pom.xml
@@ -46,5 +46,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-config-sample/pom.xml
+++ b/spring-cloud-config-sample/pom.xml
@@ -47,6 +47,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -99,6 +99,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -106,14 +106,15 @@ import org.springframework.vault.core.VaultTemplate;
 		CredhubEnvironmentProperties.class, JdbcEnvironmentProperties.class,
 		NativeEnvironmentProperties.class, VaultEnvironmentProperties.class,
 		RedisEnvironmentProperties.class, AwsS3EnvironmentProperties.class,
-	    AwsSecretsManagerEnvironmentProperties.class})
+		AwsSecretsManagerEnvironmentProperties.class })
 @Import({ CompositeRepositoryConfiguration.class, JdbcRepositoryConfiguration.class,
 		VaultConfiguration.class, VaultRepositoryConfiguration.class,
 		SpringVaultRepositoryConfiguration.class, CredhubConfiguration.class,
 		CredhubRepositoryConfiguration.class, SvnRepositoryConfiguration.class,
 		NativeRepositoryConfiguration.class, GitRepositoryConfiguration.class,
 		RedisRepositoryConfiguration.class, GoogleCloudSourceConfiguration.class,
-		AwsS3RepositoryConfiguration.class, AwsSecretsManagerRepositoryConfiguration.class,
+		AwsS3RepositoryConfiguration.class,
+		AwsSecretsManagerRepositoryConfiguration.class,
 		DefaultRepositoryConfiguration.class })
 public class EnvironmentRepositoryConfiguration {
 
@@ -208,8 +209,9 @@ public class EnvironmentRepositoryConfiguration {
 
 		@Bean
 		public AwsSecretsManagerEnvironmentRepositoryFactory awsSecretsManagerEnvironmentRepositoryFactory(
-			ConfigServerProperties configServerProperties) {
-			return new AwsSecretsManagerEnvironmentRepositoryFactory(configServerProperties);
+				ConfigServerProperties configServerProperties) {
+			return new AwsSecretsManagerEnvironmentRepositoryFactory(
+					configServerProperties);
 		}
 
 	}
@@ -376,8 +378,8 @@ class AwsSecretsManagerRepositoryConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(AwsSecretsManagerEnvironmentRepository.class)
 	public AwsSecretsManagerEnvironmentRepository awsSecretsManagerEnvironmentRepository(
-		AwsSecretsManagerEnvironmentRepositoryFactory factory,
-		AwsSecretsManagerEnvironmentProperties environmentProperties) {
+			AwsSecretsManagerEnvironmentRepositoryFactory factory,
+			AwsSecretsManagerEnvironmentProperties environmentProperties) {
 		return factory.build(environmentProperties);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -99,6 +99,7 @@ import org.springframework.vault.core.VaultTemplate;
  * @author Dylan Roberts
  * @author Alberto C. Ríos
  * @author Scott Frederick
+ * @author Tejas Pandilwar
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({ SvnKitEnvironmentProperties.class,

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
+import org.springframework.core.Ordered;
+
+@ConfigurationProperties("spring.cloud.config.server.awssecretsmanager")
+public class AwsSecretsManagerEnvironmentProperties implements EnvironmentRepositoryProperties {
+
+	static final String DEFAULT_PATH_SEPARATOR = "/";
+
+	private static final String DEFAULT_PREFIX = DEFAULT_PATH_SEPARATOR + "secret";
+
+	private static final String DEFAULT_PROFILE_SEPARATOR = "-";
+
+	private static final boolean DEFAULT_FAIL_FAST = true;
+
+	private static final String DEFAULT_ORIGIN = "aws:secret:";
+
+	/**
+	 * The region to be used by AWS Secrets Manager client
+	 */
+	private String region;
+
+	/**
+	 * The endpoint to be used by AWS Secrets Manager client
+	 */
+	private String endpoint;
+
+	/**
+	 * The order of the environment repository
+	 */
+	private int order = Ordered.LOWEST_PRECEDENCE;
+
+	/**
+	 * Prefix indicating first level for every property loaded from AWS Secrets Manager. Value must start with a forward
+	 * slash followed by a valid path segment or be empty. Defaults to "/secret".
+	 */
+	@NotNull
+	@Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
+	private String prefix = DEFAULT_PREFIX;
+
+	/**
+	 * String that separates profile from the application name.
+	 */
+	@NotNull
+	@Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
+	private String profileSeparator = DEFAULT_PROFILE_SEPARATOR;
+
+	private boolean failFast = DEFAULT_FAIL_FAST;
+
+	/**
+	 * Prefix which indicates the origin of the property. Defaults to "aws:secret:"
+	 */
+	@NotNull
+	private String origin = DEFAULT_ORIGIN;
+
+	public String getRegion() {
+		return region;
+	}
+
+	public void setRegion(String region) {
+		this.region = region;
+	}
+
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(String endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+
+	@Override
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getProfileSeparator() {
+		return profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
+	}
+
+	String getOrigin() {
+		return origin;
+	}
+
+	void setOrigin(String origin) {
+		this.origin = origin;
+	}
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -44,7 +44,8 @@ public class AwsSecretsManagerEnvironmentProperties
 	private String region;
 
 	/**
-	 * The endpoint to be used by AWS Secrets Manager client.
+	 * The endpoint to be used by AWS Secrets Manager client. This can be used to specify
+	 * an alternate endpoint for the API requests.
 	 */
 	private String endpoint;
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -44,8 +44,8 @@ public class AwsSecretsManagerEnvironmentProperties
 	private String region;
 
 	/**
-	 * The endpoint to be used by AWS Secrets Manager client. This can be used to specify
-	 * an alternate endpoint for the API requests.
+	 * The endpoint to be used by AWS Secrets Manager client.
+	 * This can be used to specify an alternate endpoint for the API requests.
 	 */
 	private String endpoint;
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -32,9 +32,7 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 
 	private static final String DEFAULT_PROFILE_SEPARATOR = "-";
 
-	private static final boolean DEFAULT_FAIL_FAST = true;
-
-	private static final String DEFAULT_ORIGIN = "aws:secret:";
+	private static final String DEFAULT_ORIGIN = "aws:secrets:";
 
 	/**
 	 * The region to be used by AWS Secrets Manager client
@@ -66,10 +64,8 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	@Pattern(regexp = "[a-zA-Z0-9.\\-_]+")
 	private String profileSeparator = DEFAULT_PROFILE_SEPARATOR;
 
-	private boolean failFast = DEFAULT_FAIL_FAST;
-
 	/**
-	 * Prefix which indicates the origin of the property. Defaults to "aws:secret:"
+	 * Prefix which indicates the origin of the property. Defaults to "aws:secrets:"
 	 */
 	@NotNull
 	private String origin = DEFAULT_ORIGIN;
@@ -113,14 +109,6 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 
 	public void setProfileSeparator(String profileSeparator) {
 		this.profileSeparator = profileSeparator;
-	}
-
-	public boolean isFailFast() {
-		return failFast;
-	}
-
-	public void setFailFast(boolean failFast) {
-		this.failFast = failFast;
 	}
 
 	String getOrigin() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -27,7 +27,8 @@ import org.springframework.core.Ordered;
  * @author Tejas Pandilwar
  */
 @ConfigurationProperties("spring.cloud.config.server.awssecretsmanager")
-public class AwsSecretsManagerEnvironmentProperties implements EnvironmentRepositoryProperties {
+public class AwsSecretsManagerEnvironmentProperties
+		implements EnvironmentRepositoryProperties {
 
 	static final String DEFAULT_PATH_SEPARATOR = "/";
 
@@ -38,23 +39,24 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	private static final String DEFAULT_ORIGIN = "aws:secrets:";
 
 	/**
-	 * The region to be used by AWS Secrets Manager client
+	 * The region to be used by AWS Secrets Manager client.
 	 */
 	private String region;
 
 	/**
-	 * The endpoint to be used by AWS Secrets Manager client
+	 * The endpoint to be used by AWS Secrets Manager client.
 	 */
 	private String endpoint;
 
 	/**
-	 * The order of the environment repository
+	 * The order of the environment repository.
 	 */
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
 	/**
-	 * Prefix indicating first level for every property loaded from AWS Secrets Manager. Value must start with a forward
-	 * slash followed by a valid path segment or be empty. Defaults to "/secret".
+	 * Prefix indicating first level for every property loaded from AWS Secrets Manager.
+	 * Value must start with a forward slash followed by a valid path segment or be empty.
+	 * Defaults to "/secret".
 	 */
 	@NotNull
 	@Pattern(regexp = "(/[a-zA-Z0-9.\\-_]+)*")
@@ -68,7 +70,7 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	private String profileSeparator = DEFAULT_PROFILE_SEPARATOR;
 
 	/**
-	 * Prefix which indicates the origin of the property. Defaults to "aws:secrets:"
+	 * Prefix which indicates the origin of the property. Defaults to "aws:secrets:".
 	 */
 	@NotNull
 	private String origin = DEFAULT_ORIGIN;
@@ -121,4 +123,5 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	public void setOrigin(String origin) {
 		this.origin = origin;
 	}
+
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -23,6 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
 import org.springframework.core.Ordered;
 
+/**
+ * @author Tejas Pandilwar
+ */
 @ConfigurationProperties("spring.cloud.config.server.awssecretsmanager")
 public class AwsSecretsManagerEnvironmentProperties implements EnvironmentRepositoryProperties {
 
@@ -111,11 +114,11 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 		this.profileSeparator = profileSeparator;
 	}
 
-	String getOrigin() {
+	public String getOrigin() {
 		return origin;
 	}
 
-	void setOrigin(String origin) {
+	public void setOrigin(String origin) {
 		this.origin = origin;
 	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -37,6 +37,9 @@ import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentProperties.DEFAULT_PATH_SEPARATOR;
 
+/**
+ * @author Tejas Pandilwar
+ */
 public class AwsSecretsManagerEnvironmentRepository implements EnvironmentRepository{
 
 	private static final Log log = LogFactory.getLog(AwsSecretsManagerEnvironmentRepository.class);
@@ -57,7 +60,6 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 		this.environmentProperties = environmentProperties;
 		this.objectMapper = new ObjectMapper();
 	}
-
 
 	@Override
 	public Environment findOne(String application, String profileList, String label) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+import static org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentProperties.DEFAULT_PATH_SEPARATOR;
+
+public class AwsSecretsManagerEnvironmentRepository implements EnvironmentRepository{
+
+	private static final Log log = LogFactory.getLog(AwsSecretsManagerEnvironmentRepository.class);
+
+	private final ObjectMapper objectMapper;
+
+	private final AWSSecretsManager awsSmClient;
+
+	private final ConfigServerProperties configServerProperties;
+
+	private final AwsSecretsManagerEnvironmentProperties environmentProperties;
+
+	public AwsSecretsManagerEnvironmentRepository(AWSSecretsManager awsSmClient,
+				ConfigServerProperties configServerProperties,
+				AwsSecretsManagerEnvironmentProperties environmentProperties) {
+		this.awsSmClient = awsSmClient;
+		this.configServerProperties = configServerProperties;
+		this.environmentProperties = environmentProperties;
+		this.objectMapper = new ObjectMapper();
+	}
+
+
+	@Override
+	public Environment findOne(String application, String profiles, String label) {
+		if(StringUtils.isEmpty(application)) {
+			application = configServerProperties.getDefaultApplicationName();
+		}
+
+		if(StringUtils.isEmpty(profiles)) {
+			profiles = configServerProperties.getDefaultProfile();
+		}
+
+		String[] profileArray = StringUtils.commaDelimitedListToStringArray(profiles);
+		Environment environment = new Environment(application, profiles, label, null, null);
+		List<PropertySource> propertySources = new ArrayList<>();
+
+		for(String profile: profileArray) {
+			PropertySource source = getSecretPropertySource(application, profile, label);
+			propertySources.add(source);
+		}
+
+		Map<String, String> overrides = configServerProperties.getOverrides();
+		if(!overrides.isEmpty()) {
+			propertySources.add(0, new PropertySource("overrides", overrides));
+		}
+
+		environment.addAll(propertySources);
+		return environment;
+	}
+
+	private PropertySource getSecretPropertySource(String application, String profile, String label) {
+		String path = buildSecretPath(application, profile);
+
+		try {
+			Map<String, Object> source = getPropertiesBySecretPath(path);
+
+			if(!source.isEmpty()) {
+				String propertySourceName =  environmentProperties.getOrigin() + path;
+				return new PropertySource(propertySourceName, source);
+			}
+		}
+		catch (Exception e) {
+			if(environmentProperties.isFailFast()) {
+				log.error("FailFast is set to True. Error encountered while retrieving configuration from AWS Secrets Manager:\n"
+					+ e.getMessage());
+				ReflectionUtils.rethrowRuntimeException(e);
+			} else {
+				log.warn("Unable to load configuration from AWS Secrets Manager for " + path, e);
+			}
+		}
+		return null; //TODO: change this!!!
+	}
+
+	private String buildSecretPath(String application, String profile) {
+		String prefix = environmentProperties.getPrefix();
+		String profileSeparator = environmentProperties.getProfileSeparator();
+
+		return prefix + DEFAULT_PATH_SEPARATOR + application + profileSeparator + profile + DEFAULT_PATH_SEPARATOR;
+	}
+
+	private Map<String, Object> getPropertiesBySecretPath(String path) throws Exception {
+		Map<String, Object> properties = new HashMap();
+
+		GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(path);
+		try {
+			GetSecretValueResult response = awsSmClient.getSecretValue(request);
+
+			if(response != null) {
+				Map<String, Object> secretMap = objectMapper.readValue(
+					response.getSecretString(), new TypeReference<Map<String, Object>>() {});
+
+				for(Map.Entry<String, Object> secretEntry : secretMap.entrySet()) {
+					properties.put(secretEntry.getKey(), secretEntry.getValue());
+				}
+			}
+		} catch (ResourceNotFoundException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		return properties;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -153,8 +153,7 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 			}
 		}
 		catch (ResourceNotFoundException | IOException e) {
-			log.warn("Unable to load secrets from AWS Secrets Manager for " + path, e);
-			throw new RuntimeException(e);
+			log.warn(String.format("Unable to load secrets from AWS Secrets Manager for secretId=%s", path), e);
 		}
 
 		return properties;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
@@ -24,6 +24,9 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.util.StringUtils;
 
+/**
+ * @author Tejas Pandilwar
+ */
 public class AwsSecretsManagerEnvironmentRepositoryFactory implements
 	EnvironmentRepositoryFactory<AwsSecretsManagerEnvironmentRepository, AwsSecretsManagerEnvironmentProperties>{
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.util.StringUtils;
+
+public class AwsSecretsManagerEnvironmentRepositoryFactory implements
+	EnvironmentRepositoryFactory<AwsSecretsManagerEnvironmentRepository, AwsSecretsManagerEnvironmentProperties>{
+
+	private final ConfigServerProperties configServerProperties;
+
+	public AwsSecretsManagerEnvironmentRepositoryFactory(ConfigServerProperties configServerProperties) {
+		this.configServerProperties = configServerProperties;
+	}
+
+	@Override
+	public AwsSecretsManagerEnvironmentRepository build(AwsSecretsManagerEnvironmentProperties environmentProperties) {
+		AWSSecretsManagerClientBuilder clientBuilder = AWSSecretsManagerClientBuilder.standard();
+		String region = environmentProperties.getRegion();
+
+		if(!StringUtils.isEmpty(region)) {
+			Regions awsRegion = Regions.fromName(region);
+			clientBuilder.withRegion(awsRegion);
+
+			String endpoint = environmentProperties.getEndpoint();
+			if(!StringUtils.isEmpty(endpoint)) {
+				AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.
+					EndpointConfiguration(endpoint, awsRegion.getName());
+				clientBuilder.withEndpointConfiguration(endpointConfiguration);
+			}
+		}
+
+		AWSSecretsManager client = clientBuilder.build();
+		return new AwsSecretsManagerEnvironmentRepository(client, configServerProperties, environmentProperties);
+	}
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
@@ -28,32 +28,37 @@ import org.springframework.util.StringUtils;
  * @author Tejas Pandilwar
  */
 public class AwsSecretsManagerEnvironmentRepositoryFactory implements
-	EnvironmentRepositoryFactory<AwsSecretsManagerEnvironmentRepository, AwsSecretsManagerEnvironmentProperties>{
+		EnvironmentRepositoryFactory<AwsSecretsManagerEnvironmentRepository, AwsSecretsManagerEnvironmentProperties> {
 
 	private final ConfigServerProperties configServerProperties;
 
-	public AwsSecretsManagerEnvironmentRepositoryFactory(ConfigServerProperties configServerProperties) {
+	public AwsSecretsManagerEnvironmentRepositoryFactory(
+			ConfigServerProperties configServerProperties) {
 		this.configServerProperties = configServerProperties;
 	}
 
 	@Override
-	public AwsSecretsManagerEnvironmentRepository build(AwsSecretsManagerEnvironmentProperties environmentProperties) {
-		AWSSecretsManagerClientBuilder clientBuilder = AWSSecretsManagerClientBuilder.standard();
+	public AwsSecretsManagerEnvironmentRepository build(
+			AwsSecretsManagerEnvironmentProperties environmentProperties) {
+		AWSSecretsManagerClientBuilder clientBuilder = AWSSecretsManagerClientBuilder
+				.standard();
 		String region = environmentProperties.getRegion();
 
-		if(!StringUtils.isEmpty(region)) {
+		if (!StringUtils.isEmpty(region)) {
 			Regions awsRegion = Regions.fromName(region);
 			clientBuilder.withRegion(awsRegion);
 
 			String endpoint = environmentProperties.getEndpoint();
-			if(!StringUtils.isEmpty(endpoint)) {
-				AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.
-					EndpointConfiguration(endpoint, awsRegion.getName());
+			if (!StringUtils.isEmpty(endpoint)) {
+				AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
+						endpoint, awsRegion.getName());
 				clientBuilder.withEndpointConfiguration(endpointConfiguration);
 			}
 		}
 
 		AWSSecretsManager client = clientBuilder.build();
-		return new AwsSecretsManagerEnvironmentRepository(client, configServerProperties, environmentProperties);
+		return new AwsSecretsManagerEnvironmentRepository(client, configServerProperties,
+				environmentProperties);
 	}
+
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
@@ -33,7 +33,6 @@ import org.springframework.cloud.config.server.encryption.EncryptionIntegrationT
 import org.springframework.cloud.config.server.encryption.EnvironmentPrefixHelperTests;
 import org.springframework.cloud.config.server.encryption.KeyStoreTextEncryptorLocatorTests;
 import org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepositoryTests;
-import org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.CompositeEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.EnvironmentControllerIntegrationTests;
 import org.springframework.cloud.config.server.environment.EnvironmentControllerTests;
@@ -101,8 +100,7 @@ import org.springframework.cloud.config.server.ssh.SshUriPropertyProcessorTest;
 		CustomCompositeEnvironmentRepositoryTests.class,
 		CustomEnvironmentRepositoryTests.class,
 		BootstrapConfigServerIntegrationTests.class,
-		AwsS3EnvironmentRepositoryTests.class,
-		AwsSecretsManagerEnvironmentRepositoryTests.class })
+		AwsS3EnvironmentRepositoryTests.class })
 @Ignore
 public class AdhocTestSuite {
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.config.server.encryption.EncryptionIntegrationT
 import org.springframework.cloud.config.server.encryption.EnvironmentPrefixHelperTests;
 import org.springframework.cloud.config.server.encryption.KeyStoreTextEncryptorLocatorTests;
 import org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepositoryTests;
+import org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.CompositeEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.EnvironmentControllerIntegrationTests;
 import org.springframework.cloud.config.server.environment.EnvironmentControllerTests;
@@ -100,7 +101,8 @@ import org.springframework.cloud.config.server.ssh.SshUriPropertyProcessorTest;
 		CustomCompositeEnvironmentRepositoryTests.class,
 		CustomEnvironmentRepositoryTests.class,
 		BootstrapConfigServerIntegrationTests.class,
-		AwsS3EnvironmentRepositoryTests.class })
+		AwsS3EnvironmentRepositoryTests.class,
+		AwsSecretsManagerEnvironmentRepositoryTests.class })
 @Ignore
 public class AdhocTestSuite {
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.config.server.environment;
 
 import java.util.Arrays;
@@ -31,7 +47,8 @@ import static org.mockito.Mockito.when;
  */
 public class AwsSecretsManagerEnvironmentRepositoryTests {
 
-	private static final Log log = LogFactory.getLog(AwsSecretsManagerEnvironmentRepository.class);
+	private static final Log log = LogFactory
+			.getLog(AwsSecretsManagerEnvironmentRepository.class);
 
 	private static final Map<String, String> APPLICATION_PROPERTIES = new HashMap<String, String>() {
 		{
@@ -54,47 +71,53 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		}
 	};
 
-	private static final Map<String, String>  APPLICATION_EAST_PROPERTIES = new HashMap<String, String>() {
+	private static final Map<String, String> APPLICATION_EAST_PROPERTIES = new HashMap<String, String>() {
 		{
 			put("s3.accessKey", "application-east-s3");
 			put("s3.secretKey", "236e01a7-623b-40f4-88c1-eb4d89229dd6");
 		}
 	};
 
-	private static final Map<String, String>  FOO_PROPERTIES = new HashMap<String, String>() {
+	private static final Map<String, String> FOO_PROPERTIES = new HashMap<String, String>() {
 		{
 			put("s3.accessKey", "foo-s3");
 			put("s3.secretKey", "ce945da2-740a-4915-a090-2978428dad05");
 		}
 	};
 
-	private static final Map<String, String>  FOO_DEFAULT_PROPERTIES = new HashMap<String, String>() {
+	private static final Map<String, String> FOO_DEFAULT_PROPERTIES = new HashMap<String, String>() {
 		{
 			put("s3.accessKey", "foo-default-s3");
 			put("s3.secretKey", "8c3c58c9-daef-4d21-96b0-c2b68a7a8234");
 		}
 	};
 
-	private static final Map<String, String>  FOO_PROD_PROPERTIES = new HashMap<String, String>() {
+	private static final Map<String, String> FOO_PROD_PROPERTIES = new HashMap<String, String>() {
 		{
 			put("s3.accessKey", "foo-prod-s3");
 			put("s3.secretKey", "42ca062d-8e4b-435e-9e4a-d058835817c0");
 		}
 	};
 
-	private static final Map<String, String>  FOO_EAST_PROPERTIES = new HashMap<String, String>() {
+	private static final Map<String, String> FOO_EAST_PROPERTIES = new HashMap<String, String>() {
 		{
 			put("s3.accessKey", "foo-east-s3");
 			put("s3.secretKey", "657f6ac5-2e1c-487d-9d61-1df109b29edf");
 		}
 	};
 
-	private final AWSSecretsManager awsSmClientMock = mock(AWSSecretsManager.class, "aws-sm-client-mock");
+	private final AWSSecretsManager awsSmClientMock = mock(AWSSecretsManager.class,
+			"aws-sm-client-mock");
+
 	private final ConfigServerProperties configServerProperties = new ConfigServerProperties();
+
 	private final AwsSecretsManagerEnvironmentProperties environmentProperties = new AwsSecretsManagerEnvironmentProperties();
+
 	private final AwsSecretsManagerEnvironmentRepository repository = new AwsSecretsManagerEnvironmentRepository(
-		awsSmClientMock,configServerProperties, environmentProperties);
-	private final ObjectMapper objectMapper = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
+			awsSmClientMock, configServerProperties, environmentProperties);
+
+	private final ObjectMapper objectMapper = new ObjectMapper()
+			.configure(SerializationFeature.INDENT_OUTPUT, true);
 
 	@Test
 	public void testFindOneWithNullApplicationAndNullProfile() {
@@ -105,42 +128,52 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null,
+				null, null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
 	public void testFindOneWithNullApplicationAndNonExistingProfile() {
 		String application = null;
-		String profile = randomAlphabetic(RandomUtils.nextInt(3,25));
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
 		String defaultApplication = configServerProperties.getDefaultApplicationName();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null,
+				null, null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -151,19 +184,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null,
+				null, null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -174,22 +212,28 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null,
+				null, null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties,
+				applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -200,19 +244,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -222,19 +271,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -244,19 +298,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -266,22 +325,28 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties,
+				applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -292,19 +357,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -314,19 +384,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -336,19 +411,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(
+				Arrays.asList(applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -358,22 +438,28 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties,
+				applicationDefaultProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -384,25 +470,32 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
-		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				FOO_DEFAULT_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -412,25 +505,32 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
-		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				FOO_DEFAULT_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -440,25 +540,32 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
-		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				FOO_DEFAULT_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -468,19 +575,23 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
 		expectedEnv.addAll(Arrays.asList(fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -490,22 +601,28 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, fooProperties,
+				applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -515,32 +632,41 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
-		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName,
+				FOO_PROD_PROPERTIES);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
-		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				FOO_DEFAULT_PROPERTIES);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooDefaultProperties,
-			applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties,
+				fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -550,25 +676,32 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
-		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName,
+				FOO_PROD_PROPERTIES);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties,
+				fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -578,38 +711,49 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
-		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName,
+				FOO_PROD_PROPERTIES);
 
 		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
-		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, FOO_EAST_PROPERTIES);
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName,
+				FOO_EAST_PROPERTIES);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
-		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				FOO_DEFAULT_PROPERTIES);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
 		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
-		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
+		PropertySource applicationEastProperties = new PropertySource(
+				applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties, applicationEastProperties,
-			fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties,
+				fooEastProperties, applicationEastProperties, fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -619,32 +763,41 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
 		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
-		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName,
+				FOO_PROD_PROPERTIES);
 
 		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
-		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, FOO_EAST_PROPERTIES);
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName,
+				FOO_EAST_PROPERTIES);
 
 		String fooPropertiesName = "aws:secrets:/secret/foo/";
-		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+		PropertySource fooProperties = new PropertySource(fooPropertiesName,
+				FOO_PROPERTIES);
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
-		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+		PropertySource applicationProdProperties = new PropertySource(
+				applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
 		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
-		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
+		PropertySource applicationEastProperties = new PropertySource(
+				applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-			applicationEastProperties, fooProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties,
+				fooEastProperties, applicationEastProperties, fooProperties,
+				applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -664,19 +817,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		PropertySource overrideProperties = new PropertySource("overrides", overrides);
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
-		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+		PropertySource applicationDefaultProperties = new PropertySource(
+				applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
-		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+		PropertySource applicationProperties = new PropertySource(
+				applicationPropertiesName, APPLICATION_PROPERTIES);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(overrideProperties, applicationDefaultProperties, applicationProperties));
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
+		expectedEnv.addAll(Arrays.asList(overrideProperties, applicationDefaultProperties,
+				applicationProperties));
 
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	@Test
@@ -685,21 +843,26 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String profile = configServerProperties.getDefaultProfile();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		Environment expectedEnv = new Environment(application, profiles, null, null,
+				null);
 		setupAwsSmClientMocks(expectedEnv);
 
 		Environment resultEnv = repository.findOne(application, profile, null);
 
-		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking()
+				.isEqualTo(expectedEnv);
 	}
 
 	private void setupAwsSmClientMocks(Environment environment) {
-		for(PropertySource ps : environment.getPropertySources()) {
-			String path = StringUtils.delete(ps.getName(), environmentProperties.getOrigin());
-			GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(path);
+		for (PropertySource ps : environment.getPropertySources()) {
+			String path = StringUtils.delete(ps.getName(),
+					environmentProperties.getOrigin());
+			GetSecretValueRequest request = new GetSecretValueRequest()
+					.withSecretId(path);
 
 			String secrets = getSecrets(ps);
-			GetSecretValueResult response = new GetSecretValueResult().withSecretString(secrets);
+			GetSecretValueResult response = new GetSecretValueResult()
+					.withSecretString(secrets);
 
 			when(awsSmClientMock.getSecretValue(eq(request))).thenReturn(response);
 		}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -1,0 +1,719 @@
+package org.springframework.cloud.config.server.environment;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.util.StringUtils;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Tejas Pandilwar
+ */
+public class AwsSecretsManagerEnvironmentRepositoryTests {
+
+	private static final Log log = LogFactory.getLog(AwsSecretsManagerEnvironmentRepository.class);
+
+	private static final Map<String, String> APPLICATION_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "application-shared-s3");
+			put("s3.secretKey", "25300773-eb3b-4ace-b6fc-500c87331da7");
+		}
+	};
+
+	private static final Map<String, String> APPLICATION_DEFAULT_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "application-shared-default-s3");
+			put("s3.secretKey", "691972aa-68d2-4e55-8d9b-eedd4c63a998");
+		}
+	};
+
+	private static final Map<String, String> APPLICATION_PROD_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "application-shared-prod-s3");
+			put("s3.secretKey", "90c1dd88-5b20-41fa-a4e9-e1d638188732");
+		}
+	};
+
+	private static final Map<String, String>  APPLICATION_EAST_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "application-east-s3");
+			put("s3.secretKey", "236e01a7-623b-40f4-88c1-eb4d89229dd6");
+		}
+	};
+
+	private static final Map<String, String>  FOO_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "foo-s3");
+			put("s3.secretKey", "ce945da2-740a-4915-a090-2978428dad05");
+		}
+	};
+
+	private static final Map<String, String>  FOO_DEFAULT_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "foo-default-s3");
+			put("s3.secretKey", "8c3c58c9-daef-4d21-96b0-c2b68a7a8234");
+		}
+	};
+
+	private static final Map<String, String>  FOO_PROD_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "foo-prod-s3");
+			put("s3.secretKey", "42ca062d-8e4b-435e-9e4a-d058835817c0");
+		}
+	};
+
+	private static final Map<String, String>  FOO_EAST_PROPERTIES = new HashMap<String, String>() {
+		{
+			put("s3.accessKey", "foo-east-s3");
+			put("s3.secretKey", "657f6ac5-2e1c-487d-9d61-1df109b29edf");
+		}
+	};
+
+	private final AWSSecretsManager awsSmClientMock = mock(AWSSecretsManager.class, "aws-sm-client-mock");
+	private final ConfigServerProperties configServerProperties = new ConfigServerProperties();
+	private final AwsSecretsManagerEnvironmentProperties environmentProperties = new AwsSecretsManagerEnvironmentProperties();
+	private final AwsSecretsManagerEnvironmentRepository repository = new AwsSecretsManagerEnvironmentRepository(
+		awsSmClientMock,configServerProperties, environmentProperties);
+	private final ObjectMapper objectMapper = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
+
+	@Test
+	public void testFindOneWithNullApplicationAndNullProfile() {
+		String application = null;
+		String profile = null;
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNonExistingProfile() {
+		String application = null;
+		String profile = randomAlphabetic(RandomUtils.nextInt(3,25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndDefaultProfile() {
+		String application = null;
+		String profile = configServerProperties.getDefaultProfile();
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndExistingProfile() {
+		String application = null;
+		String profile = "prod";
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNullProfile() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndDefaultProfile() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNonExistingProfile() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndExistingProfile() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNullProfile() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndDefaultProfile() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNonExistingProfile() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndExistingProfile() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNullProfile() {
+		String application = "foo";
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndDefaultProfile() {
+		String application = "foo";
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfile() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfile() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileForFoo() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfile() {
+		String application = "foo";
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooDefaultProperties,
+			applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNoDefaultProfiles() {
+		String application = "foo";
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfile() {
+		String application = "foo";
+		String profile = "prod,east";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, FOO_EAST_PROPERTIES);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, FOO_DEFAULT_PROPERTIES);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties, applicationEastProperties,
+			fooDefaultProperties, applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNoDefaults() {
+		String application = "foo";
+		String profile = "prod,east";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, FOO_PROD_PROPERTIES);
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, FOO_EAST_PROPERTIES);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, FOO_PROPERTIES);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName, APPLICATION_PROD_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName, APPLICATION_EAST_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
+			applicationEastProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithOverrides() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Map<String, String> overrides = new HashMap<String, String>(4) {
+			{
+				put("s3.accessKey", "override-s3");
+				put("s3.secretKey", "e7437a7d-dfa0-48a4-86d6-668fc0c157a7");
+			}
+		};
+
+		configServerProperties.setOverrides(overrides);
+		PropertySource overrideProperties = new PropertySource("overrides", overrides);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName, APPLICATION_DEFAULT_PROPERTIES);
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName, APPLICATION_PROPERTIES);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		expectedEnv.addAll(Arrays.asList(overrideProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNoSecretsStored() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, null, null, null);
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	private void setupAwsSmClientMocks(Environment environment) {
+		for(PropertySource ps : environment.getPropertySources()) {
+			String path = StringUtils.delete(ps.getName(), environmentProperties.getOrigin());
+			GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(path);
+
+			String secrets = getSecrets(ps);
+			GetSecretValueResult response = new GetSecretValueResult().withSecretString(secrets);
+
+			when(awsSmClientMock.getSecretValue(eq(request))).thenReturn(response);
+		}
+	}
+
+	private String getSecrets(PropertySource ps) {
+		Map<String, String> map = (Map<String, String>) ps.getSource();
+		try {
+			return objectMapper.writeValueAsString(map);
+		}
+		catch (JsonProcessingException e) {
+			log.error("Unable to generate secret string", e);
+		}
+		return new String();
+	}
+
+}


### PR DESCRIPTION
This PR addresses #1574 

- `AwsSecretsManagerEnvironmentRepository` implements `EnvironmentRepository`. Based on the `application` and `profile(s)`, we build path to fetch secrets in a hierarchical order of profiles as per the [documentation](https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html). 

- `AwsSecretsManagerEnvironmentProperties` defines all the properties required for configuring aws secrets manager client to fetch secrets.

- Authentication is done using [AWS Default Credential Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default)

Things to note:

- `label` has not been used since I wasn't sure.

- `GetSecretValueRequest` is constructed using only `secretId `only. That means it supports the default operation to retrieve `secretString `on the version with the `VersionStage `equal to `AWSCURRENT`

