### PR TITLE
fix NPE in NativeEnvironmentRepository

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepository.java
@@ -259,7 +259,7 @@ public class NativeEnvironmentRepository implements EnvironmentRepository, Searc
 						matches = true;
 						break;
 					}
-					if (location.startsWith("file:")) {
+					if (location != null && location.startsWith("file:")) {
 						location = StringUtils
 								.cleanPath(new File(location.substring("file:".length())).getAbsolutePath()) + "/";
 					}


### PR DESCRIPTION
Since the fix of this issue : https://github.com/spring-cloud/spring-cloud-config/issues/1771, I experience a NullpointerException at the launch of my service.
Indeed, the "location" var is null in my case.

Note : since the new Config file processing in Spring Boot 2.4, I'm using the Legacy Processing (spring.config.use-legacy-processing: true), migrating in the new process is way too breaking for my project.