### PR TITLE
Simplify regex in EnvironmentController

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -104,13 +104,13 @@ public class EnvironmentController {
 		this.acceptEmpty = acceptEmpty;
 	}
 
-	@GetMapping(path = "/{name}/{profiles:(?!.*\\b\\.(?:ya?ml|properties|json)\\b).*}",
+	@GetMapping(path = "/{name}/{profiles:[^\\.]*}",
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public Environment defaultLabel(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, false);
 	}
 
-	@GetMapping(path = "/{name}/{profiles:(?!.*\\b\\.(?:ya?ml|properties|json)\\b).*}",
+	@GetMapping(path = "/{name}/{profiles:[^\\.]*}",
 			produces = EnvironmentMediaType.V2_JSON)
 	public Environment defaultLabelIncludeOrigin(@PathVariable String name, @PathVariable String profiles) {
 		return getEnvironment(name, profiles, null, true);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -643,11 +643,11 @@ class EnvironmentControllerTests {
 
 		@Test
 		public void handleEnvironmentException() throws Exception {
-			when(EnvironmentControllerTests.this.repository.findOne(eq("exception"), eq("bad_syntax.ext"), any(),
+			when(EnvironmentControllerTests.this.repository.findOne(eq("exception"), eq("bad_syntax"), any(),
 					eq(false)))
 							.thenThrow(new FailedToConstructEnvironmentException("Cannot construct",
 									new RuntimeException("underlier")));
-			MvcResult result = this.mvc.perform(MockMvcRequestBuilders.get("/exception/bad_syntax.ext"))
+			MvcResult result = this.mvc.perform(MockMvcRequestBuilders.get("/exception/bad_syntax"))
 					.andExpect(MockMvcResultMatchers.status().is(500)).andReturn();
 			assertThat(result.getResponse().getErrorMessage()).isEqualTo("Cannot construct");
 		}


### PR DESCRIPTION
As described in #2130 , regex `.*[^-].*` still matches `"foo-db.properties"`. So we can use `[^-]*` or `[^\\.]*` to solve the problem.
According to #2083 , we should support dashes "-" in profile names. So we can use `[^\\.]*`.

I checked the history of this regex:
1. in spring-cloud-config-server:3.1.0 the regex is `.*[^-].*` but caused #2130
2. in spring-cloud-config-server:3.1.1 the regex is `[^-]+` but caused #2083
3. in spring-cloud-config-server:3.1.2 the regex is `(?!.*\\b(?:ya?ml|properties|json)\\b).*`. That's working, but maybe we should make it simpler and easier to understand.

So I suggest to use `[^\\.]*` to exclude profiles with file extensions.