### PR TITLE
docs(-): git.timeout default is 5

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -137,7 +137,7 @@ spring:
 
 ===== Setting HTTP Connection Timeout
 
-You can configure the time, in seconds, that the configuration server will wait to acquire an HTTP connection. Use the `git.timeout` property.
+You can configure the time, in seconds, that the configuration server will wait to acquire an HTTP connection. Use the `git.timeout` property (default is `5`).
 
 [source,yaml]
 ----


### PR DESCRIPTION
### I suggest common description about timeout. (default is xxxx)
https://cloud.spring.io/spring-cloud-config/reference/html/#_setting_http_connection_timeout
<img width="986" alt="스크린샷 2022-04-20 오후 5 19 17" src="https://user-images.githubusercontent.com/8468371/164183594-f5459a5e-dbc5-4755-ad45-f2f75bce5a25.png">

