### PR TITLE
Uses BindHandler if registered in bootstrap.

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
@@ -67,7 +67,7 @@ public class ConfigServerConfigDataLocationResolver
 		BindHandler bindHandler = getBindHandler(context);
 		ConfigClientProperties configClientProperties = binder
 				.bind(ConfigClientProperties.PREFIX, Bindable.of(ConfigClientProperties.class), bindHandler)
-				.orElse(new ConfigClientProperties());
+				.orElseGet(ConfigClientProperties::new);
 		String applicationName = binder.bind("spring.application.name", Bindable.of(String.class), bindHandler)
 				.orElse("application");
 		configClientProperties.setName(applicationName);

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
@@ -32,6 +32,7 @@ import org.springframework.boot.context.config.ConfigDataLocationResolver;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.Ordered;
@@ -61,13 +62,20 @@ public class ConfigServerConfigDataLocationResolver
 		return -1;
 	}
 
-	protected ConfigClientProperties loadProperties(Binder binder) {
+	protected ConfigClientProperties loadProperties(ConfigDataLocationResolverContext context) {
+		Binder binder = context.getBinder();
+		BindHandler bindHandler = getBindHandler(context);
 		ConfigClientProperties configClientProperties = binder
-				.bind(ConfigClientProperties.PREFIX, Bindable.of(ConfigClientProperties.class))
+				.bind(ConfigClientProperties.PREFIX, Bindable.of(ConfigClientProperties.class), bindHandler)
 				.orElse(new ConfigClientProperties());
-		String applicationName = binder.bind("spring.application.name", String.class).orElse("application");
+		String applicationName = binder.bind("spring.application.name", Bindable.of(String.class), bindHandler)
+				.orElse("application");
 		configClientProperties.setName(applicationName);
 		return configClientProperties;
+	}
+
+	private BindHandler getBindHandler(ConfigDataLocationResolverContext context) {
+		return context.getBootstrapContext().getOrElse(BindHandler.class, null);
 	}
 
 	protected RestTemplate createRestTemplate(ConfigClientProperties properties) {
@@ -120,8 +128,7 @@ public class ConfigServerConfigDataLocationResolver
 	public List<ConfigServerConfigDataResource> resolveProfileSpecific(
 			ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location, Profiles profiles)
 			throws ConfigDataLocationNotFoundException {
-		ConfigClientProperties properties = loadProperties(resolverContext.getBinder());
-
+		ConfigClientProperties properties = loadProperties(resolverContext);
 		String uris = location.getNonPrefixedValue(getPrefix());
 
 		if (StringUtils.hasText(uris)) {
@@ -139,7 +146,8 @@ public class ConfigServerConfigDataLocationResolver
 			return createRestTemplate(props);
 		});
 
-		boolean discoveryEnabled = resolverContext.getBinder().bind(CONFIG_DISCOVERY_ENABLED, Boolean.class)
+		boolean discoveryEnabled = resolverContext.getBinder()
+				.bind(CONFIG_DISCOVERY_ENABLED, Bindable.of(Boolean.class), getBindHandler(resolverContext))
 				.orElse(false);
 
 		if (discoveryEnabled) {

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataCustomizationIntegrationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataCustomizationIntegrationTests.java
@@ -44,8 +44,7 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 		ConfigurableApplicationContext context = null;
 		try {
 			BindHandlerBootstrapper bindHandlerBootstrapper = new BindHandlerBootstrapper();
-			context = new SpringApplicationBuilder(TestConfig.class)
-					.addBootstrapper(bindHandlerBootstrapper)
+			context = new SpringApplicationBuilder(TestConfig.class).addBootstrapper(bindHandlerBootstrapper)
 					.addBootstrapper(ConfigServerBootstrapper.create().withLoaderInterceptor(new Interceptor())
 							.withRestTemplateFactory(this::restTemplate))
 					.addBootstrapper(registry -> registry.addCloseListener(event -> {
@@ -55,7 +54,8 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 						RestTemplate restTemplate = bootstrapContext.get(RestTemplate.class);
 						beanFactory.registerSingleton("holder", new RestTemplateHolder(restTemplate));
 						beanFactory.registerSingleton("interceptor", bootstrapContext.get(LoaderInterceptor.class));
-					})).run("--spring.config.import=optional:configserver:", "--custom.prop=customval", "--spring.cloud.config.label=mylabel");
+					})).run("--spring.config.import=optional:configserver:", "--custom.prop=customval",
+							"--spring.cloud.config.label=mylabel");
 
 			RestTemplateHolder holder = context.getBean(RestTemplateHolder.class);
 			assertThat(holder).isNotNull();
@@ -133,12 +133,14 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 		public void intitialize(BootstrapRegistry registry) {
 			registry.register(BindHandler.class, context -> new BindHandler() {
 				@Override
-				public Object onSuccess(ConfigurationPropertyName name, Bindable<?> target, BindContext context, Object result) {
+				public Object onSuccess(ConfigurationPropertyName name, Bindable<?> target, BindContext context,
+						Object result) {
 					onSuccessCount++;
 					return result;
 				}
 			});
 		}
+
 	}
 
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataCustomizationIntegrationTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataCustomizationIntegrationTests.java
@@ -20,11 +20,17 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.BootstrapContext;
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.Bootstrapper;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.cloud.config.client.ConfigServerBootstrapper.LoaderInterceptor;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.client.RestTemplate;
@@ -37,7 +43,9 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 	void customizableRestTemplate() {
 		ConfigurableApplicationContext context = null;
 		try {
+			BindHandlerBootstrapper bindHandlerBootstrapper = new BindHandlerBootstrapper();
 			context = new SpringApplicationBuilder(TestConfig.class)
+					.addBootstrapper(bindHandlerBootstrapper)
 					.addBootstrapper(ConfigServerBootstrapper.create().withLoaderInterceptor(new Interceptor())
 							.withRestTemplateFactory(this::restTemplate))
 					.addBootstrapper(registry -> registry.addCloseListener(event -> {
@@ -47,7 +55,7 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 						RestTemplate restTemplate = bootstrapContext.get(RestTemplate.class);
 						beanFactory.registerSingleton("holder", new RestTemplateHolder(restTemplate));
 						beanFactory.registerSingleton("interceptor", bootstrapContext.get(LoaderInterceptor.class));
-					})).run("--spring.config.import=optional:configserver:", "--custom.prop=customval");
+					})).run("--spring.config.import=optional:configserver:", "--custom.prop=customval", "--spring.cloud.config.label=mylabel");
 
 			RestTemplateHolder holder = context.getBean(RestTemplateHolder.class);
 			assertThat(holder).isNotNull();
