### PR TITLE
Support application name with dashes on RefreshRemoteApplicationEvent

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/PropertyPathEndpoint.java
@@ -107,18 +107,17 @@ public class PropertyPathEndpoint implements ApplicationEventPublisherAware {
 		if (path != null) {
 			String stem = StringUtils.stripFilenameExtension(StringUtils.getFilename(StringUtils.cleanPath(path)));
 			// TODO: correlate with service registry
-			int index = stem.indexOf("-");
-			String name = stem;
-			if (index > 0) {
-				name = stem.substring(0, index);
-			}
-			// foo.properties is targeted at the foo application,
-			// while application.properties is targeted at all applications
-			if ("application".equals(name)) {
-				services.add("*");
-			}
-			else {
-				services.add(name);
+			String name = stem + "-";
+			int index;
+			// support application name with dashes
+			while ((index = name.lastIndexOf("-")) >= 0) {
+				name = name.substring(0, index);
+				if ("application".equals(name)) {
+					services.add("*");
+				}
+				else {
+					services.add(name);
+				}
 			}
 		}
 		return services;

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
@@ -72,7 +72,7 @@ public class PropertyPathEndpointTests {
 	public void testNotifyAllWithProfile() {
 		assertThat(this.endpoint
 				.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "application-local.yml")).toString())
-						.isEqualTo("[*]");
+						.isEqualTo("[application-local, *]");
 	}
 
 	@Test
@@ -92,13 +92,13 @@ public class PropertyPathEndpointTests {
 	@Test
 	public void testNotifyOneWithProfile() {
 		assertThat(this.endpoint.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "foo-local.yml"))
-				.toString()).isEqualTo("[foo]");
+				.toString()).isEqualTo("[foo-local, foo]");
 	}
 
 	@Test
 	public void testNotifyMultiDash() {
 		assertThat(this.endpoint.notifyByPath(new HttpHeaders(), Collections.singletonMap("path", "foo-local-dev.yml"))
-				.toString()).isEqualTo("[foo]");
+				.toString()).isEqualTo("[foo-local-dev, foo-local, foo]");
 	}
 
 }


### PR DESCRIPTION
My former PR #2139 didn't support application name with dashes. So, when editing config file `foo-bar-dev.yml`, the application `foo-bar` will not be notified. This PR will fix this problem.