### PR TITLE
Use scope required by GCP based git repository.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GoogleCloudSourceSupport.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GoogleCloudSourceSupport.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.config.server.support;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -112,7 +113,7 @@ public final class GoogleCloudSourceSupport {
 
 	}
 
-	interface CredentialsProvider {
+	public interface CredentialsProvider {
 
 		Map<String, String> getAuthorizationHeaders();
 
@@ -124,8 +125,10 @@ public final class GoogleCloudSourceSupport {
 		@Override
 		public Map<String, String> getAuthorizationHeaders() {
 			try {
-				return GoogleCredentials.getApplicationDefault().getRequestMetadata()
-						.entrySet().stream()
+				return GoogleCredentials.getApplicationDefault()
+						.createScoped(Collections.singleton(
+								"https://www.googleapis.com/auth/cloud-platform"))
+						.getRequestMetadata().entrySet().stream()
 						.collect(toMap(Entry::getKey, this::joinValues));
 			}
 			catch (IOException ex) {


### PR DESCRIPTION
GCP requires specific scopes to be predefined when trying to access specific resource. Right now, if repositiory backed by config-server is based on GCP, we receive exception:
java.io.IOException: Scopes not configured for service account. Scoped should be specified by calling createScoped or passing scopes to constructor.
    at com.google.auth.oauth2.ServiceAccountCredentials.refreshAccessToken(ServiceAccountCredentials.java:402) ~[google-auth-library-oauth2-http-0.20.0.jar!/:na]


