### PR TITLE
Support labels in AWS SecretsManager backend

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -866,7 +866,29 @@ secret value =
 }
 ----
 
-===== AWS Parameter Store
+===== Labelled Versions
+
+AWS Secrets Manager repository allows to keep labelled versions of the configuration environments the same way Git backend does. To create a labelled secret, a label should be added to its name. For example, secrets `/secret/application/1.0.0/` and `/secret/application-default/1.0.0/` are treated as secrets labelled with `1.0.0`.
+
+By default labelled version support is disabled in AWS Secrets Manager for backward compatibility. To turn it on, set `spring.cloud.config.server.aws-secretsmanager.label-enabled` property in the ConfigServer configuration to `true`. Use `spring.cloud.config.server.aws-secretsmanager.default-label` property to set the default label.
+
+[source,yaml]
+----
+spring:
+  profiles:
+    active: aws-secretsmanager
+  cloud:
+    config:
+      server:
+        aws-secretsmanager:
+          region: us-east-1
+          label-enabled: true
+          default-label: 1.0.0
+----
+
+Note that if the default label is not set and a request does not define a label, the repository will use secrets as if labelled version support is disabled. Also, the default label will be used only if the labelled support is enabled. Otherwise, defining this property is pointless.
+
+==== AWS Parameter Store
 
 When using AWS Parameter Store as a backend, you can share configuration with all applications by placing properties within the `/application` hierarchy.
 

--- a/docs/src/main/asciidoc/spring-cloud-config.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config.adoc
@@ -868,9 +868,33 @@ secret value =
 
 ===== Labelled Versions
 
-AWS Secrets Manager repository allows to keep labelled versions of the configuration environments the same way Git backend does. To create a labelled secret, a label should be added to its name. For example, secrets `/secret/application/1.0.0/` and `/secret/application-default/1.0.0/` are treated as secrets labelled with `1.0.0`.
+AWS Secrets Manager repository allows to keep labelled versions of the configuration environments the same way Git backend does.
 
-By default labelled version support is disabled in AWS Secrets Manager for backward compatibility. To turn it on, set `spring.cloud.config.server.aws-secretsmanager.label-enabled` property in the ConfigServer configuration to `true`. Use `spring.cloud.config.server.aws-secretsmanager.default-label` property to set the default label.
+The repository implementation maps the `{label}` parameter of the HTTP resource to https://docs.aws.amazon.com/secretsmanager/latest/userguide/getting-started.html#term_version[AWS Secrets Manager secret's staging label^]. To create a labelled secret, create a secret or update its content and define a staging label for it (sometimes it's called version stage in the AWS documentation). For example:
+
+[source,sh]
+----
+$ aws secretsmanager create-secret \
+      --name /secret/test/ \
+      --secret-string '{"version":"1"}'
+{
+    "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:/secret/test/-a1b2c3",
+    "Name": "/secret/test/",
+    "VersionId": "cd291674-de2f-41de-8f3b-37dbf4880d69"
+}
+
+$ aws secretsmanager update-secret-version-stage \
+      --secret-id /secret/test/ \
+      --version-stage 1.0.0 \
+      --move-to-version-id cd291674-de2f-41de-8f3b-37dbf4880d69
+
+{
+    "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:/secret/test/-a1b2c3",
+    "Name": "/secret/test/",
+}
+----
+
+Use `spring.cloud.config.server.aws-secretsmanager.default-label` property to set the default label. If the property is not defined, the backend uses AWSCURRENT as a staging label.
 
 [source,yaml]
 ----
@@ -882,11 +906,12 @@ spring:
       server:
         aws-secretsmanager:
           region: us-east-1
-          label-enabled: true
           default-label: 1.0.0
 ----
 
 Note that if the default label is not set and a request does not define a label, the repository will use secrets as if labelled version support is disabled. Also, the default label will be used only if the labelled support is enabled. Otherwise, defining this property is pointless.
+
+Note that if the staging label contains a slash (`/`), then the label in the HTTP URL should instead be specified with the special string `({special-string})` (to avoid ambiguity with other URL paths) the same way <<_git_backend,Git backend's section>> describes it.
 
 ==== AWS Parameter Store
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -49,13 +49,8 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	private String endpoint;
 
 	/**
-	 * The flag indicating enabled support of the labels. Defaults to false for backward
-	 * compatibility.
-	 */
-	private boolean labelEnabled;
-
-	/**
-	 * The default label to be suffixed (if defined) to the secret names.
+	 * The default staging label to be used to fetch the secret values. If unset, an
+	 * active version of the secret will be fetched (AWSCURRENT).
 	 */
 	private String defaultLabel;
 
