### PR TITLE
fix documentation bad reference to URL placeholder

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -1564,7 +1564,7 @@ Spring Retry has a `RetryInterceptorBuilder` that supports creating one.
 
 The Config Service serves property sources from `/{application}/{profile}/{label}`, where the default bindings in the client app are as follows:
 
-* "name" = `${spring.application.name}`
+* "application" = `${spring.application.name}`
 * "profile" = `${spring.profiles.active}` (actually `Environment.getActiveProfiles()`)
 * "label" = "master"
 


### PR DESCRIPTION
On https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.2.RELEASE/reference/html/#_locating_remote_configuration_resources chapter, the placeholder in the URL is _${application}_ whereas the reference to it in the first item is _name_

Fixed to _application_