### PR TITLE
Using consistent naming for profile in the sample

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -57,8 +57,8 @@ curl localhost:8888/foo/development
 curl localhost:8888/foo/development/master
 curl localhost:8888/foo/development,db/master
 curl localhost:8888/foo-development.yml
-curl localhost:8888/foo-db.properties
-curl localhost:8888/master/foo-db.properties
+curl localhost:8888/foo-development.properties
+curl localhost:8888/master/foo-development.properties
 ----
 
 where `application` is injected as the `spring.config.name` in the `SpringApplication` (what is normally `application` in a regular Spring Boot app), `profile` is an active profile (or comma-separated list of properties), and `label` is an optional git label (defaults to `master`.)


### PR DESCRIPTION
Using "development" just as in previous examples for profile value makes doc more consistent.