@@ -100,14 +95,6 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 
 	public void setEndpoint(String endpoint) {
 		this.endpoint = endpoint;
-	}
-
-	public boolean isLabelEnabled() {
-		return labelEnabled;
-	}
-
-	public void setLabelEnabled(boolean labelEnabled) {
-		this.labelEnabled = labelEnabled;
 	}
 
 	public String getDefaultLabel() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentProperties.java
@@ -49,6 +49,17 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 	private String endpoint;
 
 	/**
+	 * The flag indicating enabled support of the labels. Defaults to false for backward
+	 * compatibility.
+	 */
+	private boolean labelEnabled;
+
+	/**
+	 * The default label to be suffixed (if defined) to the secret names.
+	 */
+	private String defaultLabel;
+
+	/**
 	 * The order of the environment repository.
 	 */
 	private int order = Ordered.LOWEST_PRECEDENCE;
@@ -89,6 +100,22 @@ public class AwsSecretsManagerEnvironmentProperties implements EnvironmentReposi
 
 	public void setEndpoint(String endpoint) {
 		this.endpoint = endpoint;
+	}
+
+	public boolean isLabelEnabled() {
+		return labelEnabled;
+	}
+
+	public void setLabelEnabled(boolean labelEnabled) {
+		this.labelEnabled = labelEnabled;
+	}
+
+	public String getDefaultLabel() {
+		return defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
 	}
 
 	public int getOrder() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -55,18 +55,12 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 
 	private final AwsSecretsManagerEnvironmentProperties environmentProperties = new AwsSecretsManagerEnvironmentProperties();
 
-	{
-		// to show that labels have no impact in label-disabled environment
-		environmentProperties.setDefaultLabel("master");
-	}
-
 	private final AwsSecretsManagerEnvironmentRepository repository = new AwsSecretsManagerEnvironmentRepository(
 			awsSmClientMock, configServerProperties, environmentProperties);
 
 	private final AwsSecretsManagerEnvironmentProperties labeledEnvironmentProperties = new AwsSecretsManagerEnvironmentProperties();
 
 	{
-		labeledEnvironmentProperties.setLabelEnabled(true);
 		labeledEnvironmentProperties.setDefaultLabel("master");
 	}
 
@@ -691,11 +685,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -717,11 +711,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -743,11 +737,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -769,15 +763,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -800,11 +794,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -825,11 +819,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -850,11 +844,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -875,15 +869,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -906,11 +900,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -931,11 +925,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -956,11 +950,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -981,15 +975,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1012,17 +1006,17 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1044,17 +1038,17 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1076,17 +1070,17 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1108,10 +1102,10 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1132,14 +1126,14 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1160,24 +1154,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1199,17 +1193,17 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
@@ -1231,31 +1225,31 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
 
-		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/master/";
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
 		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
-		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/master/";
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
 		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
 				getApplicationEastProperties());
 
@@ -1278,24 +1272,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
 
-		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/master/";
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
 		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationProperties());
 
-		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/master/";
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
 		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
 				getApplicationEastProperties());
 
@@ -1663,11 +1657,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultProfile = configServerProperties.getDefaultProfile();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1689,11 +1683,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultApplication = configServerProperties.getDefaultApplicationName();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1715,11 +1709,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 		String label = "release";
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1741,15 +1735,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultApplication = configServerProperties.getDefaultApplicationName();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1772,11 +1766,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultProfile = configServerProperties.getDefaultProfile();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1797,11 +1791,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1822,11 +1816,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1847,15 +1841,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1878,11 +1872,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultProfile = configServerProperties.getDefaultProfile();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1903,11 +1897,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1928,11 +1922,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1953,15 +1947,15 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -1984,18 +1978,18 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String defaultProfile = configServerProperties.getDefaultProfile();
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
 				getFooDefaultReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2017,18 +2011,18 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
 				getFooDefaultReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2050,18 +2044,18 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
 				getFooDefaultReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2083,10 +2077,10 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2107,14 +2101,14 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2135,25 +2129,25 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
 				getFooDefaultReleaseProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2175,17 +2169,17 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
@@ -2207,32 +2201,32 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
 
-		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/release/";
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
 		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastReleaseProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
 				getFooDefaultReleaseProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
 				getApplicationDefaultReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
-		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/release/";
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
 		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
 				getApplicationEastReleaseProperties());
 
@@ -2255,24 +2249,24 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 		String label = "release";
 		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
 
-		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/";
 		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
 
-		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/release/";
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/";
 		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastReleaseProperties());
 
-		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		String fooPropertiesName = "aws:secrets:/secret/foo/";
 		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
 
-		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
 				getApplicationProdReleaseProperties());
 
-		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
 				getApplicationReleaseProperties());
 
-		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/release/";
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/";
 		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
 				getApplicationEastReleaseProperties());
 
