### PR TITLE
Run Docker tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             - ~/.m2
       - run:
           name: "Running build"
-          command: ./mvnw -s .settings.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent install -U -P sonar,withoutDockerTests -nsu --batch-mode -Dmaven.test.redirectTestOutputToFile=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          command: ./mvnw -s .settings.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent install -U -P sonar -nsu --batch-mode -Dmaven.test.redirectTestOutputToFile=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - run:
           name: "Aggregate test results"
           when: always


### PR DESCRIPTION
A [recent PR](https://github.com/spring-cloud/spring-cloud-config/pull/1971) introduced a new profile that would not run tests that require Docker.  At the time, the CircleCI build type was Docker which necessitated that Docker tests were skipped during build.  However, a subsequent PR changed the CircleCI build type from Docker to a VM.  This means that Docker tests should be able to execute during the build in CircleCI now.