### PR TITLE
Removes duplicate bean definition in ResourceControllerIntegrationTests

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/resource/ResourceControllerIntegrationTests.java
@@ -122,10 +122,10 @@ public class ResourceControllerIntegrationTests {
 	@Test
 	public void resourceHttpDoesNotExist() throws Exception {
 		when(this.resources.findOne("foo", "default", "master", "doesNotExist.txt"))
-			.thenThrow(new NoSuchResourceException("Does not exist"));
+				.thenThrow(new NoSuchResourceException("Does not exist"));
 
 		ResponseEntity<String> response = new TestRestTemplate()
-			.getForEntity("http://localhost:" + port + "/foo/default/master/doesNotExist.txt", String.class);
+				.getForEntity("http://localhost:" + port + "/foo/default/master/doesNotExist.txt", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 		verify(this.resources).findOne("foo", "default", "master", "doesNotExist.txt");
 	}
@@ -193,11 +193,6 @@ public class ResourceControllerIntegrationTests {
 		public ResourceRepository resourceRepository() {
 			ResourceRepository repository = Mockito.mock(ResourceRepository.class);
 			return repository;
-		}
-
-		@Bean
-		public ResourceControllerAdvice resourceControllerAdvice() {
-			return new ResourceControllerAdvice();
 		}
 
 		@Bean


### PR DESCRIPTION
This might have happened during merge. `ResourceControllerAdvice` bean was already defined in the same test class. 