### PR TITLE
Update EnvironmentController @GetMapping - Fixes gh-2130

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -103,13 +103,13 @@ public class EnvironmentController {
 		this.acceptEmpty = acceptEmpty;
 	}
 
-	@GetMapping(path = "/{name}/{profiles:(?!.*\\b\\.(?:ya?ml|properties|json)\\b).*}",
+	@GetMapping(path = "/{name}/{profiles:[^\\.]+}",
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public Environment defaultLabel(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, false);
 	}
 
-	@GetMapping(path = "/{name}/{profiles:(?!.*\\b\\.(?:ya?ml|properties|json)\\b).*}",
+	@GetMapping(path = "/{name}/{profiles:[^\\.]+}",
 			produces = EnvironmentMediaType.V2_JSON)
 	public Environment defaultLabelIncludeOrigin(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, true);


### PR DESCRIPTION
As described in #2130 , regex `.*[^-].*` still matches `"foo-db.properties"`. So we can use `[^-]+` or `[^\\.]+` to solve the problem.
According to #2083 , we should support dashes "-" in profile names. So we can use `[^\\.]+`.
Now I find that the regex has been changed to `(?!.*\\b\\.(?:ya?ml|properties|json)\\b).*`.
That's working, but maybe we should make it simpler and easier to understand.
So I suggest to use `[^\\.]+` to exclude profiles with file extensions.