@@ -2357,13 +2351,16 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 	}
 
 	private void setupAwsSmClientMocks(Environment environment) {
+		String label = environment.getLabel() != null ? environment.getLabel()
+				: environmentProperties.getDefaultLabel();
 		for (PropertySource ps : environment.getPropertySources()) {
 			String path = StringUtils.delete(ps.getName(), environmentProperties.getOrigin());
-			GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
+			GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).versionStage(label).build();
 
 			String secrets = getSecrets(ps);
 			GetSecretValueResponse response = GetSecretValueResponse.builder().secretString(secrets).build();
 
+			System.out.println("MOCK for " + request);
 			when(awsSmClientMock.getSecretValue(eq(request))).thenReturn(response);
 		}
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -55,8 +55,23 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 
 	private final AwsSecretsManagerEnvironmentProperties environmentProperties = new AwsSecretsManagerEnvironmentProperties();
 
+	{
+		// to show that labels have no impact in label-disabled environment
+		environmentProperties.setDefaultLabel("master");
+	}
+
 	private final AwsSecretsManagerEnvironmentRepository repository = new AwsSecretsManagerEnvironmentRepository(
 			awsSmClientMock, configServerProperties, environmentProperties);
+
+	private final AwsSecretsManagerEnvironmentProperties labeledEnvironmentProperties = new AwsSecretsManagerEnvironmentProperties();
+
+	{
+		labeledEnvironmentProperties.setLabelEnabled(true);
+		labeledEnvironmentProperties.setDefaultLabel("master");
+	}
+
+	private final AwsSecretsManagerEnvironmentRepository labeledRepository = new AwsSecretsManagerEnvironmentRepository(
+			awsSmClientMock, configServerProperties, labeledEnvironmentProperties);
 
 	private final ObjectMapper objectMapper = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
 
