### PR TITLE
fixed compare() GoogleSecretComparatorByVersion by making it to Integer based comparator  #2229

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/secretmanager/GoogleSecretComparatorByVersion.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/secretmanager/GoogleSecretComparatorByVersion.java
@@ -30,7 +30,11 @@ public class GoogleSecretComparatorByVersion implements Comparator<SecretVersion
 		if (leftVersion == null) {
 			return -1;
 		}
-		return leftVersion.getName().compareTo(rightVersion.getName());
+		String leftVersionName = leftVersion.getName();
+		String rightVersionName = rightVersion.getName();
+		Integer leftVersionNumber = Integer.valueOf(leftVersionName.substring(leftVersionName.lastIndexOf("/") + 1));
+		Integer rightVersionNumber = Integer.valueOf(rightVersionName.substring(rightVersionName.lastIndexOf("/") + 1));
+		return leftVersionNumber.compareTo(rightVersionNumber);
 	}
 
 }


### PR DESCRIPTION
Issue number #2206. 

Problem statement:

> In our setup, we have multiple secret versions enabled in GCP. Hence a "list secret versions" returns multiple versions with different version IDs. The greatest version ID is considered the latest.

Reason:
> GoogleSecretComparatorByVersion.class, the comparator does a String lexical comparison. So a secret version id 9 takes priority over greater version id (e.g. 11, 30, ...) and this results in the spring config server returning version id 9 always as the latest

Fix:
> Now the version viz. 1,2,3,... are first **extracted**, 
**parsed** into Integers, 
and lastly **compared** with an Integer comparator which gives the correct order for versions.