### PR TITLE
Fixes gh-1611 - AWS S3 environment repository can read the default property file as well as a profile-specific file

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
@@ -18,7 +18,10 @@ package org.springframework.cloud.config.server.environment;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -31,11 +34,13 @@ import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Clay McCoy
  * @author Scott Frederick
+ * @author Daniel Aiken
  */
 public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordered, SearchPathLocator {
 
@@ -104,10 +109,15 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 	}
 
 	private String[] parseProfiles(String profiles) {
-		if (profiles.equals(serverProperties.getDefaultProfile())) {
-			return new String[] { profiles, null };
+		if (ObjectUtils.isEmpty(profiles)) {
+			return new String[] { null };
 		}
-		return StringUtils.commaDelimitedListToStringArray(profiles);
+		List<String> parsedProfiles = Arrays.stream(profiles.split(","))
+			.collect(Collectors.collectingAndThen(Collectors.toList(), p -> {
+				p.add(null);
+				return p;
+			}));
+		return parsedProfiles.toArray(new String[0]);
 	}
 
 	private S3ConfigFile getS3ConfigFile(String application, String profile, String label) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
@@ -99,7 +99,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
 
-		assertExpectedEnvironment(env, "foo", null, null, 1, "bar");
+		assertExpectedEnvironment(env, "foo", null, null, 1, "bar", null);
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
 
-		assertExpectedEnvironment(env, "foo", null, null, 1, "bar");
+		assertExpectedEnvironment(env, "foo", null, null, 1, "bar", null);
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
 
-		assertExpectedEnvironment(env, "foo", null, null, 1, "bar");
+		assertExpectedEnvironment(env, "foo", null, null, 1, "bar", null);
 	}
 
 	@Test
@@ -145,7 +145,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "profile1,profile2", null);
 
-		assertExpectedEnvironment(env, "foo", null, null, 2, "profile1", "profile2");
+		assertExpectedEnvironment(env, "foo", null, null, 2, "profile1", "profile2", null);
 	}
 
 	@Test
@@ -154,7 +154,17 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "profile1,profile2", null);
 
-		assertExpectedEnvironment(env, "foo", null, null, 1, "profile1", "profile2");
+		assertExpectedEnvironment(env, "foo", null, null, 1, "profile1", "profile2", null);
+	}
+
+	@Test
+	public void findWithOneProfileDefaultOneFound() throws UnsupportedEncodingException {
+		setupS3("foo-profile1.yml", jsonContent);
+		setupS3("foo.yml", yamlContent);
+
+		final Environment env = envRepo.findOne("foo", "profile1", null);
+
+		assertExpectedEnvironment(env, "foo", null, null, 2, "profile1", null);
 	}
 
 	@Test
@@ -163,7 +173,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "bar", "label1");
 
-		assertExpectedEnvironment(env, "foo", "label1", null, 1, "bar");
+		assertExpectedEnvironment(env, "foo", "label1", null, 1, "bar", null);
 	}
 
 	@Test
@@ -172,7 +182,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
 
-		assertExpectedEnvironment(env, "foo", null, "v1", 1, "bar");
+		assertExpectedEnvironment(env, "foo", null, "v1", 1, "bar", null);
 	}
 
 	@Test
@@ -182,7 +192,7 @@ public class AwsS3EnvironmentRepositoryTests {
 
 		final Environment env = envRepo.findOne("foo,bar", "profile1", null);
 
-		assertExpectedEnvironment(env, "foo,bar", null, null, 2, "profile1");
+		assertExpectedEnvironment(env, "foo,bar", null, null, 2, "profile1", null);
 	}
 
 	@Test


### PR DESCRIPTION
When fetching properties from S3, always look for the default property file `[application-name].[yml|json|properties]` as well as `[application-name]-[profile].[yml|json|properties]`. Previously it was only doing this if we were supplying the property that was configured as the default on the Config Server (usually "default").

This aligns the AWS S3 environment repository behavior with that of the native implementation, git.