### PR TITLE
Remove ResourceController mappings with param useDefaultLabel

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -106,13 +106,6 @@ public class ResourceController {
 		return retrieve(request, name, profile, label, path, resolvePlaceholders);
 	}
 
-	@RequestMapping(value = "/{name}/{profile}/**", params = "useDefaultLabel")
-	public String retrieve(@PathVariable String name, @PathVariable String profile, ServletWebRequest request,
-			@RequestParam(defaultValue = "true") boolean resolvePlaceholders) throws IOException {
-		String path = getFilePath(request, name, profile, null);
-		return retrieve(request, name, profile, null, path, resolvePlaceholders);
-	}
-
 	private String getFilePath(ServletWebRequest request, String name, String profile, String label) {
 		String stem;
 		if (label != null) {
@@ -172,14 +165,6 @@ public class ResourceController {
 			ServletWebRequest request) throws IOException {
 		String path = getFilePath(request, name, profile, label);
 		return binary(request, name, profile, label, path);
-	}
-
-	@RequestMapping(value = "/{name}/{profile}/**", params = "useDefaultLabel",
-			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-	public byte[] binary(@PathVariable String name, @PathVariable String profile, ServletWebRequest request)
-			throws IOException {
-		String path = getFilePath(request, name, profile, null);
-		return binary(request, name, profile, null, path);
 	}
 
 	/*

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -297,12 +297,12 @@ public class ResourceControllerTests {
 	}
 
 	@Test
-	public void defaultLabelForBinary() throws Exception {
+	public void nullLabelForBinary() throws Exception {
 		this.environmentRepository.setSearchLocations("classpath:/test/{application}");
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		ServletWebRequest webRequest = new ServletWebRequest(request, new MockHttpServletResponse());
 		request.setRequestURI("/dev/spam/bar/" + "foo.txt");
-		byte[] resource = this.controller.binary("dev/spam", "bar", webRequest);
+		byte[] resource = this.controller.binary("dev/spam", "bar", null, webRequest);
 		assertThat(new String(resource)).isEqualToIgnoringNewLines("foo: dev_bar/spam");
 	}
 


### PR DESCRIPTION
`ResourceController` has multiple `@RequestMappings` that would conflict. Currently, to avoid passing the label, we use the `useDefaultLabel` request parameter to select. Using that parameter to select a different @RequestMapping doesn't work. The two mappings using the parameter have been removed now.

Fixes gh-1643