### PR TITLE
Migrate to AWS SDK v2

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -340,17 +340,17 @@ This helper is not used with the JGit library, so a JGit CredentialProvider for 
 AWS CodeCommit URIs follow this pattern:
 
 ```bash
-https//git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos/${repo}.
+https://git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos/${repo}
 ```
 
 If you provide a username and password with an AWS CodeCommit URI, they must be the https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html[AWS accessKeyId and secretAccessKey] that provide access to the repository.
-If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[AWS Default Credential Provider Chain].
+If you do not specify a username and password, the accessKeyId and secretAccessKey are retrieved by using the https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html[Default Credential Provider Chain].
 
 If your Git URI matches the CodeCommit URI pattern (shown earlier), you must provide valid AWS credentials in the username and password or in one of the locations supported by the default credential provider chain.
 AWS EC2 instances may use https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html[IAM Roles for EC2 Instances].
 
-NOTE: The `aws-java-sdk-core` jar is an optional dependency.
-If the `aws-java-sdk-core` jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.
+NOTE: The `software.amazon.awssdk:auth` jar is an optional dependency.
+If the `software.amazon.awssdk:auth` jar is not on your classpath, the AWS Code Commit credential provider is not created, regardless of the git server URI.
 
 ===== Authentication with Google Cloud Source
 
@@ -940,15 +940,15 @@ NOTE: When no profile is specified `default` will be used.
 ==== AWS S3 Backend
 
 Spring Cloud Config Server supports AWS S3 as a backend for configuration properties.
-You can enable this feature by adding a dependency to the link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/examples-s3.html[AWS Java SDK For Amazon S3].
+You can enable this feature by adding a dependency to the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/examples-s3.html[AWS Java SDK For Amazon S3].
 
 [source,xml,indent=0]
 .pom.xml
 ----
 	<dependencies>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 	</dependencies>
 ----
@@ -970,7 +970,7 @@ spring:
 
 It is also possible to specify an AWS URL to link:https://aws.amazon.com/blogs/developer/using-new-regions-and-endpoints/[override the standard endpoint] of your S3 service with `spring.cloud.config.server.awss3.endpoint`. This allows support for beta regions of S3, and other S3 compatible storage APIs.
 
-Credentials are found using the link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[Default AWS Credential Provider Chain]. Versioned and encrypted buckets are supported without further configuration.
+Credentials are found using the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html[Default Credential Provider Chain]. Versioned and encrypted buckets are supported without further configuration.
 
 Configuration files are stored in your bucket as `{application}-{profile}.properties`, `{application}-{profile}.yml` or `{application}-{profile}.json`. An optional label can be provided to specify a directory path to the file.
 
@@ -978,14 +978,14 @@ NOTE: When no profile is specified `default` will be used.
 
 ==== AWS Parameter Store Backend
 
-Spring Cloud Config Server supports AWS Parameter Store as a backend for configuration properties. You can enable this feature by adding a dependency to the link:https://github.com/aws/aws-sdk-java/tree/master/aws-java-sdk-ssm[AWS Java SDK for SSM].
+Spring Cloud Config Server supports AWS Parameter Store as a backend for configuration properties. You can enable this feature by adding a dependency to the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/examples-ssm.html[AWS Java SDK for SSM].
 
 [source,xml,indent=0]
 .pom.xml
 ----
     <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-ssm</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>ssm</artifactId>
     </dependency>
 ----
 
@@ -1019,7 +1019,7 @@ The following table describes the AWS Parameter Store configuration properties.
 |*region*
 |no
 |
-|The region to be used by the AWS Parameter Store client. If it's not explicitly set, the SDK tries to determine the region to use by using the link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#default-region-provider-chain[Default Region Provider Chain].
+|The region to be used by the AWS Parameter Store client. If it's not explicitly set, the SDK tries to determine the region to use by using the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/region-selection.html#default-region-provider-chain[Default Region Provider Chain].
 
 |*endpoint*
 |no
@@ -1058,7 +1058,7 @@ The following table describes the AWS Parameter Store configuration properties.
 
 |===
 
-AWS Parameter Store API credentials are determined using the link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[Default Credential Provider Chain].
+AWS Parameter Store API credentials are determined using the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html#credentials-default[Default Credential Provider Chain].
 Versioned parameters are already supported with the default behaviour of returning the latest version.
 
 [NOTE]
