### PR TITLE
Implement a better equals and hashcode method ConfigServerConfigDataResource

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -49,11 +49,16 @@ public class ConfigClientProperties {
 	public static final String PREFIX = "spring.cloud.config";
 
 	/**
+	 * Default application name.
+	 */
+	public static final String DEFAULT_APPLICATION = "application";
+
+	/**
 	 * Placeholder string that allows ${spring.cloud.config.name} to override
 	 * ${spring.application.name:application}.
 	 */
 	public static final String NAME_PLACEHOLDER = "${" + ConfigClientProperties.PREFIX
-			+ ".name:${spring.application.name:application}}";
+			+ ".name:${spring.application.name:" + DEFAULT_APPLICATION + "}}";
 
 	/**
 	 * Name of config discovery enabled property.
@@ -94,12 +99,12 @@ public class ConfigClientProperties {
 	/**
 	 * Name of application used to fetch remote properties.
 	 */
-	@Value("${spring.application.name:application}")
+	@Value("${spring.application.name:" + DEFAULT_APPLICATION + "}")
 	private String name;
 
 	/**
 	 * The label name to use to pull remote configuration properties. The default is set
-	 * on the server (generally "master" for a git based server).
+	 * on the server (generally "main" for a git based server).
 	 */
 	private String label;
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientConfigDataLoaderTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientConfigDataLoaderTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
  * spring.application.name will be set.
  *
  * At this point Boot has collected all active profiles so it will load all
- * spring.config.import statements again with active profiles. The subsequent 2 calls then
+ * spring.config.import statements again with active profiles. The subsequent call then
  * will not have spring.application.name set in the context so the config server config
  * data loader will make a request to the config server with the correct application name.
  *
@@ -73,7 +73,7 @@ public class ConfigClientConfigDataLoaderTest {
 		verify(rest).exchange(eq("http://localhost:8888/{name}/{profile}"), eq(HttpMethod.GET),
 				ArgumentMatchers.any(HttpEntity.class), eq(Environment.class), eq("application"),
 				ArgumentMatchers.<String>any());
-		verify(rest, times(2)).exchange(eq("http://localhost:8888/{name}/{profile}"), eq(HttpMethod.GET),
+		verify(rest, times(1)).exchange(eq("http://localhost:8888/{name}/{profile}"), eq(HttpMethod.GET),
 				ArgumentMatchers.any(HttpEntity.class), eq(Environment.class), eq("foo"),
 				ArgumentMatchers.<String>any());
 	}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataResourceTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataResourceTests.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.config.Profiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Ryan Baxter
+ */
+class ConfigServerConfigDataResourceTests {
+
+	@Test
+	void testEquals() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsDifferentSchemes() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "https://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsDifferentHosts() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://remotehost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsDifferentPorts() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsOptionalFalse() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, false,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, false,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsSamePath() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888/p1" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888/p1" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsDifferentPath() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888/p1" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888/p2" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testMultipleUrisDifferentOrder() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888", "http://localhost:9999", "http://localhost:7777" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:7777", "http://localhost:8888", "http://localhost:9999" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testMultipleUrisDifferentOrderWithDifferentSchemes() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888", "http://localhost:9999", "http://localhost:7777" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties
+				.setUri(new String[] { "https://localhost:7777", "https://localhost:8888", "https://localhost:9999" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testMultipleUrisDifferentLengths() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888", "http://localhost:9999", "http://localhost:7777" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:7777", "http://localhost:8888", "http://localhost:9999",
+				"http://localhost:6666" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsOptionalFalseAndTrue() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true,
+				mock(Profiles.class));
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, false,
+				mock(Profiles.class));
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsNullProfilesAndDefaultProfile() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, null);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true,
+				mock(Profiles.class));
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsNullProfiles() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, null);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, null);
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsProfilesAndProperties() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r1Profiles = mock(Profiles.class);
+		when(r1Profiles.getAccepted()).thenReturn(Collections.singletonList("foo"));
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		r2Properties.setProfile("foo");
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, r1Profiles);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, null);
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsProfiles() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r1Profiles = mock(Profiles.class);
+		when(r1Profiles.getAccepted()).thenReturn(Collections.singletonList("foo"));
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r2Profiles = mock(Profiles.class);
+		when(r2Profiles.getAccepted()).thenReturn(Collections.singletonList("foo"));
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, r1Profiles);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, r2Profiles);
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsProfilesDifferent() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r1Profiles = mock(Profiles.class);
+		when(r1Profiles.getAccepted()).thenReturn(Arrays.asList("foo", "bar"));
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r2Profiles = mock(Profiles.class);
+		when(r2Profiles.getAccepted()).thenReturn(Collections.singletonList("foo"));
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, r1Profiles);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, r2Profiles);
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsProfilesDifferentOrder() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r1Profiles = mock(Profiles.class);
+		when(r1Profiles.getAccepted()).thenReturn(Arrays.asList("foo", "bar"));
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r2Profiles = mock(Profiles.class);
+		when(r2Profiles.getAccepted()).thenReturn(Arrays.asList("bar", "foo"));
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, r1Profiles);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, r2Profiles);
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsProfilesProperties() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		Profiles r1Profiles = mock(Profiles.class);
+		when(r1Profiles.getAccepted()).thenReturn(Arrays.asList("foo", "bar"));
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		r2Properties.setProfile("foo,bar");
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, r1Profiles);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, null);
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsLabels() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		r1Properties.setLabel("foo");
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		r2Properties.setLabel("foo");
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, null);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, null);
+		assertThat(r1).isEqualTo(r2);
+		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+	}
+
+	@Test
+	void testEqualsDifferentLabels() {
+		ConfigClientProperties r1Properties = new ConfigClientProperties();
+		r1Properties.setUri(new String[] { "http://localhost:8888" });
+		r1Properties.setLabel("foo");
+		ConfigClientProperties r2Properties = new ConfigClientProperties();
+		r2Properties.setUri(new String[] { "http://localhost:8888" });
+		ConfigServerConfigDataResource r1 = new ConfigServerConfigDataResource(r1Properties, true, null);
+		ConfigServerConfigDataResource r2 = new ConfigServerConfigDataResource(r2Properties, true, null);
+		assertThat(r1).isNotEqualTo(r2);
+		assertThat(r1.hashCode()).isNotEqualTo(r2.hashCode());
+	}
+
+}


### PR DESCRIPTION
Spring Boot keeps a list of ConfigDataResources and will call contains on the list to determine whether it should load the resource.  Our hashcode and equals methods were using variables in ConfigServerConfigDataResource which had no bearing on the configuration that would be loaded, so this change simplifies this to make sure two ConfigServerConnfigDataResources would be considered equal if they would end up making the same request to the config server for configuration.