### PR TITLE
Fix tests fails on Windows caused by newline format

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerTests.java
@@ -293,7 +293,7 @@ public class ResourceControllerTests {
 	}
 
 	private String replaceNewLines(String text) {
-		return text.replace("\n", "").replace("\t", "");
+		return text.replace("\r", "").replace("\n", "").replace("\t", "");
 	}
 
 	@Test


### PR DESCRIPTION
The newline on Windows is `\r\n`, so just replace `\n` is not enough on Windows.
That causes `ResourceControllerTests` fails.