@@ -668,6 +683,1611 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void testFindOneWithNullApplicationAndNullProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = null;
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNonExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndDefaultProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = configServerProperties.getDefaultProfile();
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = "prod";
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, defaultLabel, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNullProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndDefaultProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNonExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNullProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndDefaultProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNonExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNullProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = null;
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndDefaultProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileForFooAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNoDefaultProfilesAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(
+				Arrays.asList(fooProdProperties, applicationProdProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/master/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/master/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName, getFooDefaultProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/master/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/master/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
+				getApplicationEastProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
+				applicationEastProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNoDefaultsAndNullLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String defaultLabel = labeledEnvironmentProperties.getDefaultLabel();
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/master/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdProperties());
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/master/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/master/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/master/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/master/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationProperties());
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/master/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
+				getApplicationEastProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
+				applicationEastProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, defaultLabel);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNullProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = null;
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNonExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndDefaultProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = configServerProperties.getDefaultProfile();
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = "prod";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNullProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = null;
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndDefaultProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNonExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = "prod";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNullProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = null;
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndDefaultProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = configServerProperties.getDefaultProfile();
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNonExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = "prod";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNullProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = null;
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndDefaultProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = configServerProperties.getDefaultProfile();
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileForFooAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNoDefaultProfilesAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNoDefaultsAndNonExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String label = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNullProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = null;
+		String label = "release";
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndNonExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = "release";
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndDefaultProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = configServerProperties.getDefaultProfile();
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+		String label = "release";
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNullApplicationAndExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = null;
+		String profile = "prod";
+		String label = "release";
+		String defaultApplication = configServerProperties.getDefaultApplicationName();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(defaultApplication, profiles, label, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNullProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = null;
+		String label = "release";
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndDefaultProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = configServerProperties.getDefaultProfile();
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndNonExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithDefaultApplicationAndExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = configServerProperties.getDefaultApplicationName();
+		String profile = "prod";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNullProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = null;
+		String label = "release";
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndDefaultProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = configServerProperties.getDefaultProfile();
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndNonExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithNonExistingApplicationAndExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = randomAlphabetic(RandomUtils.nextInt(3, 25));
+		String profile = "prod";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv
+				.addAll(Arrays.asList(applicationProdProperties, applicationDefaultProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNullProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = null;
+		String label = "release";
+		String defaultProfile = configServerProperties.getDefaultProfile();
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(defaultProfile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				getFooDefaultReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndDefaultProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = configServerProperties.getDefaultProfile();
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				getFooDefaultReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				getFooDefaultReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndNonExistingProfileAndNoDefaultProfileForFooAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = randomAlphabetic(RandomUtils.nextInt(2, 25));
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				getFooDefaultReleaseProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndExistingProfileAndNoDefaultProfilesAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(
+				Arrays.asList(fooProdProperties, applicationProdProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/release/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastReleaseProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/release/";
+		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
+				getFooDefaultReleaseProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/release/";
+		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
+				getApplicationDefaultReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/release/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
+				getApplicationEastReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
+				applicationEastProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
+				applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndMultipleExistingProfileAndNoDefaultsAndExistingLabelWhenDefaultLabelIsSet() {
+		String application = "foo";
+		String profile = "prod,east";
+		String label = "release";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProdPropertiesName = "aws:secrets:/secret/foo-prod/release/";
+		PropertySource fooProdProperties = new PropertySource(fooProdPropertiesName, getFooProdReleaseProperties());
+
+		String fooEastPropertiesName = "aws:secrets:/secret/foo-east/release/";
+		PropertySource fooEastProperties = new PropertySource(fooEastPropertiesName, getFooEastReleaseProperties());
+
+		String fooPropertiesName = "aws:secrets:/secret/foo/release/";
+		PropertySource fooProperties = new PropertySource(fooPropertiesName, getFooReleaseProperties());
+
+		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/release/";
+		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
+				getApplicationProdReleaseProperties());
+
+		String applicationPropertiesName = "aws:secrets:/secret/application/release/";
+		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
+				getApplicationReleaseProperties());
+
+		String applicationEastPropertiesName = "aws:secrets:/secret/application-east/release/";
+		PropertySource applicationEastProperties = new PropertySource(applicationEastPropertiesName,
+				getApplicationEastReleaseProperties());
+
+		Environment expectedEnv = new Environment(application, profiles, label, null, null);
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
+				applicationEastProperties, fooProperties, applicationProperties));
+
+		setupAwsSmClientMocks(expectedEnv);
+
+		Environment resultEnv = labeledRepository.findOne(application, profile, label);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expectedEnv);
+	}
+
+	@Test
 	public void testFindOneWithOverrides() {
 		String application = configServerProperties.getDefaultApplicationName();
 		String profile = configServerProperties.getDefaultProfile();
@@ -827,6 +2447,78 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 			{
 				put("s3.accessKey", "foo-east-s3");
 				put("s3.secretKey", "657f6ac5-2e1c-487d-9d61-1df109b29edf");
+			}
+		};
+	}
+
+	private static Map<String, String> getApplicationReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "application-shared-s3");
+				put("s3.secretKey", "f616d232-e777-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getApplicationDefaultReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "application-shared-default-s3");
+				put("s3.secretKey", "02db4214-e778-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getApplicationProdReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "application-shared-prod-s3");
+				put("s3.secretKey", "db0d3eae-e78b-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getApplicationEastReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "application-east-s3");
+				put("s3.secretKey", "e7e99834-e78b-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getFooReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "foo-s3");
+				put("s3.secretKey", "edec8728-e78b-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getFooDefaultReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "foo-default-s3");
+				put("s3.secretKey", "f3ebef4c-e78b-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getFooProdReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "foo-prod-s3");
+				put("s3.secretKey", "004ba75a-e78c-11ec-8fea-0242ac120002");
+			}
+		};
+	}
+
+	private static Map<String, String> getFooEastReleaseProperties() {
+		return new HashMap<String, String>() {
+			{
+				put("s3.accessKey", "foo-east-s3");
+				put("s3.secretKey", "044f287c-e78c-11ec-8fea-0242ac120002");
 			}
 		};
 	}


### PR DESCRIPTION
Implements versioning through labels in AWS SecretsManager backend.

To define a default label, set `spring.cloud.config.server.aws-secretsmanager.default-label`. By default it is the active version (`AWSCURRENT`) is going to be used.

E.g.:
```yaml
spring:
  profiles:
    active: aws-secretsmanager
  cloud:
    config:
      server:
        aws-secretsmanager:
          region: us-east-1
          default-label: 1.0.0
```

Note that labelled secrets should have staged labels set, for example:

```bash
$ aws secretsmanager create-secret \
      --name /secret/test/ \
      --secret-string '{"version":"1"}'
{
    "ARN": "arn:aws:secretsmanager:us-east-1:012345678990:secret:/secret/version/-a1b2c3",
    "Name": "/secret/version/",
    "VersionId": "cd291674-de2f-41de-8f3b-37dbf4880d69"
}

$ aws secretsmanager update-secret-version-stage \
      --secret-id /secret/test/ \
      --version-stage 1.0.0 \
      --move-to-version-id cd291674-de2f-41de-8f3b-37dbf4880d69

{
    "ARN": "arn:aws:secretsmanager:us-east-1:012345678990:secret:/secret/version/-a1b2c3",
    "Name": "/secret/version/",
}
```

When a request with `1.0.0` as a label comes, the secrets having staging label `1.0.0` will be picked up.

Relates to #2103.