@@ -1072,14 +1072,14 @@ Versioned parameters are already supported with the default behaviour of returni
 ==== AWS Secrets Manager Backend
 
 Spring Cloud Config Server supports link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager] as a backend for configuration properties.
-You can enable this feature by adding a dependency to link:https://github.com/aws/aws-sdk-java/tree/master/aws-java-sdk-secretsmanager[AWS Java SDK for Secrets Manager].
+You can enable this feature by adding a dependency to link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/examples-secretsmanager.html[AWS Java SDK for Secrets Manager].
 
 [source,xml,indent=0]
 .pom.xml
 ----
 <dependency>
-    <groupId>com.amazonaws</groupId>
-    <artifactId>aws-java-sdk-secretsmanager</artifactId>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>secretsmanager</artifactId>
 </dependency>
 ----
 
@@ -1102,7 +1102,7 @@ spring:
 
 ----
 
-AWS Secrets Manager API credentials are determined using link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default[Default Credential Provider Chain].
+AWS Secrets Manager API credentials are determined using link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html#credentials-default[Default Credential Provider Chain].
 
 [NOTE]
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,10 @@
 	<properties>
 		<bintray.package>config</bintray.package>
 		<spring-cloud-commons.version>4.0.0-SNAPSHOT</spring-cloud-commons.version>
-		<aws-java-sdk.version>1.11.911</aws-java-sdk.version>
+		<aws-java-sdk.version>2.17.195</aws-java-sdk.version>
 		<google-api-services-iam.version>v1-rev20201112-1.30.10</google-api-services-iam.version>
 		<testcontainers.version>1.16.2</testcontainers.version>
+		<aws-java-sdk-v1.version>1.12.220</aws-java-sdk-v1.version>
 		<wiremock.version>2.31.0</wiremock.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true
