### PR TITLE
Support for ssh key with passphrase using Apache MINA

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PassphraseCredentialsProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PassphraseCredentialsProvider.java
@@ -31,9 +31,9 @@ public class PassphraseCredentialsProvider extends CredentialsProvider {
 	/**
 	 * Prompt to skip iteration for.
 	 */
-	public static final String PROMPT = "Passphrase for";
+	public static final String PROMPT = "Passphrase";
 
-	private final String passphrase;
+	private final char[] passphrase;
 
 	/**
 	 * Initialize the provider with a the ssh passphrase.
@@ -41,7 +41,7 @@ public class PassphraseCredentialsProvider extends CredentialsProvider {
 	 */
 	public PassphraseCredentialsProvider(String passphrase) {
 		super();
-		this.passphrase = passphrase;
+		this.passphrase = passphrase.toCharArray();
 	}
 
 	/**
@@ -58,12 +58,13 @@ public class PassphraseCredentialsProvider extends CredentialsProvider {
 	@Override
 	public boolean supports(CredentialItem... items) {
 		for (final CredentialItem item : items) {
-			if (item instanceof CredentialItem.StringType && item.getPromptText().startsWith(PROMPT)) {
+			if (item instanceof CredentialItem.InformationalMessage) {
 				continue;
 			}
-			else {
-				return false;
+			if (item instanceof CredentialItem.Password && item.getPromptText().equals(PROMPT)) {
+				continue;
 			}
+			return false;
 		}
 		return true;
 	}
@@ -80,8 +81,11 @@ public class PassphraseCredentialsProvider extends CredentialsProvider {
 	@Override
 	public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
 		for (final CredentialItem item : items) {
-			if (item instanceof CredentialItem.StringType && item.getPromptText().startsWith(PROMPT)) {
-				((CredentialItem.StringType) item).setValue(this.passphrase);
+			if (item instanceof CredentialItem.InformationalMessage) {
+				continue;
+			}
+			if (item instanceof CredentialItem.Password && item.getPromptText().equals(PROMPT)) {
+				((CredentialItem.Password) item).setValue(this.passphrase);
 				continue;
 			}
 			throw new UnsupportedCredentialItem(uri, item.getClass().getName() + ":" + item.getPromptText());

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -916,12 +916,11 @@ public class JGitEnvironmentRepositoryTests {
 		CredentialsProvider provider = mockCloneCommand.getCredentialsProvider();
 		assertThat(provider.isInteractive()).isFalse();
 
-		CredentialItem.StringType stringCredential = new CredentialItem.StringType(PassphraseCredentialsProvider.PROMPT,
-				true);
+		CredentialItem.Password credential = new CredentialItem.Password(PassphraseCredentialsProvider.PROMPT);
 
-		assertThat(provider.supports(stringCredential)).isTrue();
-		provider.get(new URIish(), stringCredential);
-		assertThat(passphrase).isEqualTo(stringCredential.getValue());
+		assertThat(provider.supports(credential)).isTrue();
+		provider.get(new URIish(), credential);
+		assertThat(passphrase.toCharArray()).isEqualTo(credential.getValue());
 	}
 
 	@Test
@@ -945,12 +944,13 @@ public class JGitEnvironmentRepositoryTests {
 		CredentialsProvider provider = mockCloneCommand.getCredentialsProvider();
 		assertThat(provider.isInteractive()).isFalse();
 
-		CredentialItem.StringType stringCredential = new CredentialItem.StringType(PassphraseCredentialsProvider.PROMPT,
-				true);
+		CredentialItem.InformationalMessage informational = new CredentialItem.InformationalMessage(
+				"Passphrase required for ssh key");
+		CredentialItem.Password credential = new CredentialItem.Password(PassphraseCredentialsProvider.PROMPT);
 
-		assertThat(provider.supports(stringCredential)).isTrue();
-		provider.get(new URIish(), stringCredential);
-		assertThat(passphrase).isEqualTo(stringCredential.getValue());
+		assertThat(provider.supports(credential)).isTrue();
+		provider.get(new URIish(), informational, credential);
+		assertThat(passphrase.toCharArray()).isEqualTo(credential.getValue());
 
 	}
 


### PR DESCRIPTION
Fixes #2201

There are a couple issues with SSH keys using passphrases

* The `CredentialItem` type is now `Password` and not `StringType`
* The JSCH library would only here have 1 `CredentialItem`.  With Apache MINA there are now two, and the old code would throw an exception (for some reason) if the first one didn't match the type.  We now need to look through all of them to find the password prompt so I removed the code that would throw an exception.
* The prompt text is now different

@kvmw would appreciate it if you could also take a look at this