### PR TITLE
Feature(Vault KV2): to support a path after mount-path (backend) under which the key(s)/application(s) be found

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -52,19 +52,20 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	/** Vault backend. Defaults to secret. */
 	private String backend = "secret";
-		
 
 	/**
 	 * The key in vault shared by all applications. Defaults to application. Set to empty
 	 * to disable.
 	 */
 	private String defaultKey = "application";
-	
-	/** 
-	 * KV2 API required "data" after "mount-path". There could be folder/path structure, where the keys/applications are grouped.
-	 * This property is the path after mount-path, under which application(s) are located (appended after "data")
-	 * Default value is blank, which means all grouped applications are located right under the mount-path
-	 *  
+
+	/**
+	 * KV2 API required "data" after "mount-path". There could be folder/path structure,
+	 * where the keys/applications are grouped. This property is the path after
+	 * mount-path, under which application(s) are located (appended after "data") Default
+	 * value is blank, which means all grouped applications are located right under the
+	 * mount-path
+	 *
 	 */
 	private String pathToKey = "";
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -52,12 +52,21 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	/** Vault backend. Defaults to secret. */
 	private String backend = "secret";
+		
 
 	/**
 	 * The key in vault shared by all applications. Defaults to application. Set to empty
 	 * to disable.
 	 */
 	private String defaultKey = "application";
+	
+	/** 
+	 * KV2 API required "data" after "mount-path". There could be folder/path structure, where the keys/applications are grouped.
+	 * This property is the path after mount-path, under which application(s) are located (appended after "data")
+	 * Default value is blank, which means all grouped applications are located right under the mount-path
+	 *  
+	 */
+	private String pathToKey = "";
 
 	/** Vault profile separator. Defaults to comma. */
 	private String profileSeparator = ",";
@@ -261,6 +270,14 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	public AuthenticationMethod getAuthentication() {
 		return authentication;
+	}
+
+	public String getPathToKey() {
+		return pathToKey;
+	}
+
+	public void setPathToKey(String pathToKey) {
+		this.pathToKey = pathToKey;
 	}
 
 	public enum AuthenticationMethod {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
@@ -92,7 +92,7 @@ public class VaultEnvironmentRepository extends AbstractVaultEnvironmentReposito
 
 		String baseUrl = String.format("%s://%s:%s", this.scheme, this.host, this.port);
 
-		this.accessStrategy = VaultKvAccessStrategyFactory.forVersion(rest, baseUrl, properties.getKvVersion());
+		this.accessStrategy = VaultKvAccessStrategyFactory.forVersion(rest, baseUrl, properties.getKvVersion(), properties.getPathToKey());
 	}
 
 	/* for testing */ void setAccessStrategy(VaultKvAccessStrategy accessStrategy) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
@@ -92,7 +92,8 @@ public class VaultEnvironmentRepository extends AbstractVaultEnvironmentReposito
 
 		String baseUrl = String.format("%s://%s:%s", this.scheme, this.host, this.port);
 
