### PR TITLE
Adjust EnvironmentController for Path Pattern Parser

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,12 +104,12 @@ public class EnvironmentController {
 		this.acceptEmpty = acceptEmpty;
 	}
 
-	@GetMapping(path = "/{name}/{profiles:.*[^-].*}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/{name}/{profiles:[^-]+}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Environment defaultLabel(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, false);
 	}
 
-	@GetMapping(path = "/{name}/{profiles:.*[^-].*}", produces = EnvironmentMediaType.V2_JSON)
+	@GetMapping(path = "/{name}/{profiles:[^-]+}", produces = EnvironmentMediaType.V2_JSON)
 	public Environment defaultLabelIncludeOrigin(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, true);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AdhocTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@ import org.springframework.cloud.config.server.encryption.KeyStoreTextEncryptorL
 import org.springframework.cloud.config.server.environment.AwsParameterStoreEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.CompositeEnvironmentRepositoryTests;
-import org.springframework.cloud.config.server.environment.EnvironmentControllerIntegrationTests;
-import org.springframework.cloud.config.server.environment.EnvironmentControllerTests;
 import org.springframework.cloud.config.server.environment.EnvironmentEncryptorEnvironmentRepositoryTests;
 import org.springframework.cloud.config.server.environment.JGitEnvironmentRepositoryConcurrencyTests;
 import org.springframework.cloud.config.server.environment.JGitEnvironmentRepositoryIntegrationTests;
