### PR TITLE
Adopt dedicated AssertJ assertions for more expressive test failure messages

### DIFF
--- a/spring-cloud-config-client-tls-tests/src/test/java/org/springframework/cloud/config/client/tls/ConfigClientTlsTests.java
+++ b/spring-cloud-config-client-tls-tests/src/test/java/org/springframework/cloud/config/client/tls/ConfigClientTlsTests.java
@@ -21,7 +21,6 @@ import java.io.File;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +31,7 @@ import org.springframework.cloud.config.client.ConfigClientRequestTemplateFactor
 import org.springframework.cloud.config.server.EnableConfigServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class ConfigClientTlsTests extends AbstractTlsSetup {
 
@@ -120,7 +120,7 @@ public class ConfigClientTlsTests extends AbstractTlsSetup {
 
 	@Test
 	public void wrongPasswordCauseFailure() {
-		Assertions.assertThrows(IllegalStateException.class, () -> {
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
 			TlsConfigClientRunner client = createConfigClient(false);
 			enableTlsClient(client);
 			client.setKeyStore(clientCert, WRONG_PASSWORD, WRONG_PASSWORD);
@@ -130,7 +130,7 @@ public class ConfigClientTlsTests extends AbstractTlsSetup {
 
 	@Test
 	public void nonExistKeyStoreCauseFailure() {
-		Assertions.assertThrows(IllegalStateException.class, () -> {
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
 			TlsConfigClientRunner client = createConfigClient(false);
 			enableTlsClient(client);
 			client.setKeyStore(new File("nonExistFile"));

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -402,7 +402,7 @@ public class ConfigServerConfigDataLoaderTests {
 		PropertySource p1 = new PropertySource("p1", new HashMap<>());
 		PropertySource p2 = new PropertySource("p2", new HashMap<>());
 		ConfigData configData = setupConfigServerConfigDataLoader(Arrays.asList(p1, p2), "application-slash", null);
-		assertThat(configData.getPropertySources().size()).isEqualTo(3);
+		assertThat(configData.getPropertySources()).hasSize(3);
 		assertThat(configData.getOptions(configData.getPropertySources().get(0))
 				.contains(ConfigData.Option.IGNORE_IMPORTS)).isTrue();
 		assertThat(configData.getOptions(configData.getPropertySources().get(1))
@@ -420,7 +420,7 @@ public class ConfigServerConfigDataLoaderTests {
 		PropertySource p1 = new PropertySource("p1", Collections.singletonMap("foo", "bar"));
 		PropertySource p2 = new PropertySource("p2", Collections.singletonMap("hello", "world"));
 		ConfigData configData = setupConfigServerConfigDataLoader(Arrays.asList(p1, p2), "application-slash", "dev");
-		assertThat(configData.getPropertySources().size()).isEqualTo(0);
+		assertThat(configData.getPropertySources()).isEmpty();
 
 	}
 
@@ -433,7 +433,7 @@ public class ConfigServerConfigDataLoaderTests {
 		PropertySource p2 = new PropertySource("p2-dev", Collections.singletonMap("hello", "world"));
 		List<PropertySource> propertySources = Arrays.asList(p1, p2);
 		ConfigData configData = setupConfigServerConfigDataLoader(propertySources, "application-slash", "dev");
-		assertThat(configData.getPropertySources().size()).isEqualTo(2);
+		assertThat(configData.getPropertySources()).hasSize(2);
 		assertThat(configData.getOptions(configData.getPropertySources().get(0))
 				.contains(ConfigData.Option.IGNORE_IMPORTS)).isTrue();
 		assertThat(configData.getOptions(configData.getPropertySources().get(1))
@@ -480,7 +480,7 @@ public class ConfigServerConfigDataLoaderTests {
 
 		ConfigData configData = setupConfigServerConfigDataLoader(Arrays.asList(p1, p2, p3, p4, p5, p6, p7, p8, p9),
 				"application-slash", "foo");
-		assertThat(configData.getPropertySources().size()).isEqualTo(7);
+		assertThat(configData.getPropertySources()).hasSize(7);
 
 	}
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerHealthIndicatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerHealthIndicatorTests.java
@@ -66,10 +66,10 @@ public class ConfigServerHealthIndicatorTests {
 		setupPropertySources();
 		Map<String, Object> details = this.indicator.getHealth(true).getDetails();
 		List<String> propertySources = (List) details.get("propertySources");
-		assertThat(propertySources.contains("bootstrapProperties-test")).isTrue();
-		assertThat(propertySources.contains("configserver:test")).isTrue();
-		assertThat(propertySources.contains("configClient")).isTrue();
-		assertThat(propertySources.size()).isEqualTo(3);
+		assertThat(propertySources).contains("bootstrapProperties-test");
+		assertThat(propertySources).contains("configserver:test");
+		assertThat(propertySources).contains("configClient");
+		assertThat(propertySources).hasSize(3);
 		assertThat(this.indicator.health().getStatus()).isEqualTo(Status.UP);
 	}
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocatorTests.java
@@ -386,7 +386,7 @@ public class ConfigServicePropertySourceLocatorTests {
 		while (iterator.hasNext()) {
 			GenericRequestHeaderInterceptor genericRequestHeaderInterceptor = (GenericRequestHeaderInterceptor) iterator
 					.next();
-			assertThat(genericRequestHeaderInterceptor.getHeaders().get(AUTHORIZATION)).isEqualTo(null);
+			assertThat(genericRequestHeaderInterceptor.getHeaders()).doesNotContainKeys(AUTHORIZATION);
 		}
 	}
 

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/EnvironmentMonitorAutoConfigurationTests.java
@@ -45,7 +45,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				ServerProperties.class, PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1").run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
 		assertThat(((Collection<?>) ReflectionTestUtils.getField(ReflectionTestUtils.getField(endpoint, "extractor"),
-				"extractors")).size()).isEqualTo(7);
+				"extractors"))).hasSize(7);
 		context.close();
 	}
 
@@ -57,7 +57,7 @@ public class EnvironmentMonitorAutoConfigurationTests {
 				PropertyPlaceholderAutoConfiguration.class).properties("server.port=-1").run();
 		PropertyPathEndpoint endpoint = context.getBean(PropertyPathEndpoint.class);
 		assertThat(((Collection<?>) ReflectionTestUtils.getField(ReflectionTestUtils.getField(endpoint, "extractor"),
-				"extractors")).size()).isEqualTo(8);
+				"extractors"))).hasSize(8);
 		context.close();
 	}
 

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/PropertyPathEndpointTests.java
@@ -51,7 +51,7 @@ public class PropertyPathEndpointTests {
 
 	@Test
 	public void testNotifyByForm() {
-		assertThat(this.endpoint.notifyByForm(new HttpHeaders(), new ArrayList<>()).size()).isEqualTo(0);
+		assertThat(this.endpoint.notifyByForm(new HttpHeaders(), new ArrayList<>())).isEmpty();
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AwsS3IntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/AwsS3IntegrationTests.java
@@ -128,7 +128,7 @@ public class AwsS3IntegrationTests {
 		RestTemplate rest = new RestTemplateBuilder().build();
 		String configServerUrl = "http://localhost:" + configServerPort;
 		Environment env = rest.getForObject(configServerUrl + "/data/dev", Environment.class);
-		assertThat(env.getPropertySources().size()).isEqualTo(3);
+		assertThat(env.getPropertySources()).hasSize(3);
 		assertThat(env.getPropertySources().get(0).getName()).isEqualTo("s3:data-dev");
 		assertThat(env.getPropertySources().get(1).getName()).isEqualTo("s3:data");
 		assertThat(env.getPropertySources().get(2).getName()).isEqualTo("s3:application");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CompositeIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CompositeIntegrationTests.java
@@ -74,7 +74,7 @@ public class CompositeIntegrationTests {
 			assertThat("overrides").isEqualTo(environment.getPropertySources().get(0).getName());
 			assertThat(environment.getPropertySources().get(1).getName().contains("config-repo")
 					&& !environment.getPropertySources().get(1).getName().contains("svn-config-repo")).isTrue();
-			assertThat(environment.getPropertySources().get(2).getName().contains("svn-config-repo")).isTrue();
+			assertThat(environment.getPropertySources().get(2).getName()).contains("svn-config-repo");
 			ConfigServerTestUtils.assertConfigEnabled(environment);
 		}
 
@@ -162,7 +162,7 @@ public class CompositeIntegrationTests {
 			assertThat("overrides").isEqualTo(environment.getPropertySources().get(0).getName());
 			assertThat(environment.getPropertySources().get(1).getName().contains("config-repo")
 					&& !environment.getPropertySources().get(1).getName().contains("svn-config-repo")).isTrue();
-			assertThat(environment.getPropertySources().get(2).getName().contains("svn-config-repo")).isTrue();
+			assertThat(environment.getPropertySources().get(2).getName()).contains("svn-config-repo");
 			ConfigServerTestUtils.assertConfigEnabled(environment);
 		}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientBackwardsCompatibilityIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientBackwardsCompatibilityIntegrationTests.java
@@ -99,7 +99,7 @@ public class ConfigClientBackwardsCompatibilityIntegrationTests {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private Object getPropertySourceValue(Map environment) {
 		assertThat(environment).isNotNull();
-		assertThat(environment.containsKey("propertySources")).isTrue();
+		assertThat(environment).containsKey("propertySources");
 		List propertySources = (List) environment.get("propertySources");
 		assertThat(propertySources).hasSizeGreaterThan(1);
 		Map source = (Map) propertySources.get(0);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOffIntegrationTests.java
@@ -71,7 +71,7 @@ public class ConfigClientOffIntegrationTests {
 	public void contextLoads() {
 		Environment environment = new TestRestTemplate()
 				.getForObject("http://localhost:" + this.port + "/foo/development/", Environment.class);
-		assertThat(environment.getPropertySources().isEmpty()).isTrue();
+		assertThat(environment.getPropertySources()).isEmpty();
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ConfigClientOnIntegrationTests.java
@@ -82,7 +82,7 @@ public class ConfigClientOnIntegrationTests {
 	public void contextLoads() {
 		Environment environment = new TestRestTemplate()
 				.getForObject("http://localhost:" + this.port + "/foo/development/", Environment.class);
-		assertThat(environment.getPropertySources().isEmpty()).isTrue();
+		assertThat(environment.getPropertySources()).isEmpty();
 	}
 
 	// FIXME: configdata config client on tests

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubCompositeConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubCompositeConfigServerIntegrationTests.java
@@ -44,7 +44,7 @@ public class CredhubCompositeConfigServerIntegrationTests extends CredhubIntegra
 		Environment environment = new TestRestTemplate()
 				.getForObject("http://localhost:" + this.port + "/myapp/master/default", Environment.class);
 
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myapp-master-default");
 		assertThat(environment.getPropertySources().get(0).getSource().toString()).isEqualTo("{key=value}");
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/CredhubConfigServerIntegrationTests.java
@@ -42,7 +42,7 @@ public class CredhubConfigServerIntegrationTests extends CredhubIntegrationTest 
 		Environment environment = new TestRestTemplate()
 				.getForObject("http://localhost:" + this.port + "/myapp/master/default", Environment.class);
 
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myapp-master-default");
 		assertThat(environment.getPropertySources().get(0).getSource().toString()).isEqualTo("{key=value}");
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/NativeConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/NativeConfigServerIntegrationTests.java
@@ -60,7 +60,7 @@ public class NativeConfigServerIntegrationTests {
 				"http://localhost:" + this.port + "/foo/development", HttpMethod.GET, getV2AcceptEntity(),
 				Environment.class);
 		Environment environment = response.getBody();
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("overrides");
 		ConfigServerTestUtils.assertConfigEnabled(environment);
 	}
@@ -71,8 +71,8 @@ public class NativeConfigServerIntegrationTests {
 				"http://localhost:" + this.port + "/configserver/default", HttpMethod.GET, getV2AcceptEntity(),
 				Environment.class);
 		Environment environment = response.getBody();
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).isNotEmpty();
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("overrides");
 		ConfigServerTestUtils.assertConfigEnabled(environment);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SubversionConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/SubversionConfigServerIntegrationTests.java
@@ -70,7 +70,7 @@ public class SubversionConfigServerIntegrationTests {
 				"http://localhost:" + this.port + "/foo/development", HttpMethod.GET, getV2AcceptEntity(),
 				Environment.class);
 		Environment environment = exchange.getBody();
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("overrides");
 		ConfigServerTestUtils.assertConfigEnabled(environment);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/VanillaConfigServerIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/VanillaConfigServerIntegrationTests.java
@@ -65,7 +65,7 @@ public class VanillaConfigServerIntegrationTests {
 				"http://localhost:" + this.port + "/foo/development", HttpMethod.GET, getV2AcceptEntity(),
 				Environment.class);
 		Environment environment = response.getBody();
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("overrides");
 		ConfigServerTestUtils.assertConfigEnabled(environment);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomCompositeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomCompositeEnvironmentRepositoryTests.java
@@ -77,7 +77,7 @@ public class CustomCompositeEnvironmentRepositoryTests {
 			List<PropertySource> propertySources = environment.getPropertySources();
 			assertThat(3).isEqualTo(propertySources.size());
 			assertThat("overrides").isEqualTo(propertySources.get(0).getName());
-			assertThat(propertySources.get(1).getName().contains("config-repo")).isTrue();
+			assertThat(propertySources.get(1).getName()).contains("config-repo");
 			assertThat("p").isEqualTo(propertySources.get(2).getName());
 		}
 
@@ -128,7 +128,7 @@ public class CustomCompositeEnvironmentRepositoryTests {
 			List<PropertySource> propertySources = environment.getPropertySources();
 			assertThat(3).isEqualTo(propertySources.size());
 			assertThat("overrides").isEqualTo(propertySources.get(0).getName());
-			assertThat(propertySources.get(1).getName().contains("config-repo")).isTrue();
+			assertThat(propertySources.get(1).getName()).contains("config-repo");
 			assertThat("p").isEqualTo(propertySources.get(2).getName());
 		}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/config/CustomEnvironmentRepositoryTests.java
@@ -52,7 +52,7 @@ public class CustomEnvironmentRepositoryTests {
 	public void contextLoads() {
 		Environment environment = new TestRestTemplate()
 				.getForObject("http://localhost:" + this.port + "/foo/development", Environment.class);
-		assertThat(environment.getPropertySources().isEmpty()).isFalse();
+		assertThat(environment.getPropertySources()).isNotEmpty();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EncryptionControllerTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.config.server.encryption;
 
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -28,6 +27,7 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.security.rsa.crypto.RsaSecretEncryptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -45,19 +45,19 @@ public class EncryptionControllerTests {
 
 	@Test
 	public void cannotDecryptWithoutKey() {
-		Assertions.assertThrows(EncryptionTooWeakException.class,
-				() -> this.controller.decrypt("foo", MediaType.TEXT_PLAIN));
+		assertThatExceptionOfType(EncryptionTooWeakException.class)
+				.isThrownBy(() -> this.controller.decrypt("foo", MediaType.TEXT_PLAIN));
 	}
 
 	@Test
 	public void cannotDecryptWithNoopEncryptor() {
-		Assertions.assertThrows(EncryptionTooWeakException.class,
-				() -> this.controller.decrypt("foo", MediaType.TEXT_PLAIN));
+		assertThatExceptionOfType(EncryptionTooWeakException.class)
+				.isThrownBy(() -> this.controller.decrypt("foo", MediaType.TEXT_PLAIN));
 	}
 
 	@Test
 	public void shouldThrowExceptionOnDecryptInvalidData() {
-		Assertions.assertThrows(InvalidCipherException.class, () -> {
+		assertThatExceptionOfType(InvalidCipherException.class).isThrownBy(() -> {
 			this.controller = new EncryptionController(new SingleTextEncryptorLocator(new RsaSecretEncryptor()));
 			this.controller.decrypt("foo", MediaType.TEXT_PLAIN);
 		});
@@ -65,7 +65,7 @@ public class EncryptionControllerTests {
 
 	@Test
 	public void shouldThrowExceptionOnDecryptWrongKey() {
-		Assertions.assertThrows(InvalidCipherException.class, () -> {
+		assertThatExceptionOfType(InvalidCipherException.class).isThrownBy(() -> {
 			RsaSecretEncryptor encryptor = new RsaSecretEncryptor();
 			this.controller = new EncryptionController(new SingleTextEncryptorLocator(new RsaSecretEncryptor()));
 			this.controller.decrypt(encryptor.encrypt("foo"), MediaType.TEXT_PLAIN);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelperTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/encryption/EnvironmentPrefixHelperTests.java
@@ -59,22 +59,22 @@ public class EnvironmentPrefixHelperTests {
 	@Test
 	public void testKeysDefaults() {
 		Map<String, String> keys = this.helper.getEncryptorKeys("foo", "bar", "spam");
-		assertThat(keys.get("name")).isEqualTo("foo");
-		assertThat(keys.get("profiles")).isEqualTo("bar");
+		assertThat(keys).containsEntry("name", "foo");
+		assertThat(keys).containsEntry("profiles", "bar");
 	}
 
 	@Test
 	public void testKeysWithPrefix() {
 		Map<String, String> keys = this.helper.getEncryptorKeys("foo", "bar", "{key:mykey}foo");
-		assertThat(keys.size()).isEqualTo(3);
-		assertThat(keys.get("key")).isEqualTo("mykey");
+		assertThat(keys).hasSize(3);
+		assertThat(keys).containsEntry("key", "mykey");
 	}
 
 	@Test
 	public void testKeysWithPrefixAndEscape() {
 		Map<String, String> keys = this.helper.getEncryptorKeys("foo", "bar", "{key:mykey}{plain}{foo:bar}foo");
-		assertThat(keys.size()).isEqualTo(3);
-		assertThat(keys.get("key")).isEqualTo("mykey");
+		assertThat(keys).hasSize(3);
+		assertThat(keys).containsEntry("key", "mykey");
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
@@ -126,7 +126,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	@Test
 	public void failToFindNonexistentObject() {
 		Environment env = envRepo.findOne("foo", "bar", null);
-		assertThat(env.getPropertySources().size()).isEqualTo(0);
+		assertThat(env.getPropertySources()).isEmpty();
 	}
 
 	@Test
@@ -313,7 +313,7 @@ public class AwsS3EnvironmentRepositoryTests {
 		assertThat(env.getProfiles()).isEqualTo(profiles);
 		assertThat(env.getLabel()).isEqualTo(label);
 		assertThat(env.getVersion()).isEqualTo(versionId);
-		assertThat(env.getPropertySources().size()).isEqualTo(propertySourceCount);
+		assertThat(env.getPropertySources()).hasSize(propertySourceCount);
 		for (PropertySource ps : env.getPropertySources()) {
 			assertThat(ps.getSource()).isEqualTo(expectedProperties);
 		}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CompositeEnvironmentRepositoryTests.java
@@ -82,7 +82,7 @@ public class CompositeEnvironmentRepositoryTests {
 				ObservationRegistry.NOOP, true);
 		Environment compositeEnv = compositeRepo.findOne("foo", "bar", "world", false);
 		List<PropertySource> propertySources = compositeEnv.getPropertySources();
-		assertThat(propertySources.size()).isEqualTo(5);
+		assertThat(propertySources).hasSize(5);
 		assertThat(propertySources.get(0).getName()).isEqualTo("p2");
 		assertThat(propertySources.get(1).getName()).isEqualTo("p3");
 		assertThat(propertySources.get(2).getName()).isEqualTo("p4");
@@ -173,7 +173,7 @@ public class CompositeEnvironmentRepositoryTests {
 				ObservationRegistry.NOOP, false);
 		Environment env = compositeRepo.findOne("app", "dev", "label", false);
 		List<PropertySource> propertySources = env.getPropertySources();
-		assertThat(propertySources.size()).isEqualTo(1);
+		assertThat(propertySources).hasSize(1);
 		assertThat(propertySources.get(0).getName()).isEqualTo("p1");
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -66,7 +66,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("production");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEmpty();
@@ -82,7 +82,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("default");
 		assertThat(environment.getLabel()).isEqualTo("master");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-default-master");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
@@ -98,7 +98,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("production");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
@@ -116,7 +116,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("production", "cloud");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
@@ -150,7 +150,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("production");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		HashMap<Object, Object> expectedValues = new HashMap<>();
@@ -170,7 +170,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("production");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
@@ -192,7 +192,7 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).contains("production");
 		assertThat(environment.getLabel()).isEqualTo("mylabel");
 
-		assertThat(environment.getPropertySources().size()).isEqualTo(4);
+		assertThat(environment.getPropertySources()).hasSize(4);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("credhub-my-application-production-mylabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleSecretManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleSecretManagerEnvironmentRepositoryTests.java
@@ -29,7 +29,6 @@ import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretPayload;
 import com.google.cloud.secretmanager.v1.SecretVersion;
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
@@ -43,6 +42,7 @@ import org.springframework.cloud.config.server.environment.secretmanager.HttpHea
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,7 +60,7 @@ public class GoogleSecretManagerEnvironmentRepositoryTests {
 
 	@Test
 	public void testGetUnsupportedStrategy() {
-		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			GoogleSecretManagerEnvironmentProperties properties = new GoogleSecretManagerEnvironmentProperties();
 			SecretManagerServiceClient mock = mock(SecretManagerServiceClient.class);
 			properties.setVersion(2);
@@ -83,7 +83,7 @@ public class GoogleSecretManagerEnvironmentRepositoryTests {
 		when(response.iterateAll()).thenReturn(secrets);
 		Mockito.doReturn(response).when(mock).listSecrets(any(ListSecretsRequest.class));
 		GoogleSecretManagerV1AccessStrategy strategy = new GoogleSecretManagerV1AccessStrategy(rest, provider, mock);
-		assertThat(strategy.getSecrets().size()).isEqualTo(1);
+		assertThat(strategy.getSecrets()).hasSize(1);
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProviderTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/HttpRequestConfigTokenProviderTests.java
@@ -17,13 +17,13 @@
 package org.springframework.cloud.config.server.environment;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +45,7 @@ public class HttpRequestConfigTokenProviderTests {
 
 	@Test
 	public void missingHttpRequest() {
-		Assertions.assertThrows(IllegalStateException.class, () -> {
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
 			when(httpRequestProvider.getIfAvailable()).thenReturn(null);
 			tokenProvider.getToken();
 		});
@@ -53,7 +53,7 @@ public class HttpRequestConfigTokenProviderTests {
 
 	@Test
 	public void missingTokenHeader() {
-		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			when(httpRequestProvider.getIfAvailable()).thenReturn(new MockHttpServletRequest());
 			tokenProvider.getToken();
 		});

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryConcurrencyTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryConcurrencyTests.java
@@ -116,7 +116,7 @@ public class JGitEnvironmentRepositoryConcurrencyTests {
 			future.get();
 		}
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getName()).isEqualTo("bar");
 		assertThat(environment.getProfiles()).isEqualTo(new String[] { "staging" });
 		assertThat(environment.getLabel()).isEqualTo("master");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryIntegrationTests.java
@@ -41,7 +41,6 @@ import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.util.FileUtils;
 import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -65,6 +64,7 @@ import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * @author Dave Syer
@@ -106,7 +106,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + uri).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getName()).isEqualTo("bar");
 		assertThat(environment.getProfiles()).isEqualTo(new String[] { "staging" });
 		assertThat(environment.getLabel()).isEqualTo("master");
@@ -114,7 +114,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void shouldFailIfNotTryingMaster() {
-		Assertions.assertThrows(NoSuchLabelException.class, () -> {
+		assertThatExceptionOfType(NoSuchLabelException.class).isThrownBy(() -> {
 			String uri = ConfigServerTestUtils.prepareLocalRepo();
 			this.context = new SpringApplicationBuilder(TestConfiguration.class).web(WebApplicationType.NONE)
 					.properties("spring.cloud.config.server.git.uri:" + uri,
@@ -220,7 +220,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 				.run("--spring.cloud.config.server.git.uri=" + uri, "--spring.cloud.config.server.git.searchPaths=sub");
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -232,7 +232,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 						"--spring.cloud.config.server.git.searchPaths={application}");
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("foo,bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(3);
+		assertThat(environment.getPropertySources()).hasSize(3);
 	}
 
 	@Test
@@ -243,7 +243,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 				.run("--spring.cloud.config.server.git.uri=" + uri, "--spring.cloud.config.server.git.searchPaths=**");
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("application", "test", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo("file:././target/repos/ordering-repo//project/sub/application-test.yml");
 		assertThat(environment.getPropertySources().get(1).getName())
@@ -259,7 +259,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 						"--spring.cloud.config.server.git.searchPaths={profile}");
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("staging", "foo,bar", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(3);
+		assertThat(environment.getPropertySources()).hasSize(3);
 	}
 
 	@Test
@@ -285,7 +285,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void invalidLabel() {
-		Assertions.assertThrows(NoSuchLabelException.class, () -> {
+		assertThatExceptionOfType(NoSuchLabelException.class).isThrownBy(() -> {
 			String uri = ConfigServerTestUtils.prepareLocalRepo();
 			this.context = new SpringApplicationBuilder(TestConfiguration.class).web(WebApplicationType.NONE)
 					.properties("spring.cloud.config.server.git.uri:" + uri).run();
@@ -303,7 +303,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 		EnvironmentRepository repository = this.context.getBean(JGitEnvironmentRepository.class);
 		assertThat(((JGitEnvironmentRepository) repository).isCloneOnStart()).isTrue();
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getName()).isEqualTo("bar");
 		assertThat(environment.getProfiles()).isEqualTo(new String[] { "staging" });
 		assertThat(environment.getLabel()).isEqualTo("master");
@@ -337,12 +337,12 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 						"--spring.cloud.config.server.git.cloneOnStart=true");
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
 	public void findOne_FindInvalidLabel_IllegalStateExceptionThrown() throws IOException {
-		Assertions.assertThrows(NoSuchLabelException.class, () -> {
+		assertThatExceptionOfType(NoSuchLabelException.class).isThrownBy(() -> {
 			String uri = ConfigServerTestUtils.prepareLocalRepo();
 			this.context = new SpringApplicationBuilder(TestConfiguration.class).web(WebApplicationType.NONE)
 					.properties("spring.cloud.config.server.git.uri:" + uri,
@@ -558,7 +558,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void testUnknownLabelWithRemote() throws Exception {
-		Assertions.assertThrows(NoSuchLabelException.class, () -> {
+		assertThatExceptionOfType(NoSuchLabelException.class).isThrownBy(() -> {
 			JGitConfigServerTestData testData = JGitConfigServerTestData
 					.prepareClonedGitRepository(TestConfiguration.class);
 			testData.getRepository().findOne("bar", "staging", "BADLabel");
@@ -621,7 +621,7 @@ public class JGitEnvironmentRepositoryIntegrationTests {
 
 	@Test
 	public void testShouldFailIfRemoteBranchWasDeleted() throws Exception {
-		Assertions.assertThrows(NoSuchLabelException.class, () -> {
+		assertThatExceptionOfType(NoSuchLabelException.class).isThrownBy(() -> {
 			JGitConfigServerTestData testData = JGitConfigServerTestData.prepareClonedGitRepository(
 					Collections.singleton("spring.cloud.config.server.git.deleteUntrackedBranches=true"),
 					TestConfiguration.class);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositorySslTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositorySslTests.java
@@ -27,7 +27,6 @@ import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.junit.http.SimpleHttpServer;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -41,6 +40,8 @@ import org.springframework.cloud.config.server.config.EnvironmentRepositoryConfi
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 // FIXME: 4.0.0 https://bugs.eclipse.org/bugs/show_bug.cgi?id=570447
 @Disabled("SimpleHttpServer does not use jakarta.servlet")
@@ -71,7 +72,7 @@ public class JGitEnvironmentRepositorySslTests {
 
 	@Test
 	public void selfSignedCertIsRejected() {
-		Assertions.assertThrows(CertificateException.class, () -> {
+		assertThatExceptionOfType(CertificateException.class).isThrownBy(() -> {
 			ConfigurableApplicationContext context = new SpringApplicationBuilder(TestConfiguration.class)
 					.properties(configServerProperties()).web(WebApplicationType.NONE).run();
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -131,7 +131,7 @@ public class JGitEnvironmentRepositoryTests {
 	@Test
 	public void vanilla() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -143,7 +143,7 @@ public class JGitEnvironmentRepositoryTests {
 		this.repository.setUri(uri);
 		this.repository.setSearchPaths(new String[] { "sub" });
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/sub/application.yml");
 		assertVersion(environment);
@@ -155,7 +155,7 @@ public class JGitEnvironmentRepositoryTests {
 		this.repository.setUri(uri);
 		this.repository.setSearchPaths(new String[] { "{application}" });
 		Environment environment = this.repository.findOne("sub", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/sub/application.yml");
 		assertVersion(environment);
@@ -174,7 +174,7 @@ public class JGitEnvironmentRepositoryTests {
 		this.repository.setUri(uri);
 		this.repository.setSearchPaths(new String[] { "sub*" });
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/sub/application.yml");
 		assertVersion(environment);
@@ -184,7 +184,7 @@ public class JGitEnvironmentRepositoryTests {
 	public void branch() {
 		this.repository.setBasedir(this.basedir);
 		Environment environment = this.repository.findOne("bar", "staging", "raw");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -194,7 +194,7 @@ public class JGitEnvironmentRepositoryTests {
 	public void tag() {
 		this.repository.setBasedir(this.basedir);
 		Environment environment = this.repository.findOne("bar", "staging", "foo");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -204,7 +204,7 @@ public class JGitEnvironmentRepositoryTests {
 	public void basedir() {
 		this.repository.setBasedir(this.basedir);
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -216,7 +216,7 @@ public class JGitEnvironmentRepositoryTests {
 		assertThat(new File(this.basedir, ".nothing").createNewFile()).isTrue();
 		this.repository.setBasedir(this.basedir);
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests.java
@@ -82,7 +82,7 @@ public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 	@Test
 	public void defaultRepo() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -100,7 +100,7 @@ public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 	@Test
 	public void mappingRepo() {
 		Environment environment = this.repository.findOne("test1-config-repo", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*").replace("{application}", "test1-config-repo") + "/application.yml");
 		assertVersion(environment);
@@ -109,7 +109,7 @@ public class MultipleJGitEnvironmentApplicationPlaceholderRepositoryTests {
 	@Test
 	public void otherMappingRepo() {
 		Environment environment = this.repository.findOne("test2-config-repo", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*").replace("{application}", "test2-config-repo") + "/application.properties");
 		assertVersion(environment);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentLabelPlaceholderRepositoryTests.java
@@ -58,7 +58,7 @@ public class MultipleJGitEnvironmentLabelPlaceholderRepositoryTests {
 	@Test
 	public void defaultRepo() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo(this.defaultUri + "application.yml");
 		assertVersion(environment);
 	}
@@ -74,7 +74,7 @@ public class MultipleJGitEnvironmentLabelPlaceholderRepositoryTests {
 	@Test
 	public void defaultLabelRepo() {
 		Environment environment = this.repository.findOne("bar", "staging", null);
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo(this.defaultUri + "application.yml");
 		assertVersion(environment);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentProfilePlaceholderRepositoryTests.java
@@ -86,7 +86,7 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 	@Test
 	public void defaultRepo() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -95,7 +95,7 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 	@Test
 	public void mappingRepo() {
 		Environment environment = this.repository.findOne("application", "test1-config-repo", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		String uri = getUri("*").replace("{profile}", "test1-config-repo");
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo(uri + "/application.yml");
 		assertVersion(environment);
@@ -105,7 +105,7 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 	@Test
 	public void otherMappingRepo() {
 		Environment environment = this.repository.findOne("application", "test2-config-repo", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*").replace("{profile}", "test2-config-repo") + "/application.properties");
 		assertVersion(environment);
@@ -133,7 +133,7 @@ public class MultipleJGitEnvironmentProfilePlaceholderRepositoryTests {
 	public void twoMappingRepos() {
 		Environment environment = this.repository.findOne("application",
 				"test1-config-repo,test2-config-repo,missing-config-repo", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*").replace("{profile}", "test2-config-repo") + "/application.properties");
 		assertVersion(environment);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryIntegrationTests.java
@@ -83,7 +83,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -114,7 +114,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(30)
 				.isEqualTo(((MultipleJGitEnvironmentRepository) repository).getRepos().get("test1").getRefreshRate());
 	}
@@ -131,7 +131,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "staging,cloud", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -163,9 +163,9 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "cloud,staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		environment = repository.findOne("test1-svc", "staging,cloud", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -179,7 +179,7 @@ public class MultipleJGitEnvironmentRepositoryIntegrationTests {
 				.properties("spring.cloud.config.server.git.uri:" + defaultRepoUri).properties(repoMapping).run();
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("test1-svc", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MultipleJGitEnvironmentRepositoryTests.java
@@ -91,7 +91,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	@Test
 	public void defaultRepo() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -103,7 +103,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 		repository.setBasedir(new File("target/testBase"));
 		JGitEnvironmentRepository newRepo = this.repository.getRepository(this.repository, "config-repo", "staging",
 				"master");
-		assertThat(newRepo.getBasedir().getAbsolutePath().contains("target/testBase")).isTrue();
+		assertThat(newRepo.getBasedir().getAbsolutePath()).contains("target/testBase");
 	}
 
 	private void assertVersion(Environment environment) {
@@ -118,7 +118,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 		this.repository.setUri(uri);
 		this.repository.setSearchPaths(new String[] { "sub" });
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/sub/application.yml");
 		assertVersion(environment);
@@ -127,7 +127,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	@Test
 	public void defaultRepoBranch() {
 		Environment environment = this.repository.findOne("bar", "staging", "raw");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -136,7 +136,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	@Test
 	public void defaultRepoTag() {
 		Environment environment = this.repository.findOne("bar", "staging", "foo");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -145,7 +145,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	@Test
 	public void defaultRepoTwice() {
 		Environment environment = this.repository.findOne("bar", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -161,7 +161,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	@Test
 	public void mappingRepo() {
 		Environment environment = this.repository.findOne("test1-svc", "staging", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*test1*") + "/test1-svc.properties");
 		assertVersion(environment);
@@ -172,7 +172,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 		this.repository.setDefaultLabel("raw");
 		Environment environment = this.repository.findOne("bar", "staging", null);
 		assertThat(environment.getLabel()).isEqualTo("raw");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(this.repository.getUri() + "/bar.properties");
 		assertVersion(environment);
@@ -182,7 +182,7 @@ public class MultipleJGitEnvironmentRepositoryTests {
 	public void mappingRepoWithDefaultLabel() {
 		Environment environment = this.repository.findOne("test1-svc", "staging", null);
 		assertThat(environment.getLabel()).isEqualTo(JGitEnvironmentProperties.MAIN_LABEL);
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getName())
 				.isEqualTo(getUri("*test1*") + "/test1-svc.properties");
 		assertVersion(environment);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
@@ -60,13 +60,13 @@ public class NativeEnvironmentRepositoryTests {
 	public void emptySearchLocations() {
 		this.repository.setSearchLocations((String[]) null);
 		Environment environment = this.repository.findOne("foo", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
 	public void vanilla() {
 		Environment environment = this.repository.findOne("foo", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 	}
 
@@ -74,7 +74,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void ignoresExistingProfile() {
 		System.setProperty("spring.profiles.active", "cloud");
 		Environment environment = this.repository.findOne("foo", "main", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 	}
 
@@ -82,7 +82,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void prefixed() {
 		this.repository.setSearchLocations("classpath:/test");
 		Environment environment = this.repository.findOne("foo", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 		// gh-1778 property sources has the same name.
 		assertThat(environment.getPropertySources().get(0).getName())
@@ -93,7 +93,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void prefixedYaml() {
 		this.repository.setSearchLocations("classpath:/test");
 		Environment environment = this.repository.findOne("bar", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 		// gh-1778 property sources has the same name.
 		assertThat(environment.getPropertySources().get(0).getName())
@@ -104,7 +104,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void prefixedMultiDocProperties() {
 		this.repository.setSearchLocations("classpath:/test");
 		Environment environment = this.repository.findOne("baz", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 		// gh-1778 property sources has the same name.
 		assertThat(environment.getPropertySources().get(0).getName())
@@ -115,7 +115,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void prefixedWithFile() {
 		this.repository.setSearchLocations("file:./src/test/resources/test");
 		Environment environment = this.repository.findOne("foo", "development", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getVersion()).as("version was wrong").isEqualTo("myversion");
 	}
 
@@ -125,7 +125,7 @@ public class NativeEnvironmentRepositoryTests {
 		environment.add(new PropertySource(
 				"Config resource 'file [/tmp/config-repo-7780026223759117699/application-dev.yml]' via location 'file:/tmp/config-repo-7780026223759117699/'",
 				Collections.singletonMap("foo", "bar")));
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName().contains("application-dev.yml"));
 	}
 
@@ -135,7 +135,7 @@ public class NativeEnvironmentRepositoryTests {
 		environment.add(new PropertySource(
 				"Config resource 'classpath:/configs/application-myprofile.yml' via location 'classpath:/configs/' (document #0)",
 				Collections.singletonMap("foo", "bar")));
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName().contains("application-myprofile.yml"));
 	}
 
@@ -145,7 +145,7 @@ public class NativeEnvironmentRepositoryTests {
 		environment.add(new PropertySource(
 				"Config resource 'class path resource [configs/application.yml]' via location 'classpath:/configs/' (document #0)",
 				Collections.singletonMap("foo", "bar")));
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName().contains("application-myprofile.yml"));
 	}
 
@@ -154,7 +154,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void labelled() {
 		this.repository.setSearchLocations("classpath:/test");
 		Environment environment = this.repository.findOne("foo", "development", "dev", false);
-		assertThat(environment.getPropertySources().size()).isEqualTo(3);
+		assertThat(environment.getPropertySources()).hasSize(3);
 		// position 1 because it has higher precedence than anything except the
 		// foo-development.properties
 		assertThat(environment.getPropertySources().get(1).getSource().get("foo")).isEqualTo("dev_bar");
@@ -165,7 +165,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void placeholdersLabel() {
 		this.repository.setSearchLocations("classpath:/test/{label}/");
 		Environment environment = this.repository.findOne("foo", "development", "dev");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("dev_bar");
 	}
 
@@ -173,7 +173,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void placeholdersProfile() {
 		this.repository.setSearchLocations("classpath:/test/{profile}/");
 		Environment environment = this.repository.findOne("foo", "dev", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("dev_bar");
 	}
 
@@ -181,7 +181,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void placeholdersProfiles() {
 		this.repository.setSearchLocations("classpath:/test/{profile}/");
 		Environment environment = this.repository.findOne("foo", "dev,mysql", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("mysql");
 	}
 
@@ -189,7 +189,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void placeholdersApplicationAndProfile() {
 		this.repository.setSearchLocations("classpath:/test/{profile}/{application}/");
 		Environment environment = this.repository.findOne("app", "dev", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("app");
 	}
 
@@ -198,7 +198,7 @@ public class NativeEnvironmentRepositoryTests {
 		this.repository.setSearchLocations("classpath:/test/{profile}/{application}/");
 		// gh-2259 application name starts with "application"
 		Environment environment = this.repository.findOne("applicationxyz", "dev", "master");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("default-app");
 	}
 
@@ -231,7 +231,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void placeholdersNoTrailingSlash() {
 		this.repository.setSearchLocations("classpath:/test/{label}");
 		Environment environment = this.repository.findOne("foo", "development", "dev");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("dev_bar");
 	}
 
@@ -239,7 +239,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void locationAddLabelLocations() {
 		this.repository.setSearchLocations("classpath:/test/dev/");
 		Environment environment = this.repository.findOne("foo", "development", "ignore");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isNotEqualTo("dev_bar");
 	}
 
@@ -247,7 +247,7 @@ public class NativeEnvironmentRepositoryTests {
 	public void tryToStartReactive() {
 		this.repository.setSearchLocations("classpath:/test/reactive/");
 		Environment environment = this.repository.findOne("foo", "master", "default");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("reactive");
 	}
 
@@ -256,7 +256,7 @@ public class NativeEnvironmentRepositoryTests {
 		this.repository.setSearchLocations("classpath:/test/dev/");
 		this.repository.setAddLabelLocations(false);
 		Environment environment = this.repository.findOne("foo", "development", "ignore");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("dev_bar");
 	}
 
@@ -306,7 +306,7 @@ public class NativeEnvironmentRepositoryTests {
 	private void testImport() {
 		Environment environment = this.repository.findOne("import", "default", "master");
 		// TODO should be 4, bar.yml contains 2 yaml documents
-		assertThat(environment.getPropertySources().size()).isEqualTo(3);
+		assertThat(environment.getPropertySources()).hasSize(3);
 		assertThat(environment.getPropertySources().get(0).getSource().get("foo")).isEqualTo("imported");
 		assertThat(environment.getPropertySources().get(2).getSource().get("foo")).isEqualTo("importing");
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryIntegrationTests.java
@@ -81,7 +81,7 @@ public class SVNKitEnvironmentRepositoryIntegrationTests {
 				.profiles("subversion").run("--spring.cloud.config.server.svn.uri=" + uri);
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "trunk");
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
+		assertThat(environment.getPropertySources()).hasSize(2);
 	}
 
 	@Test
@@ -132,7 +132,7 @@ public class SVNKitEnvironmentRepositoryIntegrationTests {
 					.profiles("subversion").run("--spring.cloud.config.server.svn.uri=" + uri);
 			EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 			Environment environment = repository.findOne("bar", "staging", "unknownlabel");
-			assertThat(environment.getPropertySources().size()).isEqualTo(0);
+			assertThat(environment.getPropertySources()).isEmpty();
 		}).isInstanceOf(NoSuchLabelException.class);
 	}
 
@@ -143,8 +143,8 @@ public class SVNKitEnvironmentRepositoryIntegrationTests {
 				.profiles("subversion").run("--spring.cloud.config.server.svn.uri=" + uri);
 		EnvironmentRepository repository = this.context.getBean(EnvironmentRepository.class);
 		Environment environment = repository.findOne("bar", "staging", "demobranch");
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
+		assertThat(environment.getPropertySources()).hasSize(1);
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/SVNKitEnvironmentRepositoryTests.java
@@ -63,18 +63,18 @@ public class SVNKitEnvironmentRepositoryTests {
 	@Test
 	public void vanilla() {
 		Environment environment = this.findOne();
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
-		assertThat(environment.getPropertySources().get(1).getName().contains("application.yml")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(2);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
+		assertThat(environment.getPropertySources().get(1).getName()).contains("application.yml");
 	}
 
 	@Test
 	public void basedir() {
 		this.repository.setBasedir(this.basedir);
 		Environment environment = this.findOne();
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
-		assertThat(environment.getPropertySources().get(1).getName().contains("application.yml")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(2);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
+		assertThat(environment.getPropertySources().get(1).getName()).contains("application.yml");
 	}
 
 	@Test
@@ -87,39 +87,39 @@ public class SVNKitEnvironmentRepositoryTests {
 		this.repository.setBasedir(basedirWithSpace);
 
 		Environment environment = this.findOne();
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
-		assertThat(environment.getPropertySources().get(1).getName().contains("application.yml")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(2);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
+		assertThat(environment.getPropertySources().get(1).getName()).contains("application.yml");
 	}
 
 	@Test
 	public void branch() {
 		Environment environment = this.repository.findOne("bar", "staging", "branches/demobranch");
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(1);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
 	}
 
 	@Test
 	public void branch_no_folder() {
 		Environment environment = this.repository.findOne("bar", "staging", "demobranch", false);
-		assertThat(environment.getPropertySources().size()).isEqualTo(1);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(1);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
 	}
 
 	@Test
 	public void vanilla_with_update() {
 		this.findOne();
 		Environment environment = this.findOne();
-		assertThat(environment.getPropertySources().size()).isEqualTo(2);
-		assertThat(environment.getPropertySources().get(0).getName().contains("bar.properties")).isTrue();
-		assertThat(environment.getPropertySources().get(1).getName().contains("application.yml")).isTrue();
+		assertThat(environment.getPropertySources()).hasSize(2);
+		assertThat(environment.getPropertySources().get(0).getName()).contains("bar.properties");
+		assertThat(environment.getPropertySources().get(1).getName()).contains("application.yml");
 	}
 
 	@Test
 	public void invalidLabel() {
 		Assertions.assertThatThrownBy(() -> {
 			Environment environment = this.repository.findOne("bar", "staging", "unknownlabel");
-			assertThat(environment.getPropertySources().size()).isEqualTo(0);
+			assertThat(environment.getPropertySources()).isEmpty();
 		}).isInstanceOf(NoSuchLabelException.class);
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/GitSkipSslValidationCredentialsProviderTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/GitSkipSslValidationCredentialsProviderTest.java
@@ -24,7 +24,6 @@ import org.eclipse.jgit.internal.JGitText;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -155,7 +155,7 @@ public class GitSkipSslValidationCredentialsProviderTest {
 
 	@Test
 	public void testGetUnrelatedCredentialItemTypes() throws URISyntaxException {
-		Assertions.assertThrows(UnsupportedCredentialItem.class, () -> {
+		assertThatExceptionOfType(UnsupportedCredentialItem.class).isThrownBy(() -> {
 			URIish uri = new URIish("https://example.com/repo.git");
 			CredentialItem usernameCredentialItem = new CredentialItem.Username();
 			CredentialItem passwordCredentialItem = new CredentialItem.Password();


### PR DESCRIPTION
Noticed that there were some instances where AssertJ wasn't used to it's full expressive potential, so I ran our [AssertJ best practices recipe](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj) ([via](https://app.moderne.io/recipes/builder/bGVuS?organizationId=RGVmYXVsdA%3D%3D)) to adopt dedicated assertions. This should help the message when an assertion fails, such that it's not "expected true but was false", but instead something like "expected collection to contain "apple", but was ["banana"]".

```diff
-assertThat(environment.getPropertySources().size()).isEqualTo(2);
+assertThat(environment.getPropertySources()).hasSize(2);
```

These are mostly automated changes with some manual fixes; I recommend a squash merge if possible. I hope this is appreciated! :)