### PR TITLE
management.endpoints.web.base-path=/admin

### DIFF
--- a/spring-cloud-config-server/src/main/resources/configserver.yml
+++ b/spring-cloud-config-server/src/main/resources/configserver.yml
@@ -18,4 +18,6 @@ spring:
 server:
   port: 8888
 management:
-  context_path: /admin
+  endpoints:
+    web:
+      base-path: /admin


### PR DESCRIPTION
According to [3.1. Customizing the Management Endpoint Paths](https://docs.spring.io/spring-boot/docs/2.4.x/reference/html/production-ready-features.html#production-ready-customizing-management-server-context-path) it seems to me that `management.endpoints.web.base-path=/admin` is the best choice.

If one really wants to change the actuator endpoint to `/admin` then the docs should also be corrected; see:

> The Config Server properties show up in the /env endpoint as a high-priority property source, as shown in the following example 

at [Client Side Usage](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_client_side_usage).

If it's not `/admin` then the docs should anyway be corrected to `/actuator/admin`.