### PR TITLE
Remove withReuse(true) in AwsS3IntegrationTests

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AwsS3IntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AwsS3IntegrationTests.java
@@ -54,8 +54,7 @@ public class AwsS3IntegrationTests {
 
 	@Container
 	static LocalStackContainer localstack = new LocalStackContainer(
-			DockerImageName.parse("localstack/localstack:1.3.1")).withServices(LocalStackContainer.Service.S3)
-					.withReuse(true);
+			DockerImageName.parse("localstack/localstack:1.3.1")).withServices(LocalStackContainer.Service.S3);
 
 	@BeforeAll
 	public static void startConfigServer() throws IOException, InterruptedException, JSONException {


### PR DESCRIPTION
Reusable containers is an experimental feature which needs additional
configuration in order to enable it. This is used in test and it
is not inteded to keep the container running.

See more https://www.testcontainers.org/features/reuse/
