### PR TITLE
Add OAuth2 feature for config clients

### DIFF
--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -21,6 +21,11 @@
     ]]>
 	</description>
 
+	<properties>
+		<jasypt-spring-boot.version>3.0.5</jasypt-spring-boot.version>
+		<okhttp.version>4.11.0</okhttp.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -81,6 +86,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot</artifactId>
+			<version>${jasypt-spring-boot.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -93,6 +103,18 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenResponse {
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	public void setTokenType(String tokenType) {
+		this.tokenType = tokenType;
+	}
+
+	public String getBearerHeader() {
+		return getTokenType() + " " + getAccessToken();
+	}
+
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -118,6 +118,47 @@ public class ConfigClientProperties {
 	private String password;
 
 	/**
+	 * The OAuth2 token URI of the IDP issuing JWT tokens. When present enables OAuth2
+	 * client calls.
+	 */
+	private String tokenUri;
+
+	/**
+	 * The OAuth2 grant type (client_credentials, password).
+	 */
+	private String grantType;
+
+	/**
+	 * The OAuth2 client id should it be needed in JWT token request.
+	 */
+	private String clientId;
+
+	/**
+	 * The OAuth2 client secret should it be needed in JWT token request.
+	 */
+	private String clientSecret;
+
+	/**
+	 * The OAuth2 username to use when contacting the IDP.
+	 */
+	private String oauthUsername;
+
+	/**
+	 * The OAuth2 user password to use when contacting the IDP.
+	 */
+	private String oauthPassword;
+
+	/**
+	 * The Jasypt encryption algorithm.
+	 */
+	private String encryptorAlgorithm;
+
+	/**
+	 * Encryption iterations.
+	 */
+	private Integer encryptorIterations = 1000;
+
+	/**
 	 * The URI of the remote server (default http://localhost:8888).
 	 */
 	private String[] uri = { "http://localhost:8888" };
@@ -246,6 +287,70 @@ public class ConfigClientProperties {
 
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	public String getTokenUri() {
+		return tokenUri;
+	}
+
+	public void setTokenUri(String tokenUri) {
+		this.tokenUri = tokenUri;
+	}
+
+	public String getGrantType() {
+		return grantType;
+	}
+
+	public void setGrantType(String grantType) {
+		this.grantType = grantType;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public String getOauthUsername() {
+		return oauthUsername;
+	}
+
+	public void setOauthUsername(String oauthUsername) {
+		this.oauthUsername = oauthUsername;
+	}
+
+	public String getOauthPassword() {
+		return oauthPassword;
+	}
+
+	public void setOauthPassword(String oauthPassword) {
+		this.oauthPassword = oauthPassword;
+	}
+
+	public String getEncryptorAlgorithm() {
+		return encryptorAlgorithm;
+	}
+
+	public void setEncryptorAlgorithm(String encryptorAlgorithm) {
+		this.encryptorAlgorithm = encryptorAlgorithm;
+	}
+
+	public Integer getEncryptorIterations() {
+		return encryptorIterations;
+	}
+
+	public void setEncryptorIterations(Integer encryptorIterations) {
+		this.encryptorIterations = encryptorIterations;
 	}
 
 	public Credentials getCredentials(int index) {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
@@ -18,13 +18,19 @@ package org.springframework.cloud.config.client;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEByteEncryptor;
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEStringEncryptor;
 import org.apache.commons.logging.Log;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -33,10 +39,13 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
+import org.jasypt.salt.RandomSaltGenerator;
 
 import org.springframework.cloud.configuration.SSLContextFactory;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -44,11 +53,16 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Base64Utils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 import static org.springframework.cloud.config.client.ConfigClientProperties.AUTHORIZATION;
 
 public class ConfigClientRequestTemplateFactory {
+
+	private SimplePBEStringEncryptor encryptor;
 
 	private final Log log;
 
@@ -57,6 +71,7 @@ public class ConfigClientRequestTemplateFactory {
 	public ConfigClientRequestTemplateFactory(Log log, ConfigClientProperties properties) {
 		this.log = log;
 		this.properties = properties;
+		this.encryptor = new SimplePBEStringEncryptor(buildEncryptor());
 	}
 
 	public Log getLog() {
@@ -65,6 +80,17 @@ public class ConfigClientRequestTemplateFactory {
 
 	public ConfigClientProperties getProperties() {
 		return this.properties;
+	}
+
+	public SimplePBEByteEncryptor buildEncryptor() {
+		SimplePBEByteEncryptor byteEncryptor = new SimplePBEByteEncryptor();
+		byteEncryptor.setPassword(System.getProperty("encryptor-password"));
+		byteEncryptor.setSaltGenerator(new RandomSaltGenerator());
+		byteEncryptor.setIterations(properties.getEncryptorIterations());
+		if (StringUtils.hasText(properties.getEncryptorAlgorithm())) {
+			byteEncryptor.setAlgorithm(properties.getEncryptorAlgorithm());
+		}
+		return byteEncryptor;
 	}
 
 	public RestTemplate create() {
@@ -79,11 +105,55 @@ public class ConfigClientRequestTemplateFactory {
 		RestTemplate template = new RestTemplate(requestFactory);
 		Map<String, String> headers = new HashMap<>(properties.getHeaders());
 		headers.remove(AUTHORIZATION); // To avoid redundant addition of header
-		if (!headers.isEmpty()) {
-			template.setInterceptors(Arrays.asList(new GenericRequestHeaderInterceptor(headers)));
+
+		if (StringUtils.hasText(properties.getTokenUri())) {
+			Optional<AccessTokenResponse> responseOpt = getOAuthToken(template, properties.getTokenUri());
+			if (responseOpt.isPresent()) {
+				AccessTokenResponse accessTokenResponse = responseOpt.get();
+				headers.put(AUTHORIZATION, accessTokenResponse.getBearerHeader());
+				properties.setHeaders(headers);
+			}
 		}
 
 		return template;
+	}
+
+	private Optional<AccessTokenResponse> getOAuthToken(RestTemplate template, String tokenUri) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.put("grant_type", List.of(properties.getGrantType()));
+		if (StringUtils.hasText(properties.getClientId())) {
+			map.put("client_id", List.of(properties.getClientId()));
+			map.put("client_secret", List.of(decryptProperty(properties.getClientSecret())));
+		}
+		if (StringUtils.hasText(properties.getOauthUsername())) {
+			map.put("username", List.of(properties.getOauthUsername()));
+			map.put("password", List.of(decryptProperty(properties.getOauthPassword())));
+		}
+		HttpEntity<MultiValueMap<String, String>> requestBodyFormUrlEncoded = new HttpEntity<>(map, httpHeaders);
+
+		String tokenJson = template.postForObject(tokenUri, requestBodyFormUrlEncoded, String.class);
+		return parseTokenResponse(tokenJson);
+	}
+
+	private String decryptProperty(String prop) {
+		if (prop.startsWith("ENC(")) {
+			prop = prop.substring(4, prop.lastIndexOf(")"));
+			return encryptor.decrypt(prop);
+		}
+		return prop;
+	}
+
+	private Optional<AccessTokenResponse> parseTokenResponse(String tokenJson) {
+		try {
+			ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+					false);
+			return Optional.of(objectMapper.readValue(tokenJson, AccessTokenResponse.class));
+		}
+		catch (JsonProcessingException e) {
+			return Optional.empty();
+		}
 	}
 
 	protected ClientHttpRequestFactory createHttpRequestFactory(ConfigClientProperties client) {

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEByteEncryptor;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasypt.salt.RandomSaltGenerator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.config.client.ConfigClientProperties.AUTHORIZATION;
+
+/**
+ * @author Bruce Randall
+ *
+ */
+class ConfigClientRequestTemplateFactoryTest {
+
+	private static final Log LOG = LogFactory.getLog(ConfigClientRequestTemplateFactoryTest.class);
+
+	public static MockWebServer mockWebServer;
+
+	private static String idpUrl;
+
+	private static final String TOKEN_RESPONSE = """
+			{"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJVQ2RaakhjZ0tFU0NFV0w3V1JlMWpnaVRyQVNGbFhndU5CZWVGN1VlUnZJIn0.eyJleHAiOjE3MDE0NDQ2NTcsImlhdCI6MTcwMTQ0NDM1NywianRpIjoiN2IzZTczZTMtZWJlYy00YWE3LWI0MjgtZjRlMmJiYTQxYWNlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo5MDgwL3JlYWxtcy9vc2ludC1yZWFsbSIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiJhN2EyNWZiMC02MzljLTQxYTktYmEwNS04NDlkYTE0Y2NiMzQiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJvc2ludC1rZXljbG9hay1jbGllbnQiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly9sb2NhbGhvc3Q6ODM1MSJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJkZWZhdWx0LXJvbGVzLW9zaW50LXJlYWxtIiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJvc2ludC1rZXljbG9hay1jbGllbnQiOnsicm9sZXMiOlsidW1hX3Byb3RlY3Rpb24iLCJtMm0iXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoicHJvZmlsZSBlbWFpbCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiY2xpZW50SG9zdCI6IjE3Mi4xNy4wLjEiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtb3NpbnQta2V5Y2xvYWstY2xpZW50IiwiY2xpZW50QWRkcmVzcyI6IjE3Mi4xNy4wLjEiLCJjbGllbnRfaWQiOiJvc2ludC1rZXljbG9hay1jbGllbnQifQ.AFY1g8_DxAq1eXd-qpJP2PD-8g7-n_gIeScX_ESLWB6UHnZtxe_MvPYvn13X6K4olDsPZ37EGE4-BkdY8pgs-UBCD6EsFD_aZmf9PjZFsHDacAKotcvjsb5U9kqbm0wPuyhrhgSftkrx9AceHe_wETzAPoI775MuyQgSWjihLqLnOZSIMu24t-Ga07Xn0yaOoTD2tS1lfkgXWwRrQF1_KQxHftvJDDhJEN0rfEVJ7SOr9meWH0IQ1w8HgjRFBBkOhtp",
+			"expires_in": 300,
+			"refresh_expires_in": 0,
+			"token_type": "Bearer",
+			"not-before-policy": 0,
+			"scope": "profile email"
+			}""";
+
+	@BeforeAll
+	static void beforeAll() throws IOException {
+		mockWebServer = new MockWebServer();
+		mockWebServer.start();
+		idpUrl = String.format("http://localhost:%s/", mockWebServer.getPort());
+	}
+
+	@AfterAll
+	static void afterAll() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@Test
+	void whenParseTokenResponse_givenValidJson_thenParseToken() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+
+		// when
+		Optional<AccessTokenResponse> tokenOpt = ReflectionTestUtils.invokeMethod(templateFactory, "parseTokenResponse",
+				TOKEN_RESPONSE);
+		// then
+		assertThat(tokenOpt).isPresent();
+		AccessTokenResponse tokenResponse = tokenOpt.get();
+		assertThat(tokenResponse.getAccessToken()).isNotNull();
+		assertThat(tokenResponse.getAccessToken())
+				.startsWith("eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJVQ2RaakhjZ0tFU0NFV0w3V1JlMWpnaVR");
+		assertThat(tokenResponse.getAccessToken()).endsWith("WH0IQ1w8HgjRFBBkOhtp");
+		assertThat(tokenResponse.getTokenType()).isNotNull();
+		assertThat(tokenResponse.getTokenType()).isEqualTo("Bearer");
+		assertThat(tokenResponse.getBearerHeader())
+				.isEqualTo(tokenResponse.getTokenType() + " " + tokenResponse.getAccessToken());
+		assertThat(templateFactory.getLog()).isNotNull();
+		assertThat(templateFactory.getProperties()).isNotNull();
+	}
+
+	@Test
+	void whenCreate_givenTokenUri_thenGetOAuthToken() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
+		properties.setClientId("clientId");
+		properties.setClientSecret("clientSecret");
+		properties.setGrantType("client_credentials");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		Optional<AccessTokenResponse> tokenOpt = ReflectionTestUtils.invokeMethod(templateFactory, "parseTokenResponse",
+				TOKEN_RESPONSE);
+		assertThat(tokenOpt).isPresent();
+		AccessTokenResponse tokenResponse = tokenOpt.get();
+		mockWebServer.enqueue(new MockResponse().setBody(TOKEN_RESPONSE).setHeader(HttpHeaders.CONTENT_TYPE,
+				MediaType.APPLICATION_JSON_VALUE));
+		// when
+		RestTemplate restTemplate = templateFactory.create();
+		List<ClientHttpRequestInterceptor> interceptors = List
+				.of(new ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor(properties.getHeaders()));
+		restTemplate.setInterceptors(interceptors);
+
+		// then
+		assertThat(restTemplate).isNotNull();
+		assertThat(restTemplate.getInterceptors()).isNotNull();
+		assertThat(restTemplate.getInterceptors()).isNotEmpty();
+		ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor genericInterceptor = (ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor) restTemplate
+				.getInterceptors().get(0);
+		assertThat(genericInterceptor.getHeaders()).isNotNull();
+		assertThat(properties.getHeaders()).isNotNull();
+		assertThat(properties.getHeaders()).isNotEmpty();
+		String header = properties.getHeaders().get(AUTHORIZATION);
+		assertThat(header).isEqualTo(tokenResponse.getTokenType() + " " + tokenResponse.getAccessToken());
+		assertThat(genericInterceptor.getHeaders().get(AUTHORIZATION))
+				.isEqualTo(properties.getHeaders().get(AUTHORIZATION));
+
+	}
+
+	@Test
+	void whenCreate_givenBadTokenResponse_thenNoHeaderSet() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
+		properties.setOauthUsername("oauthUsername");
+		properties.setOauthPassword("oauthPassword");
+		properties.setGrantType("password");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		mockWebServer.enqueue(new MockResponse().setBody("TOKEN_RESPONSE").setHeader(HttpHeaders.CONTENT_TYPE,
+				MediaType.APPLICATION_JSON_VALUE));
+
+		// when
+		templateFactory.create();
+
+		// then
+		assertThat(properties.getHeaders()).isNotNull();
+	}
+
+	@Test
+	void whenDecryptProperty_givenEncryptedProp_thenDecryptProp() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setEncryptorAlgorithm("PBEWITHHMACSHA512ANDAES_256");
+		System.setProperty("encryptor-password", "YaddaYaddaYadda");
+		SimplePBEByteEncryptor encryptor = buildEncryptor(properties);
+		String secret = UUID.randomUUID().toString();
+		String encryptedProp = new String(
+				Base64.getEncoder().encode(encryptor.encrypt(secret.getBytes(StandardCharsets.UTF_8))));
+		properties.setClientSecret("ENC(" + encryptedProp + ")");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		// when
+		templateFactory.create();
+		String actualSecret = ReflectionTestUtils.invokeMethod(templateFactory, "decryptProperty",
+				properties.getClientSecret());
+
+		// then
+		assertThat(secret).isEqualTo(actualSecret);
+	}
+
+	private SimplePBEByteEncryptor buildEncryptor(ConfigClientProperties properties) {
+		SimplePBEByteEncryptor byteEncryptor = new SimplePBEByteEncryptor();
+		byteEncryptor.setPassword(System.getProperty("encryptor-password"));
+		byteEncryptor.setSaltGenerator(new RandomSaltGenerator());
+		byteEncryptor.setIterations(1000);
+		if (StringUtils.hasText(properties.getEncryptorAlgorithm())) {
+			byteEncryptor.setAlgorithm(properties.getEncryptorAlgorithm());
+		}
+		return byteEncryptor;
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -19,11 +19,14 @@ package org.springframework.cloud.config.client;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -412,6 +415,28 @@ public class ConfigServerConfigDataLoaderTests {
 
 	}
 
+	@Test
+	public void useDiscoveryUriIfEnabled() throws Exception {
+		String[] uris = new String[] { "http://uritest:8888" };
+		properties.setUri(uris);
+		ConfigClientProperties.Discovery discovery = new ConfigClientProperties.Discovery();
+		discovery.setEnabled(true);
+		discovery.setServiceId("configservice");
+		properties.setDiscovery(discovery);
+		this.loader = new ConfigServerConfigDataLoader(destination -> logger);
+		ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
+		RestTemplate restTemplate = new RestTemplate(requestFactory);
+		when(bootstrapContext.get(RestTemplate.class)).thenReturn(restTemplate);
+		ConfigClientProperties bootstrapConfigClientProperties = new ConfigClientProperties();
+		bootstrapConfigClientProperties.setDiscovery(discovery);
+		bootstrapConfigClientProperties.setUri(new String[] { "http://configservice:8888" });
+		when(bootstrapContext.get(ConfigClientProperties.class)).thenReturn(bootstrapConfigClientProperties);
+
+		mockRequestResponse(requestFactory, "http://configservice:8888", HttpStatus.OK);
+
+		assertThat(this.loader.load(context, resource)).isNotNull();
+	}
+
 	@Disabled
 	@Test
 	// TODO Enable once we have
@@ -667,6 +692,74 @@ public class ConfigServerConfigDataLoaderTests {
 
 		when(request.getHeaders()).thenReturn(new HttpHeaders());
 		when(request.execute()).thenThrow(IOException.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenOauth_thenAddInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		Map<String, String> tokenHeader = new HashMap<>();
+		tokenHeader.put(AUTHORIZATION, "Bearer " + UUID.randomUUID().toString());
+		properties.setHeaders(tokenHeader);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), null);
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(1)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenOauthNoToken_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		properties.setSendState(false);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenBasicAuth_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenBasicAuthToken_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setToken("Basic "
+				+ Arrays.toString(Base64.getEncoder().encode("YaddaYaddaYadda".getBytes(StandardCharsets.UTF_8))));
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
 	}
 
 }


### PR DESCRIPTION
When IDP token URI property present, call IDP for Bearer token. 
Append Bearer token to header on config server resource call.