### PR TITLE
Add support for multiple application config in aws s3 repository.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
@@ -75,22 +75,30 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 		final String label = StringUtils.isEmpty(specifiedLabel) ? serverProperties.getDefaultLabel() : specifiedLabel;
 
 		String[] profileArray = parseProfiles(profiles);
+		String[] apps = new String[] { application };
+		if (application != null) {
+			apps = StringUtils.commaDelimitedListToStringArray(application.replace(" ",""));
+		}
 
 		final Environment environment = new Environment(application, profileArray);
 		environment.setLabel(label);
 
 		for (String profile : profileArray) {
-			S3ConfigFile s3ConfigFile = getS3ConfigFile(application, profile, label);
-			if (s3ConfigFile != null) {
-				environment.setVersion(s3ConfigFile.getVersion());
+			for (String app : apps) {
+				S3ConfigFile s3ConfigFile = getS3ConfigFile(app, profile, label);
+				if (s3ConfigFile != null) {
+					environment.setVersion(s3ConfigFile.getVersion());
 
-				final Properties config = s3ConfigFile.read();
-				config.putAll(serverProperties.getOverrides());
-				StringBuilder propertySourceName = new StringBuilder().append("s3:").append(application);
-				if (profile != null) {
-					propertySourceName.append("-").append(profile);
+					final Properties config = s3ConfigFile.read();
+					config.putAll(serverProperties.getOverrides());
+					StringBuilder propertySourceName = new StringBuilder().append("s3:")
+						.append(app);
+					if (profile != null) {
+						propertySourceName.append("-").append(profile);
+					}
+					environment
+						.add(new PropertySource(propertySourceName.toString(), config));
 				}
-				environment.add(new PropertySource(propertySourceName.toString(), config));
 			}
 		}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
@@ -175,6 +175,16 @@ public class AwsS3EnvironmentRepositoryTests {
 		assertExpectedEnvironment(env, "foo", null, "v1", 1, "bar");
 	}
 
+	@Test
+	public void findWithMultipleApplicationAllFound() throws UnsupportedEncodingException {
+		setupS3("foo-profile1.yml", jsonContent);
+		setupS3("bar-profile1.yml", jsonContent);
+
+		final Environment env = envRepo.findOne("foo,bar", "profile1", null);
+
+		assertExpectedEnvironment(env, "foo,bar", null, null, 2, "profile1");
+	}
+
 	private void setupS3(String fileName, String propertyContent) throws UnsupportedEncodingException {
 		setupS3(fileName, null, propertyContent);
 	}


### PR DESCRIPTION
Multiple application configurations can be loaded with comma separators from aws s3.

For example, `abc-service` and `aws-common` config can be load.
```
spring:
  application:
    name: abc-service
  cloud:
    config:
      name: abc-service, aws-common
```