-		this.accessStrategy = VaultKvAccessStrategyFactory.forVersion(rest, baseUrl, properties.getKvVersion(), properties.getPathToKey());
+		this.accessStrategy = VaultKvAccessStrategyFactory.forVersion(rest, baseUrl, properties.getKvVersion(),
+				properties.getPathToKey());
 	}
 
 	/* for testing */ void setAccessStrategy(VaultKvAccessStrategy accessStrategy) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.config.server.environment;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 
 /**
@@ -39,7 +40,7 @@ public final class VaultKvAccessStrategyFactory {
 	 * @param rest must not be {@literal null}.
 	 * @param baseUrl the Vault base URL.
 	 * @param version version of the Vault key-value backend.
-	 * @param pathToKey: path after the mount-path, under which the key(s) can be found.
+	 * @param pathToKey path after the mount-path, under which the key(s) can be found.
 	 * @return the access strategy.
 	 */
 	public static VaultKvAccessStrategy forVersion(RestOperations rest, String baseUrl, int version, String pathToKey) {
@@ -79,8 +80,9 @@ public final class VaultKvAccessStrategyFactory {
 	 * Strategy for the key-value backend API version 2.
 	 */
 	static class V2VaultKvAccessStrategy extends VaultKvAccessStrategySupport {
-		
-        String pathToKey;
+
+		private String pathToKey;
+
 		V2VaultKvAccessStrategy(String baseUrl, String pathToKey, RestOperations rest) {
 			super(baseUrl, rest);
 			this.pathToKey = pathToKey;
@@ -88,7 +90,12 @@ public final class VaultKvAccessStrategyFactory {
 
 		@Override
 		public String getPath() {
-			return "data/" + pathToKey + "/{key}";
+
+			if (StringUtils.hasText(pathToKey)) {
+				return "data/" + pathToKey + "/{key}";
+			}
+
+			return "data/{key}";
 		}
 
 		@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactory.java
@@ -39,15 +39,16 @@ public final class VaultKvAccessStrategyFactory {
 	 * @param rest must not be {@literal null}.
 	 * @param baseUrl the Vault base URL.
 	 * @param version version of the Vault key-value backend.
+	 * @param pathToKey: path after the mount-path, under which the key(s) can be found.
 	 * @return the access strategy.
 	 */
-	public static VaultKvAccessStrategy forVersion(RestOperations rest, String baseUrl, int version) {
+	public static VaultKvAccessStrategy forVersion(RestOperations rest, String baseUrl, int version, String pathToKey) {
 
 		switch (version) {
 		case 1:
 			return new V1VaultKvAccessStrategy(baseUrl, rest);
 		case 2:
-			return new V2VaultKvAccessStrategy(baseUrl, rest);
+			return new V2VaultKvAccessStrategy(baseUrl, pathToKey, rest);
 		default:
 			throw new IllegalArgumentException("No support for given Vault k/v backend version " + version);
 		}
@@ -78,14 +79,16 @@ public final class VaultKvAccessStrategyFactory {
 	 * Strategy for the key-value backend API version 2.
 	 */
 	static class V2VaultKvAccessStrategy extends VaultKvAccessStrategySupport {
-
-		V2VaultKvAccessStrategy(String baseUrl, RestOperations rest) {
+		
+        String pathToKey;
+		V2VaultKvAccessStrategy(String baseUrl, String pathToKey, RestOperations rest) {
 			super(baseUrl, rest);
+			this.pathToKey = pathToKey;
 		}
 
 		@Override
 		public String getPath() {
-			return "data/{key}";
+			return "data/" + pathToKey + "/{key}";
 		}
 
 		@Override

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyFactoryTest.java
@@ -30,19 +30,19 @@ public class VaultKvAccessStrategyFactoryTest {
 
 	@Test
 	public void testGetV1Strategy() {
-		VaultKvAccessStrategy vaultKvAccessStrategy = VaultKvAccessStrategyFactory.forVersion(null, "foo", 1);
+		VaultKvAccessStrategy vaultKvAccessStrategy = VaultKvAccessStrategyFactory.forVersion(null, "foo", 1, "");
 		assertThat(vaultKvAccessStrategy instanceof V1VaultKvAccessStrategy).isTrue();
 	}
 
 	@Test
 	public void testGetV2Strategy() {
-		VaultKvAccessStrategy vaultKvAccessStrategy = VaultKvAccessStrategyFactory.forVersion(null, "foo", 2);
+		VaultKvAccessStrategy vaultKvAccessStrategy = VaultKvAccessStrategyFactory.forVersion(null, "foo", 2, "");
 		assertThat(vaultKvAccessStrategy instanceof V2VaultKvAccessStrategy).isTrue();
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testGetUnsupportedStrategy() {
-		VaultKvAccessStrategyFactory.forVersion(null, "foo", 0);
+		VaultKvAccessStrategyFactory.forVersion(null, "foo", 0, "");
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultKvAccessStrategyTest.java
@@ -36,7 +36,7 @@ public class VaultKvAccessStrategyTest {
 	private ObjectMapper objectMapper = new ObjectMapper();
 
 	private static VaultKvAccessStrategySupport getStrategy(int version) {
-		return (VaultKvAccessStrategySupport) VaultKvAccessStrategyFactory.forVersion(null, "foo", version);
+		return (VaultKvAccessStrategySupport) VaultKvAccessStrategyFactory.forVersion(null, "foo", version, "");
 	}
 
 	@Test


### PR DESCRIPTION
Hello,

**Usecase/Problem**
Please note that below is a problem that can not be worked around for KV2 Vault APIs, due to the "data" that exactly need to go right after mount-path. 
1. In big corporations, we have needs, to group secret types together (e.g All-API-Secrets; All-Secrets-for-Pipelines for Team/ORG within the company) and manage policies accordingly.
2. Then there are use cases such that we create a separate mount-path for each type of secrets then application-level secrets (apps and app,profile) for an ORG can go under a separate path under (after) mount-path. So that we do not need to put all keys(applications) across ORGs(or teams) right under-mount path.
3. For example something like KV2 mount-path = cloud-api-secrets; under which we will have a path "ORG-1 (or Team-A)" and all applications (keys) belonging to ORG-1 will be created under org-1. I can also have ORG-2(or Team-B) as another path and all applications(keys) belonging to ORG2 will be created under org-2
- That means an effective path where keys can be found for org-1 would be /cloud-api-secrets/data/org-1
- That means an effective path where keys can be found for org-2 would be /cloud-api-secrets/data/org-2
3. The current version of the config-server does not support this. As it detects KV1 or KV2 based on a kvVersion prop, getPath() method in then KV2Strategy class returns "backend/data/{key}" as the effective path.
4. I made an enhancement to support a "path" between mount-path (backend) and "keys" (that's a folder/path under which a specific Org/Team's keys/apps can be found).

**Changes made**
1. I introduced another prop for KV2 called pathToKey (a path after mount-path, under which keys/apps can be found, with an empty default value  (i.e. by default it searches for keys right under mount-path(backend).
2. If pathToKey is configured, then conditionally for KV2, this path inserted between backend and key as "backend/data/path2key/{key}
- KV1 this is not a problem as *data* does not need to be included at a specific place in the API call.
4.  I made changes accordingly.
5. Fixed tests as needed.
6. Added a new test case called  "testVaultKV2WithPath2Key" for this use case alone.
7. Did "checkstyle" validations and committed to this feature branch, that I forked from "spring-cloud-config" master.

**Other points to be noted (considerations)**
- This will work even if the path is nested for example mount-path/data/path2Keys where path2Keys = nameA/nameA1 (effective path e.g. /secrets/data/nameA/nameA1/{key}) as long as all "keys" intended for that team/org are right under the path,  keys will be searched recursively under this path (e.g. application, application,profile1... for all profiles) 
- But *will not* recursively search in all paths for keys, in other words, **it is not equivalent to** to searchPaths feature in GIT Backend. It will only look for keys right under "pathToKeys" only (if nothing configured for this prop, it will search right under mount-path).
- I considered implementing a recursive search through multiple nested folders like searchPaths, but it felt like making it overly complicated, making it slower with KV2 (kv2 is already slower than kv1).  
- Plus I can not think of a use case as to why one would require "search folders" for secrets and make "vault policies" management maintenance complex as well with too many levels of nesting. OR if policies are created only at Team/ORG, I did not see a valid need for nesting.

Please let me know if this can be accepted?

Regards
sp