### PR TITLE
Ordering support for AWSParameterStore. Fixes gm-2117

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepository.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.config.server.environment.AwsParameterStoreEnvironmentProperties.DEFAULT_PATH_SEPARATOR;
@@ -41,7 +42,7 @@ import static org.springframework.cloud.config.server.environment.AwsParameterSt
 /**
  * @author Iulian Antohe
  */
-public class AwsParameterStoreEnvironmentRepository implements EnvironmentRepository {
+public class AwsParameterStoreEnvironmentRepository implements EnvironmentRepository, Ordered {
 
 	private final AWSSimpleSystemsManagement awsSsmClient;
 
@@ -49,12 +50,15 @@ public class AwsParameterStoreEnvironmentRepository implements EnvironmentReposi
 
 	private final AwsParameterStoreEnvironmentProperties environmentProperties;
 
+	private final int order;
+
 	public AwsParameterStoreEnvironmentRepository(AWSSimpleSystemsManagement awsSsmClient,
 			ConfigServerProperties configServerProperties,
 			AwsParameterStoreEnvironmentProperties environmentProperties) {
 		this.awsSsmClient = awsSsmClient;
 		this.configServerProperties = configServerProperties;
 		this.environmentProperties = environmentProperties;
+		this.order = environmentProperties.getOrder();
 	}
 
 	@Override
@@ -163,6 +167,11 @@ public class AwsParameterStoreEnvironmentRepository implements EnvironmentReposi
 
 			properties.put(name, parameter.getValue());
 		}
+	}
+
+	@Override
+	public int getOrder() {
+		return order;
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
@@ -799,6 +800,18 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 		String random = randomAlphabetic(RandomUtils.nextInt(3, 33));
 
 		return Base64.getEncoder().encodeToString(random.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void testOrderPopulation() {
+		int expectedOrder = Ordered.HIGHEST_PRECEDENCE;
+		AwsParameterStoreEnvironmentRepositoryFactory factory = new AwsParameterStoreEnvironmentRepositoryFactory(
+				new ConfigServerProperties());
+		AwsParameterStoreEnvironmentProperties properties = new AwsParameterStoreEnvironmentProperties();
+		properties.setOrder(expectedOrder);
+		AwsParameterStoreEnvironmentRepository repository = factory.build(properties);
+		int actualOrder = repository.getOrder();
+		assertThat(actualOrder).isEqualTo(expectedOrder);
 	}
 
 }


### PR DESCRIPTION
Currently when trying to configure multiple repositories in spring config server along with AWSParameterStore, the order specified for the AWSParameterStore is not followed.

https://github.com/spring-cloud/spring-cloud-config/issues/2117

Version : v3.1.3
Module : Spring-Cloud-Config-Server

applicationConfig:

```
spring:
  profiles:
    active:
    - awsparamstore
    - aws-secretsmanager
    - git
    name: app-config-server
  cloud:
    config:
      server:
        fail-on-composite-error: false
        aws-secretsmanager:
          prefix: /aws
          profile-separator: '-'
          order: 1
        awsparamstore:
          prefix: /aws
          profile-separator: '/'
          order: 2
        git:
          uri: https://github.com/Organization/{application}
          order: 3
```