### PR TITLE
Make SQL Without Profile Adaptive

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JdbcEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JdbcEnvironmentProperties.java
@@ -43,8 +43,6 @@ public class JdbcEnvironmentProperties implements EnvironmentRepositoryPropertie
 	/** SQL used to query database for keys and values. */
 	private String sql = DEFAULT_SQL;
 
-	private boolean enableSqlWithoutProfile = false;
-
 	/** SQL used to query database for keys and values when profile is null. */
 	private String sqlWithoutProfile = DEFAULT_SQL_WITHOUT_PROFILE;
 
@@ -94,12 +92,9 @@ public class JdbcEnvironmentProperties implements EnvironmentRepositoryPropertie
 		this.failOnError = failOnError;
 	}
 
-	public boolean isEnableSqlWithoutProfile() {
-		return enableSqlWithoutProfile;
-	}
-
-	public void setEnableSqlWithoutProfile(boolean enableSqlWithoutProfile) {
-		this.enableSqlWithoutProfile = enableSqlWithoutProfile;
+	public boolean isConfigIncomplete() {
+		// sql and sqlWithoutProfile should be customized at the same time
+		return !this.sql.equals(DEFAULT_SQL) && this.sqlWithoutProfile.equals(DEFAULT_SQL_WITHOUT_PROFILE);
 	}
 
 }

--- a/spring-cloud-config-server/src/test/resources/data-jdbc.sql
+++ b/spring-cloud-config-server/src/test/resources/data-jdbc.sql
@@ -6,6 +6,8 @@ INSERT into PROPERTIES(APPLICATION, PROFILE, LABEL, "KEY", "VALUE") values ('app
 INSERT into PROPERTIES(APPLICATION, PROFILE, LABEL, "KEY", "VALUE") values ('application', null, 'master', 'a.b.c', 'application-null');
 
 INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('foo', 'bar', 'master', 'a.b.c', 'foo-bar');
+INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('foo', 'default', 'master', 'a.b.c', 'foo-default');
 INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('foo', null, 'master', 'a.b.c', 'foo-null');
 INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('application', 'bar', 'master', 'a.b.c', 'application-bar');
+INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('application', 'default', 'master', 'a.b.c', 'application-default');
 INSERT into MY_PROPERTIES(APPLICATION, PROFILE, LABEL, MY_KEY, MY_VALUE) values ('application', null, 'master', 'a.b.c', 'application-null');


### PR DESCRIPTION
The new SQL Without Profile feature breaks existing projects like #2185. Here provides another solution that don't need to introduce a new flag. If users changed both `sql` and `sqlWithoutProfile` property or leave them both unchanged, then the new feature will be enabled. Otherwise, the config will be considered as incomplete and fallback to previous behavior. This will keep it compatible with previous projects.