### PR TITLE
bump spring vault core to 2.3.2 to be compatible with spring cloud vault

### DIFF
--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<description>Spring Cloud Config Dependencies</description>
 	<properties>
 		<jgit.version>5.1.3.201810200350-r</jgit.version>
-		<spring-vault.version>2.3.0</spring-vault.version>
+		<spring-vault.version>2.3.2</spring-vault.version>
 		<spring-credhub.version>2.1.1.RELEASE</spring-credhub.version>
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
- Bump version for spring vault core from `2.3.0` to `2.3.2`

Fixes #1841 