### PR TITLE
restore useDefaultLabel parameter in ResourceController

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/resource/ResourceController.java
@@ -106,6 +106,13 @@ public class ResourceController {
 		return retrieve(request, name, profile, label, path, resolvePlaceholders);
 	}
 
+	@RequestMapping(value = "/{name}/{profile}/{path:.*}", params = "useDefaultLabel")
+	public String retrieveDefault(@PathVariable String name, @PathVariable String profile, @PathVariable String path,
+						   ServletWebRequest request,@RequestParam(defaultValue = "true") boolean resolvePlaceholders
+	) throws IOException {
+		return retrieve(request, name, profile, null, path, resolvePlaceholders);
+	}
+
 	private String getFilePath(ServletWebRequest request, String name, String profile, String label) {
 		String stem;
 		if (label != null) {
@@ -165,6 +172,14 @@ public class ResourceController {
 			ServletWebRequest request) throws IOException {
 		String path = getFilePath(request, name, profile, label);
 		return binary(request, name, profile, label, path);
+	}
+
+	@RequestMapping(value = "/{name}/{profile}/{path:.*}", params = "useDefaultLabel",
+			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public byte[] binaryDefault(@PathVariable String name, @PathVariable String profile, @PathVariable String path,
+						 ServletWebRequest request
+	)  throws IOException {
+		return binary(request, name, profile, null, path);
 	}
 
 	/*

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerIntegrationTests.java
@@ -122,7 +122,6 @@ public class ResourceControllerIntegrationTests {
 		verify(this.resources).findOne("foo", "default", "master", "foo.txt");
 	}
 
-	@Ignore
 	@Test
 	public void resourceNoLabel() throws Exception {
 		when(this.repository.findOne("foo", "default", null, false))
@@ -135,7 +134,6 @@ public class ResourceControllerIntegrationTests {
 		verify(this.resources).findOne("foo", "default", null, "foo.txt");
 	}
 
-	@Ignore
 	@Test
 	public void resourceNoLabelHttp() throws Exception {
 		when(this.repository.findOne("foo", "default", null, false))
@@ -144,23 +142,22 @@ public class ResourceControllerIntegrationTests {
 				.thenReturn(new ClassPathResource("resource-controller/foo.txt"));
 
 		ResponseEntity<String> response = new TestRestTemplate()
-				.getForEntity("http://localhost:" + port + "/foo/default/master/foo.txt", String.class);
+				.getForEntity("http://localhost:" + port + "/foo/default/foo.txt?useDefaultLabel", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		verify(this.repository).findOne("foo", "default", null, false);
 		verify(this.resources).findOne("foo", "default", null, "foo.txt");
 	}
 
-	@Ignore
 	@Test
 	public void binaryResourceNoLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", null, false))
-				.thenReturn(new Environment("foo", "default", "master"));
+		when(this.repository.findOne("foo", "default", null))
+			.thenReturn(new Environment("foo", "default", "master"));
 		when(this.resources.findOne("foo", "default", null, "foo.txt"))
 				.thenReturn(new ClassPathResource("resource-controller/foo.txt"));
 		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/foo.txt").param("useDefaultLabel", "")
 				.header(HttpHeaders.ACCEPT, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE))
 				.andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo", "default", null, false);
+		verify(this.repository).findOne("foo", "default", null);
 		verify(this.resources).findOne("foo", "default", null, "foo.txt");
 	}
 


### PR DESCRIPTION
Add back the ability to retrieve text files without specifying a label, using the documented syntax
`/{application}/{profile}/{path}?useDefaultLabel