### PR TITLE
Fixes NPE in HttpProxyDataFactory when is called with unknown host.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
@@ -241,6 +241,10 @@ public class PropertyBasedSshSessionFactory extends SshdSessionFactory {
 		@Override
 		public ProxyData get(InetSocketAddress remoteAddress) {
 			JGitEnvironmentProperties sshProperties = sshKeysByHostname.get(remoteAddress.getHostName());
+			if (sshProperties == null) {
+				return null;
+			}
+
 			ProxyHostProperties proxyHostProperties = sshProperties.getProxy()
 					.get(ProxyHostProperties.ProxyForScheme.HTTP);
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
@@ -232,6 +232,21 @@ public class PropertyBasedSshSessionFactoryTest {
 	}
 
 	@Test
+	public void proxyFactoryHandlesUnknownHost() {
+		Map<ProxyHostProperties.ProxyForScheme, ProxyHostProperties> map = new HashMap<>();
+		map.put(ProxyHostProperties.ProxyForScheme.HTTP, new ProxyHostProperties());
+
+		JGitEnvironmentProperties sshProperties = new JGitEnvironmentProperties();
+		sshProperties.setUri("ssh://gitlab.example.local:3322/somerepo.git");
+		sshProperties.setProxy(map);
+		setupSessionFactory(sshProperties);
+
+		ProxyData proxyData = getSshProxyData("unknown.host");
+
+		assertThat(proxyData).isNull();
+	}
+
+	@Test
 	public void defaultSshConfigIsSet() {
 		setupSessionFactory(new JGitEnvironmentProperties());
 


### PR DESCRIPTION
`PropertyBasedSshSessionFactory.HttpProxyDataFactory` throws NPE if it's called with an unknown host. 

It should handle those kind of hosts gracefully. 