@@ -60,6 +68,8 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 			Interceptor interceptor = (Interceptor) loaderInterceptor;
 			assertThat(interceptor.applied).isTrue();
 			assertThat(interceptor.hasBinder).isTrue();
+
+			assertThat(bindHandlerBootstrapper.onSuccessCount).isGreaterThan(1);
 		}
 		finally {
 			if (context != null) {
@@ -113,6 +123,22 @@ public class ConfigServerConfigDataCustomizationIntegrationTests {
 			this.customProp = customProp;
 		}
 
+	}
+
+	static class BindHandlerBootstrapper implements Bootstrapper {
+
+		private int onSuccessCount = 0;
+
+		@Override
+		public void intitialize(BootstrapRegistry registry) {
+			registry.register(BindHandler.class, context -> new BindHandler() {
+				@Override
+				public Object onSuccess(ConfigurationPropertyName name, Bindable<?> target, BindContext context, Object result) {
+					onSuccessCount++;
+					return result;
+				}
+			});
+		}
 	}
 
 }

--- a/spring-cloud-config-sample/src/test/java/sample/ApplicationFailFastTests.java
+++ b/spring-cloud-config-sample/src/test/java/sample/ApplicationFailFastTests.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class ApplicationFailFastTests {
 
-	// FIXME: configdata failfast works.
 	@Test
 	public void contextFails() {
 		try {

--- a/spring-cloud-config-sample/src/test/java/sample/ApplicationTests.java
+++ b/spring-cloud-config-sample/src/test/java/sample/ApplicationTests.java
@@ -40,8 +40,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
 		// Normally spring.cloud.config.enabled:true is the default but since we have the
-		// config
-		// server on the classpath we need to set it explicitly
+		// config server on the classpath we need to set it explicitly
 		properties = { "spring.cloud.config.enabled:true",
 				// FIXME: configdata why is this needed here?
 				"spring.config.use-legacy-processing=true", "management.security.enabled=false",

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EncryptionAutoConfiguration.java
@@ -53,9 +53,15 @@ import org.springframework.util.StringUtils;
  *
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(KeyProperties.class)
+@EnableConfigurationProperties
 @Import({ SingleTextEncryptorConfiguration.class, DefaultTextEncryptorConfiguration.class })
 public class EncryptionAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public KeyProperties keyProperties() {
+		return new KeyProperties();
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnProperty(value = "spring.cloud.config.server.encrypt.enabled", matchIfMissing = true)


### PR DESCRIPTION
This allows spring-cloud-context to register a TextEncryptorBindHandler and handle `{cipher}` prefixed properties prior to sending for remote data.

Depends on https://github.com/spring-cloud/spring-cloud-commons/pull/872/commits/77d93c44c1163672765844be09e324c467336022