@@ -67,8 +65,7 @@ import org.springframework.cloud.config.server.ssh.SshUriPropertyProcessorTest;
 @SuiteClasses({ NativeConfigServerIntegrationTests.class, GenericResourceRepositoryTests.class,
 		ResourceControllerTests.class, ResourceControllerIntegrationTests.class, ConfigClientOnIntegrationTests.class,
 		ConfigServerApplicationTests.class, VanillaConfigServerIntegrationTests.class,
-		EnvironmentControllerIntegrationTests.class, MultipleJGitEnvironmentRepositoryIntegrationTests.class,
-		EnvironmentEncryptorEnvironmentRepositoryTests.class, EnvironmentControllerTests.class,
+		MultipleJGitEnvironmentRepositoryIntegrationTests.class, EnvironmentEncryptorEnvironmentRepositoryTests.class,
 		SVNKitEnvironmentRepositoryIntegrationTests.class,
 		MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.class, JdbcEnvironmentRepositoryTests.class,
 		CompositeEnvironmentRepositoryTests.class, JGitEnvironmentRepositoryConcurrencyTests.class,

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,27 +19,25 @@ package org.springframework.cloud.config.server.environment;
 import java.util.HashMap;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
-import org.springframework.cloud.config.server.environment.EnvironmentControllerIntegrationTests.ControllerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,131 +46,144 @@ import static org.mockito.Mockito.when;
  * @author Dave Syer
  * @author Roy Clarkson
  * @author Ivan Corrales Solera
+ * @author Henning Pöttker
  */
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = ControllerConfiguration.class)
-public class EnvironmentControllerIntegrationTests {
+class EnvironmentControllerIntegrationTests {
 
-	@Autowired
-	private WebApplicationContext context;
+	abstract static class TestCases {
 
-	private MockMvc mvc;
+		@Autowired
+		private WebApplicationContext context;
 
-	@Autowired
-	private EnvironmentRepository repository;
+		private MockMvc mvc;
 
-	private Environment environment = new Environment("foo", "default");
+		@Autowired
+		private EnvironmentRepository repository;
 
-	@Before
-	public void init() {
-		Mockito.reset(this.repository);
-		this.mvc = MockMvcBuilders.webAppContextSetup(this.context).build();
-		this.environment.add(new PropertySource("foo", new HashMap<>()));
+		private final Environment environment = new Environment("foo", "default");
+
+		@BeforeEach
+		public void init() {
+			Mockito.reset(this.repository);
+			this.mvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+			this.environment.add(new PropertySource("foo", new HashMap<>()));
+		}
+
+		@Test
+		public void environmentNoLabel() throws Exception {
+			when(this.repository.findOne("foo", "default", null, false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(this.repository).findOne("foo", "default", null, false);
+		}
+
+		@Test
+		public void propertiesNoLabel() throws Exception {
+			when(this.repository.findOne("foo", "default", null, false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo-default.properties"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(this.repository).findOne("foo", "default", null, false);
+		}
+
+		@Test
+		public void propertiesLabel() throws Exception {
+			when(this.repository.findOne("foo", "default", "label", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-default.properties"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(this.repository).findOne("foo", "default", "label", false);
+		}
+
+		@Test
+		public void propertiesLabelWhenApplicationNameContainsHyphen() throws Exception {
+			Environment environment = new Environment("foo-bar", "default");
+			environment.add(new PropertySource("foo", new HashMap<>()));
+			when(this.repository.findOne("foo-bar", "default", "label", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-bar-default.properties"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(this.repository).findOne("foo-bar", "default", "label", false);
+		}
+
+		@Test
+		public void propertiesLabelWithSlash() throws Exception {
+
+			when(this.repository.findOne("foo", "default", "label/spam", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/label(_)spam/foo-default.properties"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+			verify(this.repository).findOne("foo", "default", "label/spam", false);
+		}
+
+		@Test
+		public void environmentWithLabel() throws Exception {
+			when(this.repository.findOne("foo", "default", "awesome", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/awesome"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		public void environmentWithMissingLabel() throws Exception {
+			when(this.repository.findOne("foo", "default", "missing", false))
+					.thenThrow(new NoSuchLabelException("Planned"));
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/missing"))
+					.andExpect(MockMvcResultMatchers.status().isNotFound());
+		}
+
+		@Test
+		public void environmentWithMissingRepo() throws Exception {
+			when(this.repository.findOne("foo", "default", "missing", false))
+					.thenThrow(new NoSuchRepositoryException("Planned"));
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/missing"))
+					.andExpect(MockMvcResultMatchers.status().isNotFound());
+		}
+
+		@Test
+		public void environmentWithLabelContainingPeriod() throws Exception {
+			when(this.repository.findOne("foo", "default", "1.0.0", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/1.0.0"))
+					.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@Test
+		public void environmentWithLabelContainingSlash() throws Exception {
+			when(this.repository.findOne("foo", "default", "feature/puff", false)).thenReturn(this.environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/feature(_)puff"))
+					.andExpect(MockMvcResultMatchers.status().isOk())
+					.andExpect(MockMvcResultMatchers.content().string(Matchers.containsString("\"propertySources\":")));
+		}
+
+		@Test
+		public void environmentWithApplicationContainingSlash() throws Exception {
+			Environment environment = new Environment("foo/app", "default");
+			environment.add(new PropertySource("foo", new HashMap<>()));
+			when(this.repository.findOne("foo/app", "default", null, false)).thenReturn(environment);
+			this.mvc.perform(MockMvcRequestBuilders.get("/foo(_)app/default"))
+					.andExpect(MockMvcResultMatchers.status().isOk())
+					.andExpect(MockMvcResultMatchers.content().string(Matchers.containsString("\"propertySources\":")));
+		}
+
 	}
 
-	@Test
-	public void environmentNoLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", null, false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default")).andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo", "default", null, false);
+	@SpringBootTest(classes = ControllerConfiguration.class)
+	static class PathPatternParserTests extends TestCases {
+
 	}
 
-	@Test
-	public void propertiesNoLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", null, false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo-default.properties"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo", "default", null, false);
-	}
+	@SpringBootTest(classes = ControllerConfiguration.class)
+	@TestPropertySource(properties = "spring.mvc.pathmatch.matching-strategy=ant_path_matcher")
+	static class AntPathMatcherTests extends TestCases {
 
-	@Test
-	public void propertiesLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", "label", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-default.properties"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo", "default", "label", false);
-	}
-
-	@Test
-	public void propertiesLabelWhenApplicationNameContainsHyphen() throws Exception {
-		Environment environment = new Environment("foo-bar", "default");
-		environment.add(new PropertySource("foo", new HashMap<>()));
-		when(this.repository.findOne("foo-bar", "default", "label", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/label/foo-bar-default.properties"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo-bar", "default", "label", false);
-	}
-
-	@Test
-	public void propertiesLabelWithSlash() throws Exception {
-
-		when(this.repository.findOne("foo", "default", "label/spam", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/label(_)spam/foo-default.properties"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-		verify(this.repository).findOne("foo", "default", "label/spam", false);
-	}
-
-	@Test
-	public void environmentWithLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", "awesome", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/awesome"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-	}
-
-	@Test
-	public void environmentWithMissingLabel() throws Exception {
-		when(this.repository.findOne("foo", "default", "missing", false))
-				.thenThrow(new NoSuchLabelException("Planned"));
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/missing"))
-				.andExpect(MockMvcResultMatchers.status().isNotFound());
-	}
-
-	@Test
-	public void environmentWithMissingRepo() throws Exception {
-		when(this.repository.findOne("foo", "default", "missing", false))
-				.thenThrow(new NoSuchRepositoryException("Planned"));
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/missing"))
-				.andExpect(MockMvcResultMatchers.status().isNotFound());
-	}
-
-	@Test
-	public void environmentWithLabelContainingPeriod() throws Exception {
-		when(this.repository.findOne("foo", "default", "1.0.0", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/1.0.0"))
-				.andExpect(MockMvcResultMatchers.status().isOk());
-	}
-
-	@Test
-	public void environmentWithLabelContainingSlash() throws Exception {
-		when(this.repository.findOne("foo", "default", "feature/puff", false)).thenReturn(this.environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo/default/feature(_)puff"))
-				.andExpect(MockMvcResultMatchers.status().isOk())
-				.andExpect(MockMvcResultMatchers.content().string(Matchers.containsString("\"propertySources\":")));
-	}
-
-	@Test
-	public void environmentWithApplicationContainingSlash() throws Exception {
-		Environment environment = new Environment("foo/app", "default");
-		environment.add(new PropertySource("foo", new HashMap<>()));
-		when(this.repository.findOne("foo/app", "default", null, false)).thenReturn(environment);
-		this.mvc.perform(MockMvcRequestBuilders.get("/foo(_)app/default"))
-				.andExpect(MockMvcResultMatchers.status().isOk())
-				.andExpect(MockMvcResultMatchers.content().string(Matchers.containsString("\"propertySources\":")));
 	}
 
 	@Configuration
-	@EnableWebMvc
-	@Import(PropertyPlaceholderAutoConfiguration.class)
-	public static class ControllerConfiguration {
+	@Import({ PropertyPlaceholderAutoConfiguration.class, WebMvcAutoConfiguration.class })
+	static class ControllerConfiguration {
 
 		@Bean
-		public EnvironmentRepository environmentRepository() {
-			EnvironmentRepository repository = Mockito.mock(EnvironmentRepository.class);
-			return repository;
+		EnvironmentRepository environmentRepository() {
+			return Mockito.mock(EnvironmentRepository.class);
 		}
 
 		@Bean
-		public EnvironmentController controller() {
+		EnvironmentController controller() {
 			return new EnvironmentController(environmentRepository());
 		}
 


### PR DESCRIPTION
Fixes #2020 and #2021.

Config server URLs with paths like `/{label}/{application}-{profile}.properties` currently do not work as expected when Spring Web MVC uses `PathPatternParser` instead of `AntPathMatcher`. But with Spring Boot 2.6. the default matching strategy in the auto-configuration for Web MVC has been flipped to `PathPatternParser`.

This PR adjusts a regex in `EnvironmentController` such that both matching strategies work as expected. Furthermore, the Mock MVC tests for the controller are now executed with both strategies. As this is simpler with JUnit 5 than with Junit 4, the two test classes have been migrated.