### PR TITLE
fix: transmit data from spring cloud config server controller to getEncryptor

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -103,12 +103,12 @@ public class EncryptionController {
 	@PostMapping("/encrypt/{name}/{profiles}")
 	public String encrypt(@PathVariable String name, @PathVariable String profiles, @RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
-		TextEncryptor encryptor = getEncryptor(name, profiles, "");
-		validateEncryptionWeakness(encryptor);
 		String input = stripFormData(data, type, false);
+		TextEncryptor encryptor = getEncryptor(name, profiles, input);
+		validateEncryptionWeakness(encryptor);
 		Map<String, String> keys = helper.getEncryptorKeys(name, profiles, input);
 		String textToEncrypt = helper.stripPrefix(input);
-		String encrypted = helper.addPrefix(keys, encryptorLocator.locate(keys).encrypt(textToEncrypt));
+		String encrypted = helper.addPrefix(keys, encryptor.encrypt(textToEncrypt));
 		if (logger.isInfoEnabled()) {
 			logger.info("Encrypted data");
 		}
@@ -123,11 +123,10 @@ public class EncryptionController {
 	@PostMapping("/decrypt/{name}/{profiles}")
 	public String decrypt(@PathVariable String name, @PathVariable String profiles, @RequestBody String data,
 			@RequestHeader("Content-Type") MediaType type) {
-		TextEncryptor encryptor = getEncryptor(name, profiles, "");
-		checkDecryptionPossible(encryptor);
-		validateEncryptionWeakness(encryptor);
 		try {
-			encryptor = getEncryptor(name, profiles, data);
+			TextEncryptor encryptor = getEncryptor(name, profiles, data);
+			checkDecryptionPossible(encryptor);
+			validateEncryptionWeakness(encryptor);
 			String input = stripFormData(helper.stripPrefix(data), type, true);
 			String decrypted = encryptor.decrypt(input);
 			if (logger.isInfoEnabled()) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
@@ -145,12 +145,14 @@ public class EncryptionControllerTests {
 
 			@Override
 			public TextEncryptor locate(Map<String, String> keys) {
+				assertThat(keys.containsKey("key")).as("Missing encryptor key").isTrue();
+				assertThat(keys.get("key")).as("Bad encryptor key value").isEqualTo("value");
 				return this.encryptor;
 			}
 		};
 		this.controller = new EncryptionController(locator);
 		// Add space to input
-		String cipher = this.controller.encrypt("app", "default", "foo bar", MediaType.TEXT_PLAIN);
+		String cipher = this.controller.encrypt("app", "default", "{key:value}foo bar", MediaType.TEXT_PLAIN);
 		assertThat(cipher.contains("{name:app}")).as("Wrong cipher: " + cipher).isFalse();
 		String decrypt = this.controller.decrypt("app", "default", cipher, MediaType.TEXT_PLAIN);
 		assertThat(decrypt).as("Wrong decrypted plaintext: " + decrypt).isEqualTo("foo bar");


### PR DESCRIPTION
attention point to methods

https://github.com/spring-cloud/spring-cloud-config/blob/main/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java#L93

https://github.com/spring-cloud/spring-cloud-config/blob/main/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java#L84

which always have same bug but could not be properly fixed due to missing data in Get request

Fixes gh-2252