### PR TITLE
Don't throw exception when a repository can't be read [#661]

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/CompositeConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/CompositeConfiguration.java
@@ -39,23 +39,30 @@ public class CompositeConfiguration {
 
 	private List<EnvironmentRepository> environmentRepos = new ArrayList<>();
 
+	private ConfigServerProperties properties;
+
 	@Bean
 	@Primary
 	@ConditionalOnBean(SearchPathLocator.class)
 	public SearchPathCompositeEnvironmentRepository searchPathCompositeEnvironmentRepository() {
-		return new SearchPathCompositeEnvironmentRepository(this.environmentRepos);
+		return new SearchPathCompositeEnvironmentRepository(this.environmentRepos, properties.isFailOnCompositeError());
 	}
 
 	@Bean
 	@Primary
 	@ConditionalOnMissingBean(SearchPathLocator.class)
 	public CompositeEnvironmentRepository compositeEnvironmentRepository() {
-		return new CompositeEnvironmentRepository(this.environmentRepos);
+		return new CompositeEnvironmentRepository(this.environmentRepos, properties.isFailOnCompositeError());
 	}
 
 	@Autowired
 	public void setEnvironmentRepos(List<EnvironmentRepository> repos) {
 		this.environmentRepos = repos;
+	}
+
+	@Autowired
+	public void setProperties(ConfigServerProperties properties) {
+		this.properties = properties;
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/ConfigServerProperties.java
@@ -74,6 +74,17 @@ public class ConfigServerProperties {
 	private String defaultProfile = "default";
 
 	/**
+	 * Flag indicating that if there are any errors reading properties from a subordinate
+	 * environment repository in a composite environment repository, then the entire
+	 * composite read should fail. Useful when set to false when a Vault repository is in
+	 * the composite to allow clients to still read properties from other repositories
+	 * without providing a valid Vault token.
+	 *
+	 * Defaults to true, resulting in a failure on any error.
+	 */
+	private boolean failOnCompositeError = true;
+
+	/**
 	 * Decryption configuration for when server handles encrypted properties before
 	 * sending them to clients.
 	 */
@@ -145,6 +156,14 @@ public class ConfigServerProperties {
 
 	public void setDefaultProfile(String defaultProfile) {
 		this.defaultProfile = defaultProfile;
+	}
+
+	public boolean isFailOnCompositeError() {
+		return failOnCompositeError;
+	}
+
+	public void setFailOnCompositeError(boolean failOnCompositeError) {
+		this.failOnCompositeError = failOnCompositeError;
 	}
 
 	/**

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -429,16 +429,17 @@ class CompositeRepositoryConfiguration {
 	@Bean
 	@ConditionalOnSearchPathLocator
 	public SearchPathCompositeEnvironmentRepository searchPathCompositeEnvironmentRepository(
-			List<EnvironmentRepository> environmentRepositories) {
-		return new SearchPathCompositeEnvironmentRepository(environmentRepositories);
+			List<EnvironmentRepository> environmentRepositories, ConfigServerProperties properties) {
+		return new SearchPathCompositeEnvironmentRepository(environmentRepositories,
+				properties.isFailOnCompositeError());
 	}
 
 	@Primary
 	@Bean
 	@ConditionalOnMissingSearchPathLocator
 	public CompositeEnvironmentRepository compositeEnvironmentRepository(
-			List<EnvironmentRepository> environmentRepositories) {
-		return new CompositeEnvironmentRepository(environmentRepositories);
+			List<EnvironmentRepository> environmentRepositories, ConfigServerProperties properties) {
+		return new CompositeEnvironmentRepository(environmentRepositories, properties.isFailOnCompositeError());
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.config.environment.Environment;
-import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.core.OrderComparator;
 
 /**

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
@@ -37,15 +37,18 @@ public class CompositeEnvironmentRepository implements EnvironmentRepository {
 
 	protected List<EnvironmentRepository> environmentRepositories;
 
+	private boolean failOnError;
+
 	/**
 	 * Creates a new {@link CompositeEnvironmentRepository}.
 	 * @param environmentRepositories The list of {@link EnvironmentRepository}s to create
 	 * the composite from.
 	 */
-	public CompositeEnvironmentRepository(List<EnvironmentRepository> environmentRepositories) {
+	public CompositeEnvironmentRepository(List<EnvironmentRepository> environmentRepositories, boolean failOnError) {
 		// Sort the environment repositories by the priority
 		Collections.sort(environmentRepositories, OrderComparator.INSTANCE);
 		this.environmentRepositories = environmentRepositories;
+		this.failOnError = failOnError;
 	}
 
 	@Override
@@ -69,7 +72,12 @@ public class CompositeEnvironmentRepository implements EnvironmentRepository {
 					env.addAll(repo.findOne(application, profile, label, includeOrigin).getPropertySources());
 				}
 				catch (Exception e) {
-					log.info("Error adding environment for " + repo);
+					if (failOnError) {
+						throw e;
+					}
+					else {
+						log.info("Error adding environment for " + repo);
+					}
 				}
 			}
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
@@ -19,8 +19,8 @@ package org.springframework.cloud.config.server.environment;
 import java.util.Collections;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.core.OrderComparator;
@@ -33,7 +33,7 @@ import org.springframework.core.OrderComparator;
  */
 public class CompositeEnvironmentRepository implements EnvironmentRepository {
 
-	private static final Logger logger = LoggerFactory.getLogger(CompositeEnvironmentRepository.class);
+	Log log = LogFactory.getLog(getClass());
 
 	protected List<EnvironmentRepository> environmentRepositories;
 
@@ -69,7 +69,7 @@ public class CompositeEnvironmentRepository implements EnvironmentRepository {
 					env.addAll(repo.findOne(application, profile, label, includeOrigin).getPropertySources());
 				}
 				catch (Exception e) {
-					logger.info("Error adding environment for " + repo);
+					log.info("Error adding environment for " + repo);
 				}
 			}
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepository.java
@@ -19,7 +19,11 @@ package org.springframework.cloud.config.server.environment;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.core.OrderComparator;
 
 /**
@@ -29,6 +33,8 @@ import org.springframework.core.OrderComparator;
  * @author Ryan Baxter
  */
 public class CompositeEnvironmentRepository implements EnvironmentRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(CompositeEnvironmentRepository.class);
 
 	protected List<EnvironmentRepository> environmentRepositories;
 
@@ -60,7 +66,12 @@ public class CompositeEnvironmentRepository implements EnvironmentRepository {
 		}
 		else {
 			for (EnvironmentRepository repo : environmentRepositories) {
-				env.addAll(repo.findOne(application, profile, label, includeOrigin).getPropertySources());
+				try {
+					env.addAll(repo.findOne(application, profile, label, includeOrigin).getPropertySources());
+				}
+				catch (Exception e) {
+					logger.info("Error adding environment for " + repo);
+				}
 			}
 		}
 		return env;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SearchPathCompositeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/SearchPathCompositeEnvironmentRepository.java
@@ -33,8 +33,9 @@ public class SearchPathCompositeEnvironmentRepository extends CompositeEnvironme
 	 * @param environmentRepositories The {@link EnvironmentRepository}s to create this
 	 * composite from.
 	 */
-	public SearchPathCompositeEnvironmentRepository(List<EnvironmentRepository> environmentRepositories) {
-		super(environmentRepositories);
+	public SearchPathCompositeEnvironmentRepository(List<EnvironmentRepository> environmentRepositories,
+			boolean failOnError) {
+		super(environmentRepositories, failOnError);
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepositoryTests.java
@@ -76,7 +76,8 @@ public class CompositeEnvironmentRepositoryTests {
 		repos.add(new TestOrderedEnvironmentRepository(3, e1, loc1));
 		repos.add(new TestOrderedEnvironmentRepository(2, e3, loc2));
 		repos.add(new TestOrderedEnvironmentRepository(1, e2, loc3));
-		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos);
+		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos,
+				true);
 		Environment compositeEnv = compositeRepo.findOne("foo", "bar", "world", false);
 		List<PropertySource> propertySources = compositeEnv.getPropertySources();
 		assertThat(propertySources.size()).isEqualTo(5);
@@ -121,9 +122,10 @@ public class CompositeEnvironmentRepositoryTests {
 		List<EnvironmentRepository> repos2 = new ArrayList<EnvironmentRepository>();
 		repos2.add(new TestOrderedEnvironmentRepository(3, e1, loc1));
 		repos2.add(new TestOrderedEnvironmentRepository(3, e2, loc2));
-		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos);
+		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos,
+				true);
 		SearchPathCompositeEnvironmentRepository multiCompositeRepo = new SearchPathCompositeEnvironmentRepository(
-				repos2);
+				repos2, true);
 		Environment env = compositeRepo.findOne("app", "dev", "label", false);
 		assertThat(env.getVersion()).isEqualTo("1");
 		assertThat(env.getState()).isEqualTo("state");
@@ -165,7 +167,8 @@ public class CompositeEnvironmentRepositoryTests {
 		repos.add(new TestOrderedEnvironmentRepository(2, e1, loc1));
 		repos.add(new TestFailingEnvironmentRepository(1, e2, loc2));
 
-		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos);
+		SearchPathCompositeEnvironmentRepository compositeRepo = new SearchPathCompositeEnvironmentRepository(repos,
+				false);
 		Environment env = compositeRepo.findOne("app", "dev", "label", false);
 		List<PropertySource> propertySources = env.getPropertySources();
 		assertThat(propertySources.size()).isEqualTo(1);
@@ -233,7 +236,7 @@ public class CompositeEnvironmentRepositoryTests {
 		@Primary
 		CompositeEnvironmentRepository customCompositeEnvironmentRepository() {
 			return new CompositeEnvironmentRepository(Arrays.<EnvironmentRepository>asList(
-					new TestOrderedEnvironmentRepository(1, new Environment("app", "dev"), null)));
+					new TestOrderedEnvironmentRepository(1, new Environment("app", "dev"), null)), true);
 		}
 
 	}


### PR DESCRIPTION
This change simply ignores (but logs) any exceptions that take place when a composite repository is reading from one of its subordinate repositories. 

This addresses the issue where a Config Server has been configured with a Vault backend, but the client may not have a Vault token to request properties with. Currently, lack of a valid Vault token results in an error. With this change, properties from other backends will still be served and the Vault backend(s) will be absent from the response. 

As I noted in a comment on #661, it might be desirable and possible to include the unreadable backends in the response, albeit with no properties. But I'm going to go ahead and submit this PR and if there is reason to include empty property sources in the response, then I'll accept that as useful feedback.