@@ -71,23 +72,23 @@
 				<version>${spring-cloud-commons.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-core</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>protocol-core</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-s3</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>s3</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-secretsmanager</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>secretsmanager</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-ssm</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>ssm</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>
@@ -116,8 +117,13 @@
 				<version>${testcontainers.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-      </dependency>
-      <dependency>
+			</dependency>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-core</artifactId>
+				<version>${aws-java-sdk-v1.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>com.github.tomakehurst</groupId>
 				<artifactId>wiremock-jre8</artifactId>
 				<version>${wiremock.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 			</dependency>
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>protocol-core</artifactId>
+				<artifactId>auth</artifactId>
 				<version>${aws-java-sdk.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<description>Spring Cloud Config Dependencies</description>
 	<properties>
 		<jgit.version>5.12.0.202106070339-r</jgit.version>
-		<spring-vault.version>2.3.2</spring-vault.version>
+		<spring-vault.version>3.0.0-M1</spring-vault.version>
 		<spring-credhub.version>2.1.1.RELEASE</spring-credhub.version>
 	</properties>
 	<dependencyManagement>

--- a/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
+++ b/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.junit.jupiter.Container;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * vaultordering/client-dev.yml
  */
 @Testcontainers
+@Tag("DockerRequired")
 public class ConfigDataOrderingVaultIntegrationTests {
 
 	private static final int configServerPort = TestSocketUtils.findAvailableTcpPort();

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -94,23 +94,23 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>protocol-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>secretsmanager</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ssm</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ssm</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -166,6 +166,16 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>localstack</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -95,7 +95,7 @@
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>protocol-core</artifactId>
+			<artifactId>auth</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ package org.springframework.cloud.config.server.config;
 import java.util.List;
 import java.util.Optional;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.http.client.HttpClient;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.tmatesoft.svn.core.SVNException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
@@ -210,7 +210,7 @@ public class EnvironmentRepositoryConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(AmazonS3.class)
+	@ConditionalOnClass(S3Client.class)
 	static class AwsS3FactoryConfig {
 
 		@Bean
@@ -221,7 +221,7 @@ public class EnvironmentRepositoryConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(AWSSecretsManager.class)
+	@ConditionalOnClass(SecretsManagerClient.class)
 	static class AwsSecretsManagerFactoryConfig {
 
 		@Bean
@@ -233,7 +233,7 @@ public class EnvironmentRepositoryConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(AWSSimpleSystemsManagement.class)
+	@ConditionalOnClass(SsmClient.class)
 	static class AwsParameterStoreFactoryConfig {
 
 		@Bean

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsClientBuilderConfigurer.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsClientBuilderConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.client.builder.AwsSyncClientBuilder;
+import java.net.URI;
+
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
 
 import org.springframework.util.StringUtils;
 
@@ -26,15 +28,11 @@ abstract class AwsClientBuilderConfigurer {
 	private AwsClientBuilderConfigurer() {
 	}
 
-	static void configureClientBuilder(AwsSyncClientBuilder<?, ?> clientBuilder, String region, String endpoint) {
+	static void configureClientBuilder(AwsClientBuilder<?, ?> clientBuilder, String region, String endpoint) {
 		if (StringUtils.hasText(region)) {
+			clientBuilder.region(Region.of(region));
 			if (StringUtils.hasText(endpoint)) {
-				AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
-						endpoint, region);
-				clientBuilder.withEndpointConfiguration(endpointConfiguration);
-			}
-			else {
-				clientBuilder.withRegion(region);
+				clientBuilder.endpointOverride(URI.create(endpoint));
 			}
 		}
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 
@@ -37,11 +37,11 @@ public class AwsParameterStoreEnvironmentRepositoryFactory implements
 
 	@Override
 	public AwsParameterStoreEnvironmentRepository build(AwsParameterStoreEnvironmentProperties environmentProperties) {
-		AWSSimpleSystemsManagementClientBuilder clientBuilder = AWSSimpleSystemsManagementClientBuilder.standard();
+		SsmClientBuilder clientBuilder = SsmClient.builder();
 
 		configureClientBuilder(clientBuilder, environmentProperties.getRegion(), environmentProperties.getEndpoint());
 
-		AWSSimpleSystemsManagement client = clientBuilder.build();
+		SsmClient client = clientBuilder.build();
 
 		return new AwsParameterStoreEnvironmentRepository(client, configServerProperties, environmentProperties);
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectIdBuilder;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.cloud.config.environment.Environment;
@@ -31,6 +31,7 @@ import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -43,7 +44,7 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 	private static final String PATH_SEPARATOR = "/";
 
-	private final AmazonS3 s3Client;
+	private final S3Client s3Client;
 
 	private final String bucketName;
 
@@ -51,7 +52,7 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 	protected int order = Ordered.LOWEST_PRECEDENCE;
 
-	public AwsS3EnvironmentRepository(AmazonS3 s3Client, String bucketName, ConfigServerProperties server) {
+	public AwsS3EnvironmentRepository(S3Client s3Client, String bucketName, ConfigServerProperties server) {
 		this.s3Client = s3Client;
 		this.bucketName = bucketName;
 		this.serverProperties = server;
@@ -68,11 +69,11 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 	@Override
 	public Environment findOne(String specifiedApplication, String specifiedProfiles, String specifiedLabel) {
-		final String application = StringUtils.isEmpty(specifiedApplication)
+		final String application = ObjectUtils.isEmpty(specifiedApplication)
 				? serverProperties.getDefaultApplicationName() : specifiedApplication;
-		final String profiles = StringUtils.isEmpty(specifiedProfiles) ? serverProperties.getDefaultProfile()
+		final String profiles = ObjectUtils.isEmpty(specifiedProfiles) ? serverProperties.getDefaultProfile()
 				: specifiedProfiles;
-		final String label = StringUtils.isEmpty(specifiedLabel) ? serverProperties.getDefaultLabel() : specifiedLabel;
+		final String label = ObjectUtils.isEmpty(specifiedLabel) ? serverProperties.getDefaultLabel() : specifiedLabel;
 
 		String[] profileArray = parseProfiles(profiles);
 		String[] apps = new String[] { application };
@@ -113,41 +114,40 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 	private S3ConfigFile getS3ConfigFile(String application, String profile, String label) {
 		String objectKeyPrefix = buildObjectKeyPrefix(application, profile, label);
 
-		final S3ObjectIdBuilder s3ObjectIdBuilder = new S3ObjectIdBuilder().withBucket(bucketName);
+		final GetObjectRequest.Builder requestBuilder = GetObjectRequest.builder().bucket(bucketName);
 
-		return getS3ConfigFile(s3ObjectIdBuilder, objectKeyPrefix);
+		return getS3ConfigFile(requestBuilder, objectKeyPrefix);
 	}
 
 	private String buildObjectKeyPrefix(String application, String profile, String label) {
 		StringBuilder objectKeyPrefix = new StringBuilder();
-		if (!StringUtils.isEmpty(label)) {
+		if (StringUtils.hasLength(label)) {
 			objectKeyPrefix.append(label).append(PATH_SEPARATOR);
 		}
 		objectKeyPrefix.append(application);
-		if (!StringUtils.isEmpty(profile)) {
+		if (StringUtils.hasLength(profile)) {
 			objectKeyPrefix.append("-").append(profile);
 		}
 		return objectKeyPrefix.toString();
 	}
 
-	private S3ConfigFile getS3ConfigFile(S3ObjectIdBuilder s3ObjectIdBuilder, String keyPrefix) {
+	private S3ConfigFile getS3ConfigFile(GetObjectRequest.Builder requestBuilder, String keyPrefix) {
 		try {
-			final S3Object properties = s3Client
-					.getObject(new GetObjectRequest(s3ObjectIdBuilder.withKey(keyPrefix + ".properties").build()));
-			return new PropertyS3ConfigFile(properties.getObjectMetadata().getVersionId(),
-					properties.getObjectContent());
+			ResponseInputStream<GetObjectResponse> inputStream = s3Client
+					.getObject(requestBuilder.key(keyPrefix + ".properties").build());
+			return new PropertyS3ConfigFile(inputStream.response().versionId(), inputStream);
 		}
 		catch (Exception eProperties) {
 			try {
-				final S3Object yaml = s3Client
-						.getObject(new GetObjectRequest(s3ObjectIdBuilder.withKey(keyPrefix + ".yml").build()));
-				return new YamlS3ConfigFile(yaml.getObjectMetadata().getVersionId(), yaml.getObjectContent());
+				ResponseInputStream<GetObjectResponse> inputStream = s3Client
+						.getObject(requestBuilder.key(keyPrefix + ".yml").build());
+				return new YamlS3ConfigFile(inputStream.response().versionId(), inputStream);
 			}
 			catch (Exception eYaml) {
 				try {
-					final S3Object json = s3Client
-							.getObject(new GetObjectRequest(s3ObjectIdBuilder.withKey(keyPrefix + ".json").build()));
-					return new JsonS3ConfigFile(json.getObjectMetadata().getVersionId(), json.getObjectContent());
+					ResponseInputStream<GetObjectResponse> inputStream = s3Client
+							.getObject(requestBuilder.key(keyPrefix + ".json").build());
+					return new JsonS3ConfigFile(inputStream.response().versionId(), inputStream);
 				}
 				catch (Exception eJson) {
 					return null;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 
@@ -34,9 +34,9 @@ public class AwsS3EnvironmentRepositoryFactory
 
 	@Override
 	public AwsS3EnvironmentRepository build(AwsS3EnvironmentProperties environmentProperties) {
-		final AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard();
+		final S3ClientBuilder clientBuilder = S3Client.builder();
 		configureClientBuilder(clientBuilder, environmentProperties.getRegion(), environmentProperties.getEndpoint());
-		final AmazonS3 client = clientBuilder.build();
+		final S3Client client = clientBuilder.build();
 
 		AwsS3EnvironmentRepository repository = new AwsS3EnvironmentRepository(client,
 				environmentProperties.getBucket(), server);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 
@@ -37,11 +37,11 @@ public class AwsSecretsManagerEnvironmentRepositoryFactory implements
 
 	@Override
 	public AwsSecretsManagerEnvironmentRepository build(AwsSecretsManagerEnvironmentProperties environmentProperties) {
-		AWSSecretsManagerClientBuilder clientBuilder = AWSSecretsManagerClientBuilder.standard();
+		SecretsManagerClientBuilder clientBuilder = SecretsManagerClient.builder();
 
 		configureClientBuilder(clientBuilder, environmentProperties.getRegion(), environmentProperties.getEndpoint());
 
-		AWSSecretsManager client = clientBuilder.build();
+		SecretsManagerClient client = clientBuilder.build();
 		return new AwsSecretsManagerEnvironmentRepository(client, configServerProperties, environmentProperties);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,12 +118,13 @@ public class GitCredentialsProviderFactory {
 
 	/**
 	 * Check to see if the AWS Authentication API is available.
-	 * @return true if the com.amazonaws.auth.DefaultAWSCredentialsProviderChain is
-	 * present, false otherwise.
+	 * @return true if the
+	 * software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider is present,
+	 * false otherwise.
 	 */
 	private boolean awsAvailable() {
 		return this.awsCodeCommitEnabled
-				&& ClassUtils.isPresent("com.amazonaws.auth.DefaultAWSCredentialsProviderChain", null);
+				&& ClassUtils.isPresent("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider", null);
 	}
 
 	/**

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/credentials/AwsCodeCommitCredentialsProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package org.springframework.cloud.config.server.credentials;
 
 import java.net.URISyntaxException;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import org.springframework.cloud.config.server.support.AwsCodeCommitCredentialProvider;
 import org.springframework.cloud.config.server.support.GitCredentialsProviderFactory;
@@ -97,18 +98,18 @@ public class AwsCodeCommitCredentialsProviderTests {
 
 	@Test
 	public void testAwsCredentialsProviderIsNullInitially() {
-		AWSCredentialsProvider awsProvider = this.provider.getAwsCredentialProvider();
+		AwsCredentialsProvider awsProvider = this.provider.getAwsCredentialProvider();
 		assertThat(awsProvider).isNull();
 	}
 
 	@Test
 	public void testAwsCredentialsProviderIsDefinedAfterGet() throws URISyntaxException {
-		AWSCredentialsProvider awsProvider = this.provider.getAwsCredentialProvider();
+		AwsCredentialsProvider awsProvider = this.provider.getAwsCredentialProvider();
 		assertThat(awsProvider).isNull();
 		assertThat(this.provider.get(new URIish(AWS_REPO), makeCredentialItems())).isTrue();
 		awsProvider = this.provider.getAwsCredentialProvider();
 		assertThat(awsProvider).isNotNull();
-		assertThat(awsProvider instanceof AwsCodeCommitCredentialProvider.AWSStaticCredentialsProvider).isTrue();
+		assertThat(awsProvider).isInstanceOf(StaticCredentialsProvider.class);
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryIntegrationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SSM;
+import static software.amazon.awssdk.services.ssm.model.ParameterType.STRING;
+
+/**
+ * @author Henning Pöttker
+ */
+@Testcontainers
+@Tag("DockerRequired")
+class AwsParameterStoreEnvironmentRepositoryIntegrationTests {
+
+	@Container
+	static LocalStackContainer localStack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.3.1")).withServices(SSM);
+
+	@Test
+	void test() {
+		SsmClient ssmClient = SsmClient.builder().region(Region.of(localStack.getRegion()))
+				.endpointOverride(localStack.getEndpointOverride(SSM))
+				.credentialsProvider(StaticCredentialsProvider
+						.create(AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
+				.build();
+		ssmClient.putParameter((builder) -> builder.name("/config/foo-bar/tag").value("myapp").type(STRING));
+
+		Environment env = new AwsParameterStoreEnvironmentRepository(ssmClient, new ConfigServerProperties(),
+				new AwsParameterStoreEnvironmentProperties()).findOne("foo", "bar", "");
+		assertThat(env.getName()).isEqualTo("foo");
+		assertThat(env.getPropertySources()).hasSize(1);
+		assertThat(env.getPropertySources().get(0).getSource().get("tag")).isEqualTo("myapp");
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,13 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
-import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
-import com.amazonaws.services.simplesystemsmanagement.model.ParameterType;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+import software.amazon.awssdk.services.ssm.model.ParameterType;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -97,8 +97,7 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 		}
 	};
 
-	private final AWSSimpleSystemsManagement awsSsmClientMock = mock(AWSSimpleSystemsManagement.class,
-			"aws-ssm-client-mock");
+	private final SsmClient awsSsmClientMock = mock(SsmClient.class, "aws-ssm-client-mock");
 
 	private final ConfigServerProperties configServerProperties = new ConfigServerProperties();
 
@@ -686,7 +685,7 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 		Environment expected = new Environment(application, profiles, null, null, null);
 
 		when(awsSsmClientMock.getParametersByPath(any(GetParametersByPathRequest.class)))
-				.thenReturn(new GetParametersByPathResult());
+				.thenReturn(GetParametersByPathResponse.builder().build());
 
 		// Act
 		Environment result = repository.findOne(application, profile, null);
@@ -725,14 +724,14 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 		for (PropertySource ps : environment.getPropertySources()) {
 			String path = StringUtils.delete(ps.getName(), environmentProperties.getOrigin());
 
-			GetParametersByPathRequest request = new GetParametersByPathRequest().withPath(path)
-					.withRecursive(environmentProperties.isRecursive())
-					.withWithDecryption(environmentProperties.isDecryptValues())
-					.withMaxResults(environmentProperties.getMaxResults());
+			GetParametersByPathRequest request = GetParametersByPathRequest.builder().path(path)
+					.recursive(environmentProperties.isRecursive())
+					.withDecryption(environmentProperties.isDecryptValues())
+					.maxResults(environmentProperties.getMaxResults()).build();
 
 			Set<Parameter> parameters = getParameters(ps, path, withSlashesForPropertyName);
 
-			GetParametersByPathResult response = new GetParametersByPathResult().withParameters(parameters);
+			GetParametersByPathResponse response = GetParametersByPathResponse.builder().parameters(parameters).build();
 
 			if (paginatedResponse && environmentProperties.getMaxResults() < parameters.size()) {
 				List<Set<Parameter>> chunks = splitParametersIntoChunks(parameters);
@@ -745,24 +744,24 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 					if (i == 0) {
 						nextToken = generateNextToken();
 
-						GetParametersByPathResult responseClone = response.clone().withParameters(chunk)
-								.withNextToken(nextToken);
+						GetParametersByPathResponse responseClone = response.toBuilder().parameters(chunk)
+								.nextToken(nextToken).build();
 
 						when(awsSsmClientMock.getParametersByPath(eq(request))).thenReturn(responseClone);
 					}
 					else if (i == chunks.size() - 1) {
-						GetParametersByPathRequest requestClone = request.clone().withNextToken(nextToken);
-						GetParametersByPathResult responseClone = response.clone().withParameters(chunk);
+						GetParametersByPathRequest requestClone = request.toBuilder().nextToken(nextToken).build();
+						GetParametersByPathResponse responseClone = response.toBuilder().parameters(chunk).build();
 
 						when(awsSsmClientMock.getParametersByPath(eq(requestClone))).thenReturn(responseClone);
 					}
 					else {
 						String newNextToken = generateNextToken();
 
-						GetParametersByPathRequest requestClone = request.clone().withNextToken(nextToken);
+						GetParametersByPathRequest requestClone = request.toBuilder().nextToken(nextToken).build();
 
-						GetParametersByPathResult responseClone = response.clone().withParameters(chunk)
-								.withNextToken(newNextToken);
+						GetParametersByPathResponse responseClone = response.toBuilder().parameters(chunk)
+								.nextToken(newNextToken).build();
 
 						when(awsSsmClientMock.getParametersByPath(eq(requestClone))).thenReturn(responseClone);
 
@@ -778,10 +777,10 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 
 	private Set<Parameter> getParameters(PropertySource propertySource, String path,
 			boolean withSlashesForPropertyName) {
-		Function<Map.Entry<?, ?>, Parameter> mapper = p -> new Parameter()
-				.withName(path + (withSlashesForPropertyName
+		Function<Map.Entry<?, ?>, Parameter> mapper = p -> Parameter
+				.builder().name(path + (withSlashesForPropertyName
 						? ((String) p.getKey()).replace(".", DEFAULT_PATH_SEPARATOR) : p.getKey()))
-				.withType(ParameterType.String).withValue((String) p.getValue()).withVersion(1L);
+				.type(ParameterType.STRING).value((String) p.getValue()).version(1L).build();
 
 		return propertySource.getSource().entrySet().stream().map(mapper).collect(Collectors.toSet());
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryIntegrationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+/**
+ * @author Henning Pöttker
+ */
+@Testcontainers
+@Tag("DockerRequired")
+class AwsS3EnvironmentRepositoryIntegrationTests {
+
+	private static final String BUCKET = "bucket1";
+
+	@Container
+	static LocalStackContainer localStack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.3.1")).withServices(S3);
+
+	@Test
+	void test() {
+		S3Client s3Client = S3Client.builder().region(Region.of(localStack.getRegion()))
+				.endpointOverride(localStack.getEndpointOverride(S3))
+				.credentialsProvider(StaticCredentialsProvider
+						.create(AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
+				.build();
+		s3Client.createBucket((builder) -> builder.bucket(BUCKET));
+		s3Client.putObject((builder) -> builder.bucket(BUCKET).key("foo-bar.json"),
+				RequestBody.fromString("{\"tag\": \"myapp\"}"));
+
+		Environment env = new AwsS3EnvironmentRepository(s3Client, BUCKET, new ConfigServerProperties()).findOne("foo",
+				"bar", "");
+		assertThat(env.getName()).isEqualTo("foo");
+		assertThat(env.getPropertySources()).hasSize(1);
+		assertThat(env.getPropertySources().get(0).getSource().get("tag")).isEqualTo("myapp");
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryIntegrationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SECRETSMANAGER;
+
+/**
+ * @author Henning Pöttker
+ */
+@Testcontainers
+@Tag("DockerRequired")
+class AwsSecretsManagerEnvironmentRepositoryIntegrationTests {
+
+	@Container
+	static LocalStackContainer localStack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:0.14.3.1")).withServices(SECRETSMANAGER);
+
+	@Test
+	void test() {
+		SecretsManagerClient client = SecretsManagerClient.builder().region(Region.of(localStack.getRegion()))
+				.endpointOverride(localStack.getEndpointOverride(SECRETSMANAGER))
+				.credentialsProvider(StaticCredentialsProvider
+						.create(AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
+				.build();
+		client.createSecret((builder) -> builder.name("/secret/foo-bar/").secretString("{\"tag\": \"myapp\"}"));
+
+		Environment env = new AwsSecretsManagerEnvironmentRepository(client, new ConfigServerProperties(),
+				new AwsSecretsManagerEnvironmentProperties()).findOne("foo", "bar", "");
+		assertThat(env.getName()).isEqualTo("foo");
+		assertThat(env.getPropertySources()).hasSize(1);
+		assertThat(env.getPropertySources().get(0).getSource().get("tag")).isEqualTo("myapp");
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -30,6 +27,9 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -49,7 +49,7 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 
 	private static final Log log = LogFactory.getLog(AwsSecretsManagerEnvironmentRepository.class);
 
-	private final AWSSecretsManager awsSmClientMock = mock(AWSSecretsManager.class, "aws-sm-client-mock");
+	private final SecretsManagerClient awsSmClientMock = mock(SecretsManagerClient.class, "aws-sm-client-mock");
 
 	private final ConfigServerProperties configServerProperties = new ConfigServerProperties();
 
@@ -739,10 +739,10 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 	private void setupAwsSmClientMocks(Environment environment) {
 		for (PropertySource ps : environment.getPropertySources()) {
 			String path = StringUtils.delete(ps.getName(), environmentProperties.getOrigin());
-			GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(path);
+			GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
 
 			String secrets = getSecrets(ps);
-			GetSecretValueResult response = new GetSecretValueResult().withSecretString(secrets);
+			GetSecretValueResponse response = GetSecretValueResponse.builder().secretString(secrets).build();
 
 			when(awsSmClientMock.getSecretValue(eq(request))).thenReturn(response);
 		}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultClientConfigurationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultClientConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ class SpringVaultClientConfigurationTests {
 	@Test
 	public void awsIamAuthentication() {
 		System.setProperty("aws.accessKeyId", "access-key-id");
-		System.setProperty("aws.secretKey", "secret-key");
+		System.setProperty("aws.secretAccessKey", "secret-access-key");
 
 		properties.setAuthentication(AWS_IAM);
 		properties.getAwsIam().setRole("server");


### PR DESCRIPTION
The PR migrates the AWS SDK from v1 to v2 and resolves #2038.

I'm quite happy with the current state but there are some open points:
- The integration with AWS CodeCommit needs to be tested manually as the Community Edition of LocalStack does not support it.
- AFAICT there is currently no release of Spring Cloud AWS with the v2 SDK. But this could also be addressed in a follow-up step to resolve #1939.

