### PR TITLE
Replaces Jsch with Apache MINA in config-server

### DIFF
--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -15,7 +15,7 @@
 	<name>spring-cloud-config-dependencies</name>
 	<description>Spring Cloud Config Dependencies</description>
 	<properties>
-		<jgit.version>5.13.1.202206130422-r</jgit.version>
+		<jgit.version>6.2.0.202206071550-r</jgit.version>
 		<spring-vault.version>3.0.0-M1</spring-vault.version>
 		<spring-credhub.version>2.1.1.RELEASE</spring-credhub.version>
 	</properties>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/FileBasedSshTransportConfigCallback.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/FileBasedSshTransportConfigCallback.java
@@ -43,7 +43,8 @@ public class FileBasedSshTransportConfigCallback implements TransportConfigCallb
 	@Override
 	public void configure(Transport transport) {
 		if (transport instanceof SshTransport) {
-			((SshTransport) transport).setSshSessionFactory(new FileBasedSshSessionFactory(sshUriProperties));
+			((SshTransport) transport).setSshSessionFactory(new FileBasedSshSessionFactory(
+					new SshUriPropertyProcessor(this.sshUriProperties).getSshKeysByHostname()));
 		}
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
@@ -40,6 +40,7 @@ import org.eclipse.jgit.internal.transport.ssh.OpenSshConfigFile;
 import org.eclipse.jgit.internal.transport.sshd.OpenSshServerKeyDatabase;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.SshConfigStore;
+import org.eclipse.jgit.transport.SshConstants;
 import org.eclipse.jgit.transport.sshd.JGitKeyCache;
 import org.eclipse.jgit.transport.sshd.ProxyData;
 import org.eclipse.jgit.transport.sshd.ProxyDataFactory;
@@ -84,6 +85,18 @@ public class PropertyBasedSshSessionFactory extends SshdSessionFactory {
 			@Override
 			public HostConfig lookup(@NonNull String hostName, int port, String userName) {
 				OpenSshConfigFile.HostEntry hostEntry = new OpenSshConfigFile.HostEntry();
+
+				return updateIfNeeded(hostEntry, hostName);
+			}
+
+			@Override
+			public HostConfig lookupDefault(String hostName, int port, String userName) {
+				OpenSshConfigFile.HostEntry hostEntry = new OpenSshConfigFile.HostEntry();
+
+				hostEntry.setValue(SshConstants.HOST_NAME, hostName);
+				hostEntry.setValue(SshConstants.PORT,
+						Integer.toString(port > 0 ? port : SshConstants.SSH_DEFAULT_PORT));
+				hostEntry.setValue(SshConstants.USER, userName);
 
 				return updateIfNeeded(hostEntry, hostName);
 			}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
@@ -209,7 +209,7 @@ public class PropertyBasedSshSessionFactoryTest {
 	}
 
 	@Test
-	public void proxySettingsIsUsed() throws Exception {
+	public void proxySettingsIsUsed() {
 		JGitEnvironmentProperties sshProperties = new JGitEnvironmentProperties();
 		sshProperties.setUri("ssh://gitlab.example.local:3322/somerepo.git");
 		sshProperties.setPrivateKey(PRIVATE_KEY);
@@ -229,6 +229,17 @@ public class PropertyBasedSshSessionFactoryTest {
 		assertThat(new String(proxyData.getPassword())).isEqualTo("password");
 		assertThat(proxyData.getProxy().type().toString()).isEqualTo("HTTP");
 		assertThat(proxyData.getProxy().address().toString()).containsPattern("host\\.domain.*:8080");
+	}
+
+	@Test
+	public void defaultSshConfigIsSet() {
+		setupSessionFactory(new JGitEnvironmentProperties());
+
+		SshConfigStore.HostConfig sshConfig = getDefaultSshHostConfig("host.name", 123, "user.name");
+
+		assertThat(sshConfig.getValue("HostName")).isEqualTo("host.name");
+		assertThat(sshConfig.getValue("Port")).isEqualTo("123");
+		assertThat(sshConfig.getValue("User")).isEqualTo("user.name");
 	}
 
 	@Test
@@ -307,6 +318,11 @@ public class PropertyBasedSshSessionFactoryTest {
 	private SshConfigStore.HostConfig getSshHostConfig(String hostName) {
 		return factory.createSshConfigStore(new File("dummy"), new File("dummy"), "localUserName").lookup(hostName, 22,
 				"userName");
+	}
+
+	private SshConfigStore.HostConfig getDefaultSshHostConfig(String hostName, int port, String username) {
+		return factory.createSshConfigStore(new File("dummy"), new File("dummy"), "localUserName")
+				.lookupDefault(hostName, port, username);
 	}
 
 	private void setupSessionFactory(JGitEnvironmentProperties sshKey) {


### PR DESCRIPTION
-  Bumps jgit to 6.2.x
- FileBasedSshSessionFacotry sets the properties only for relevant host.
    In the existing `FileBasedSshSessionFactory` the `StrictHostKeyChecking` flag is decided based on top level 
   `strictHostKeyChecking` property under `git`.  This has changed in this pull-request  and the decision is made based on 
   `strictHostKeyChecking` for the specific hostname.  The main reason for this change was to make it behave like 
 `PropertyBasedSshSessionFactory`.  If this is not the desired behaviour, it can be reverted. 
