### PR TITLE
remove redundanct default search location

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AbstractScmAccessor.java
@@ -217,7 +217,7 @@ public abstract class AbstractScmAccessor implements ResourceLoaderAware {
 		if (locations == null || locations.length == 0) {
 			locations = AbstractScmAccessorProperties.DEFAULT_LOCATIONS;
 		}
-		else if (locations != AbstractScmAccessorProperties.DEFAULT_LOCATIONS) {
+		else if (!Arrays.equals(locations, AbstractScmAccessorProperties.DEFAULT_LOCATIONS)) {
 			locations = StringUtils.concatenateStringArrays(AbstractScmAccessorProperties.DEFAULT_LOCATIONS, locations);
 		}
 		Collection<String> output = new LinkedHashSet<String>();


### PR DESCRIPTION
compare two arrays, use `Arrays.equals` , otherwise the default will add into locations twice.