### PR TITLE
Sets default connection attempt to 1 in config-server

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
@@ -89,6 +89,7 @@ public class PropertyBasedSshSessionFactory extends SshdSessionFactory {
 				hostEntry.setValue(SshConstants.PORT,
 						Integer.toString(port > 0 ? port : SshConstants.SSH_DEFAULT_PORT));
 				hostEntry.setValue(SshConstants.USER, userName);
+				hostEntry.setValue(SshConstants.CONNECTION_ATTEMPTS, "1");
 
 				return updateIfNeeded(hostEntry, hostName);
 			}
@@ -231,9 +232,6 @@ public class PropertyBasedSshSessionFactory extends SshdSessionFactory {
 		@Override
 		public ProxyData get(InetSocketAddress remoteAddress) {
 			JGitEnvironmentProperties sshProperties = findEnvironmentProperties(sshKeysByHostname, remoteAddress);
-			if (sshProperties == null) {
-				return null;
-			}
 
 			ProxyHostProperties proxyHostProperties = sshProperties.getProxy()
 					.get(ProxyHostProperties.ProxyForScheme.HTTP);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
@@ -286,6 +286,7 @@ public class PropertyBasedSshSessionFactoryTest {
 		assertThat(sshConfig.getValue("HostName")).isEqualTo("gitlab.example.local");
 		assertThat(sshConfig.getValue("Port")).isEqualTo("123");
 		assertThat(sshConfig.getValue("User")).isEqualTo("user.name");
+		assertThat(sshConfig.getValue("ConnectionAttempts")).isEqualTo("1");
 	}
 
 	@Test


### PR DESCRIPTION
according to  the interface/contract definition `SshConfigStore.lookupDefault` should set the `ConnectionAttempts` to 1.