### PR TITLE
Update PropertyPathEndpoint to ignore profiles - Fixes gh-2138

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
@@ -108,22 +108,16 @@ public class PropertyPathEndpoint implements ApplicationEventPublisherAware {
 			String stem = StringUtils.stripFilenameExtension(StringUtils.getFilename(StringUtils.cleanPath(path)));
 			// TODO: correlate with service registry
 			int index = stem.indexOf("-");
-			while (index >= 0) {
-				String name = stem.substring(0, index);
-				String profile = stem.substring(index + 1);
-				if ("application".equals(name)) {
-					services.add("*:" + profile);
-				}
-				else if (!name.startsWith("application")) {
-					services.add(name + ":" + profile);
-				}
-				index = stem.indexOf("-", index + 1);
-			}
 			String name = stem;
+			if (index > 0) {
+				name = stem.substring(0, index);
+			}
+			// foo.properties is targeted at the foo application,
+			// while application.properties is targeted at all applications
 			if ("application".equals(name)) {
 				services.add("*");
 			}
-			else if (!name.startsWith("application")) {
+			else {
 				services.add(name);
 			}
 		}

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
@@ -72,7 +72,7 @@ public class PropertyPathEndpointTests {
 	public void testNotifyAllWithProfile() {
 		assertThat(this.endpoint
 				.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "application-local.yml")).toString())
-						.isEqualTo("[*:local]");
+						.isEqualTo("[*]");
 	}
 
 	@Test
@@ -92,13 +92,13 @@ public class PropertyPathEndpointTests {
 	@Test
 	public void testNotifyOneWithProfile() {
 		assertThat(this.endpoint.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "foo-local.yml"))
-				.toString()).isEqualTo("[foo:local, foo-local]");
+				.toString()).isEqualTo("[foo]");
 	}
 
 	@Test
 	public void testNotifyMultiDash() {
 		assertThat(this.endpoint.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "foo-local-dev.yml"))
-				.toString()).isEqualTo("[foo:local-dev, foo-local:dev, foo-local-dev]");
+				.toString()).isEqualTo("[foo]");
 	}
 
 }


### PR DESCRIPTION
As described in #2138 , the Spring Cloud Bus addressing instances by service ID
https://docs.spring.io/spring-cloud-bus/docs/current/reference/html/#addressing-an-instance
> The default value of the ID is constructed in the form of `app:index:id`, where:
> `app` is the vcap.application.name, if it exists, or spring.application.name
> `index` is the vcap.application.instance_index, if it exists, spring.application.index, local.server.port, server.port, or 0 (in that order).
> `id` is the vcap.application.instance_id, if it exists, or a random value.

So the `destination` of `RefreshRemoteApplicationEvent` should be like `foo:8080` or `foo`. But the current `guessServiceName()` method generates the profile name into the `destination`, so when users edit the config file like `foo-dev.yml` to trigger the refresh, the destination would be `foo:dev`, that caused `foo` applications to be skipped by Spring Cloud Bus.