### PR TITLE
Fix access to redirected git repositories

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
@@ -70,7 +70,13 @@ public class HttpClientConfigurableHttpConnectionFactory implements Configurable
 	@Override
 	public HttpConnection create(URL url, Proxy proxy) throws IOException {
 		HttpClientBuilder builder = lookupHttpClientBuilder(url);
-		return new HttpClientConnection(url.toString(), null, builder != null ? builder.build() : null);
+		if (builder != null) {
+			return new HttpClientConnection(url.toString(), null, builder.build());
+		}
+		else {
+			/* No matching builder found: let jGit handle the creation of the HttpClient */
+			return new HttpClientConnection(url.toString());
+		}
 	}
 
 	private void addHttpClient(JGitEnvironmentProperties properties) throws GeneralSecurityException {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactory.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.eclipse.jgit.transport.http.HttpConnection;
 import org.eclipse.jgit.transport.http.apache.HttpClientConnection;
 
@@ -70,7 +69,8 @@ public class HttpClientConfigurableHttpConnectionFactory implements Configurable
 
 	@Override
 	public HttpConnection create(URL url, Proxy proxy) throws IOException {
-		return new HttpClientConnection(url.toString(), null, lookupHttpClientBuilder(url).build());
+		HttpClientBuilder builder = lookupHttpClientBuilder(url);
+		return new HttpClientConnection(url.toString(), null, builder != null ? builder.build() : null);
 	}
 
 	private void addHttpClient(JGitEnvironmentProperties properties) throws GeneralSecurityException {
@@ -99,7 +99,7 @@ public class HttpClientConfigurableHttpConnectionFactory implements Configurable
 
 		if (builderMap.isEmpty()) {
 			this.log.warn(String.format("No custom http config found for URL: %s", url));
-			return HttpClients.custom();
+			return null;
 		}
 		if (builderMap.size() > 1) {
 			/*
@@ -118,7 +118,7 @@ public class HttpClientConfigurableHttpConnectionFactory implements Configurable
 					"More than one git repo URL template matched URL:"
 							+ " %s, proxy and skipSslValidation config won't be applied. Matched templates: %s",
 					url, builderMap.keySet().stream().collect(Collectors.joining(", "))));
-			return HttpClients.custom();
+			return null;
 		}
 		return new ArrayList<>(builderMap.values()).get(0);
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
@@ -64,7 +64,9 @@ public final class HttpClientSupport {
 			httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
 			httpClientBuilder.setDefaultCredentialsProvider(new SystemDefaultCredentialsProvider());
 		}
-
+		
+		/* According to https://git.eclipse.org/c/jgit/jgit.git/commit/?id=e17bfc96f293744cc5c0cef306e100f53d63bb3d
+		   jGit does its own redirect handling and disables HttpClient's redirect handing.  */
 		httpClientBuilder.disableRedirectHandling();
 
 		int timeout = environmentProperties.getTimeout() * 1000;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
@@ -64,7 +64,7 @@ public final class HttpClientSupport {
 			httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
 			httpClientBuilder.setDefaultCredentialsProvider(new SystemDefaultCredentialsProvider());
 		}
-		
+
 		/* According to https://git.eclipse.org/c/jgit/jgit.git/commit/?id=e17bfc96f293744cc5c0cef306e100f53d63bb3d
 		   jGit does its own redirect handling and disables HttpClient's redirect handing.  */
 		httpClientBuilder.disableRedirectHandling();

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/HttpClientSupport.java
@@ -65,6 +65,8 @@ public final class HttpClientSupport {
 			httpClientBuilder.setDefaultCredentialsProvider(new SystemDefaultCredentialsProvider());
 		}
 
+		httpClientBuilder.disableRedirectHandling();
+
 		int timeout = environmentProperties.getTimeout() * 1000;
 		return httpClientBuilder.setSSLContext(sslContextBuilder.build()).setDefaultRequestConfig(
 				RequestConfig.custom().setSocketTimeout(timeout).setConnectTimeout(timeout).build());

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpClientConfigurableHttpConnectionFactoryTest.java
@@ -198,10 +198,8 @@ public class HttpClientConfigurableHttpConnectionFactoryTest {
 		HttpConnection actualConnection = this.connectionFactory.create(
 				new URL(properties2.getUri().replace("{placeholder1}", "value1").replace("{placeholder2}", "value2")));
 
-		HttpClientBuilder expectedHttpClientBuilder = this.connectionFactory.httpClientBuildersByUri
-				.get(properties2.getUri());
-		HttpClientBuilder actualHttpClientBuilder = getActualHttpClientBuilder(actualConnection);
-		assertThat(actualHttpClientBuilder).isNotSameAs(expectedHttpClientBuilder);
+		HttpClient actualHttpClient = getActualHttpClient(actualConnection);
+		assertThat(actualHttpClient).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
spring-cloud-config-server configured to use a git repository throws `TransportException with error code 302 Found` when that repository gets redirected (e.g. moved to a diferent group/organization).

Fixes [issue 2123](https://github.com/spring-cloud/spring-cloud-config/issues/2123)

Version : v3.1.3
Module : Spring-Cloud-Config-Server
