### PR TITLE
Additional information in the log output when an InvalidCipherException occurs.

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -136,7 +136,8 @@ public class EncryptionController {
 		}
 		catch (IllegalArgumentException | IllegalStateException e) {
 			if (logger.isErrorEnabled()) {
-				logger.error("Cannot decrypt key:" + name + ", value:" + data, e);
+				logger.error("Cannot decrypt key:" + name + ", value:" + data +
+					", Please verify if symmetric key is set correctly", e);
 			}
 			throw new InvalidCipherException();
 		}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -137,7 +137,7 @@ public class EncryptionController {
 		catch (IllegalArgumentException | IllegalStateException e) {
 			if (logger.isErrorEnabled()) {
 				logger.error("Cannot decrypt key:" + name + ", value:" + data +
-					", Please verify if symmetric key is set correctly", e);
+					", Please verify if encrypt.key is set correctly", e);
 			}
 			throw new InvalidCipherException();
 		}


### PR DESCRIPTION
When a client application is starting with a mismatch symmetric key (between client and server), the output log prints before InvalidCipherException is thrown due to un-decryptable configuration properties, which creates additional information with log message because the message alone lacks information to guess why the InvalidCipherException occurred.

Relates to #1386