### PR TITLE
Add OAuth2 feature for Config Clients

### DIFF
--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -23,7 +23,6 @@
 
 	<properties>
 		<jasypt-spring-boot.version>3.0.5</jasypt-spring-boot.version>
-		<okhttp.version>4.11.0</okhttp.version>
 	</properties>
 
 	<dependencies>
@@ -108,13 +107,11 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-config-client/pom.xml
+++ b/spring-cloud-config-client/pom.xml
@@ -21,6 +21,11 @@
     ]]>
 	</description>
 
+	<properties>
+		<jasypt-spring-boot.version>3.0.5</jasypt-spring-boot.version>
+		<okhttp.version>4.11.0</okhttp.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -81,6 +86,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot</artifactId>
+			<version>${jasypt-spring-boot.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -93,6 +103,18 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>${okhttp.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenResponse {
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	public void setTokenType(String tokenType) {
+		this.tokenType = tokenType;
+	}
+
+	public String getBearerHeader() {
+		return getTokenType() + " " + getAccessToken();
+	}
+
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/AccessTokenResponse.java
@@ -18,6 +18,10 @@ package org.springframework.cloud.config.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @author Bruce Randall
+ *
+ */
 public class AccessTokenResponse {
 
 	@JsonProperty("access_token")

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientOAuth2Properties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientOAuth2Properties.java
@@ -22,8 +22,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Bruce Randall
  *
  */
-@ConfigurationProperties(ConfigClientOauth2Properties.PREFIX)
-public class ConfigClientOauth2Properties {
+@ConfigurationProperties(ConfigClientOAuth2Properties.PREFIX)
+public class ConfigClientOAuth2Properties {
 
 	/**
 	 * Prefix for Spring Cloud Config properties.
@@ -111,7 +111,7 @@ public class ConfigClientOauth2Properties {
 
 	@Override
 	public String toString() {
-		return "ConfigClientOauth2Properties{" + "tokenUri='" + tokenUri + '\'' + ", grantType='" + grantType + '\''
+		return "ConfigClientOAuth2Properties{" + "tokenUri='" + tokenUri + '\'' + ", grantType='" + grantType + '\''
 				+ ", clientId='" + clientId + '\'' + ", oauthUsername='" + oauthUsername + '\'' + '}';
 	}
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientOauth2Properties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientOauth2Properties.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Bruce Randall
+ *
+ */
+@ConfigurationProperties(ConfigClientOauth2Properties.PREFIX)
+public class ConfigClientOauth2Properties {
+
+	/**
+	 * Prefix for Spring Cloud Config properties.
+	 */
+	public static final String PREFIX = "spring.cloud.config.oauth2";
+
+	/**
+	 * The OAuth2 token URI of the IDP issuing JWT tokens. When present enables OAuth2
+	 * client calls.
+	 */
+	private String tokenUri;
+
+	/**
+	 * The OAuth2 grant type (client_credentials, password).
+	 */
+	private String grantType;
+
+	/**
+	 * The OAuth2 client id should it be needed in JWT token request.
+	 */
+	private String clientId;
+
+	/**
+	 * The OAuth2 client secret should it be needed in JWT token request.
+	 */
+	private String clientSecret;
+
+	/**
+	 * The OAuth2 username to use when contacting the IDP.
+	 */
+	private String oauthUsername;
+
+	/**
+	 * The OAuth2 user password to use when contacting the IDP.
+	 */
+	private String oauthPassword;
+
+	public String getTokenUri() {
+		return tokenUri;
+	}
+
+	public void setTokenUri(String tokenUri) {
+		this.tokenUri = tokenUri;
+	}
+
+	public String getGrantType() {
+		return grantType;
+	}
+
+	public void setGrantType(String grantType) {
+		this.grantType = grantType;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public String getOauthUsername() {
+		return oauthUsername;
+	}
+
+	public void setOauthUsername(String oauthUsername) {
+		this.oauthUsername = oauthUsername;
+	}
+
+	public String getOauthPassword() {
+		return oauthPassword;
+	}
+
+	public void setOauthPassword(String oauthPassword) {
+		this.oauthPassword = oauthPassword;
+	}
+
+	@Override
+	public String toString() {
+		return "ConfigClientOauth2Properties{" + "tokenUri='" + tokenUri + '\'' + ", grantType='" + grantType + '\''
+				+ ", clientId='" + clientId + '\'' + ", oauthUsername='" + oauthUsername + '\'' + '}';
+	}
+
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -120,7 +120,7 @@ public class ConfigClientProperties {
 	/**
 	 * OAUTH2 Properties.
 	 */
-	private ConfigClientOauth2Properties configClientOauth2Properties;
+	private ConfigClientOAuth2Properties configClientOAuth2Properties;
 
 	/**
 	 * Encryption properties.
@@ -258,12 +258,12 @@ public class ConfigClientProperties {
 		this.password = password;
 	}
 
-	public ConfigClientOauth2Properties getConfigClientOauth2Properties() {
-		return configClientOauth2Properties;
+	public ConfigClientOAuth2Properties getConfigClientOAuth2Properties() {
+		return configClientOAuth2Properties;
 	}
 
-	public void setConfigClientOauth2Properties(ConfigClientOauth2Properties configClientOauth2Properties) {
-		this.configClientOauth2Properties = configClientOauth2Properties;
+	public void setConfigClientOAuth2Properties(ConfigClientOAuth2Properties configClientOAuth2Properties) {
+		this.configClientOAuth2Properties = configClientOAuth2Properties;
 	}
 
 	public EncryptorConfig getEncryptorConfig() {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -118,45 +118,14 @@ public class ConfigClientProperties {
 	private String password;
 
 	/**
-	 * The OAuth2 token URI of the IDP issuing JWT tokens. When present enables OAuth2
-	 * client calls.
+	 * OAUTH2 Properties.
 	 */
-	private String tokenUri;
+	private ConfigClientOauth2Properties configClientOauth2Properties;
 
 	/**
-	 * The OAuth2 grant type (client_credentials, password).
+	 * Encryption properties.
 	 */
-	private String grantType;
-
-	/**
-	 * The OAuth2 client id should it be needed in JWT token request.
-	 */
-	private String clientId;
-
-	/**
-	 * The OAuth2 client secret should it be needed in JWT token request.
-	 */
-	private String clientSecret;
-
-	/**
-	 * The OAuth2 username to use when contacting the IDP.
-	 */
-	private String oauthUsername;
-
-	/**
-	 * The OAuth2 user password to use when contacting the IDP.
-	 */
-	private String oauthPassword;
-
-	/**
-	 * The Jasypt encryption algorithm.
-	 */
-	private String encryptorAlgorithm;
-
-	/**
-	 * Encryption iterations.
-	 */
-	private Integer encryptorIterations = 1000;
+	private EncryptorConfig encryptorConfig;
 
 	/**
 	 * The URI of the remote server (default http://localhost:8888).
@@ -289,68 +258,20 @@ public class ConfigClientProperties {
 		this.password = password;
 	}
 
-	public String getTokenUri() {
-		return tokenUri;
+	public ConfigClientOauth2Properties getConfigClientOauth2Properties() {
+		return configClientOauth2Properties;
 	}
 
-	public void setTokenUri(String tokenUri) {
-		this.tokenUri = tokenUri;
+	public void setConfigClientOauth2Properties(ConfigClientOauth2Properties configClientOauth2Properties) {
+		this.configClientOauth2Properties = configClientOauth2Properties;
 	}
 
-	public String getGrantType() {
-		return grantType;
+	public EncryptorConfig getEncryptorConfig() {
+		return encryptorConfig;
 	}
 
-	public void setGrantType(String grantType) {
-		this.grantType = grantType;
-	}
-
-	public String getClientId() {
-		return clientId;
-	}
-
-	public void setClientId(String clientId) {
-		this.clientId = clientId;
-	}
-
-	public String getClientSecret() {
-		return clientSecret;
-	}
-
-	public void setClientSecret(String clientSecret) {
-		this.clientSecret = clientSecret;
-	}
-
-	public String getOauthUsername() {
-		return oauthUsername;
-	}
-
-	public void setOauthUsername(String oauthUsername) {
-		this.oauthUsername = oauthUsername;
-	}
-
-	public String getOauthPassword() {
-		return oauthPassword;
-	}
-
-	public void setOauthPassword(String oauthPassword) {
-		this.oauthPassword = oauthPassword;
-	}
-
-	public String getEncryptorAlgorithm() {
-		return encryptorAlgorithm;
-	}
-
-	public void setEncryptorAlgorithm(String encryptorAlgorithm) {
-		this.encryptorAlgorithm = encryptorAlgorithm;
-	}
-
-	public Integer getEncryptorIterations() {
-		return encryptorIterations;
-	}
-
-	public void setEncryptorIterations(Integer encryptorIterations) {
-		this.encryptorIterations = encryptorIterations;
+	public void setEncryptorConfig(EncryptorConfig encryptorConfig) {
+		this.encryptorConfig = encryptorConfig;
 	}
 
 	public Credentials getCredentials(int index) {
@@ -496,7 +417,7 @@ public class ConfigClientProperties {
 		return credentials;
 	}
 
-	public ConfigClientProperties override(org.springframework.core.env.Environment environment) {
+	public ConfigClientProperties override(Environment environment) {
 		ConfigClientProperties override = new ConfigClientProperties();
 		BeanUtils.copyProperties(this, override);
 		override.setName(environment.resolvePlaceholders(NAME_PLACEHOLDER));

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -118,6 +118,47 @@ public class ConfigClientProperties {
 	private String password;
 
 	/**
+	 * The OAuth2 token URI of the IDP issuing JWT tokens. When present enables OAuth2
+	 * client calls.
+	 */
+	private String tokenUri;
+
+	/**
+	 * The OAuth2 grant type (client_credentials, password).
+	 */
+	private String grantType;
+
+	/**
+	 * The OAuth2 client id should it be needed in JWT token request.
+	 */
+	private String clientId;
+
+	/**
+	 * The OAuth2 client secret should it be needed in JWT token request.
+	 */
+	private String clientSecret;
+
+	/**
+	 * The OAuth2 username to use when contacting the IDP.
+	 */
+	private String oauthUsername;
+
+	/**
+	 * The OAuth2 user password to use when contacting the IDP.
+	 */
+	private String oauthPassword;
+
+	/**
+	 * The Jasypt encryption algorithm.
+	 */
+	private String encryptorAlgorithm;
+
+	/**
+	 * Encryption iterations.
+	 */
+	private Integer encryptorIterations = 1000;
+
+	/**
 	 * The URI of the remote server (default http://localhost:8888).
 	 */
 	private String[] uri = { "http://localhost:8888" };
@@ -246,6 +287,70 @@ public class ConfigClientProperties {
 
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+	public String getTokenUri() {
+		return tokenUri;
+	}
+
+	public void setTokenUri(String tokenUri) {
+		this.tokenUri = tokenUri;
+	}
+
+	public String getGrantType() {
+		return grantType;
+	}
+
+	public void setGrantType(String grantType) {
+		this.grantType = grantType;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public String getOauthUsername() {
+		return oauthUsername;
+	}
+
+	public void setOauthUsername(String oauthUsername) {
+		this.oauthUsername = oauthUsername;
+	}
+
+	public String getOauthPassword() {
+		return oauthPassword;
+	}
+
+	public void setOauthPassword(String oauthPassword) {
+		this.oauthPassword = oauthPassword;
+	}
+
+	public String getEncryptorAlgorithm() {
+		return encryptorAlgorithm;
+	}
+
+	public void setEncryptorAlgorithm(String encryptorAlgorithm) {
+		this.encryptorAlgorithm = encryptorAlgorithm;
+	}
+
+	public Integer getEncryptorIterations() {
+		return encryptorIterations;
+	}
+
+	public void setEncryptorIterations(Integer encryptorIterations) {
+		this.encryptorIterations = encryptorIterations;
 	}
 
 	public Credentials getCredentials(int index) {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
@@ -121,7 +121,12 @@ public class ConfigClientRequestTemplateFactory {
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.put("grant_type", List.of(properties.getGrantType()));
+		if (StringUtils.hasText(properties.getGrantType())) {
+			map.put("grant_type", List.of(properties.getGrantType()));
+		}
+		else {
+			throw new IllegalStateException("Grant type is required for OAuth2 requests.");
+		}
 		if (StringUtils.hasText(properties.getClientId())) {
 			map.put("client_id", List.of(properties.getClientId()));
 			map.put("client_secret", List.of(decryptProperty(properties.getClientSecret())));

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
@@ -61,11 +61,14 @@ public class ConfigClientRequestTemplateFactory {
 
 	private final Log log;
 
+	private EncryptorConfig encryptorConfig;
+
 	private final ConfigClientProperties properties;
 
 	public ConfigClientRequestTemplateFactory(Log log, ConfigClientProperties properties) {
 		this.log = log;
 		this.properties = properties;
+		this.encryptorConfig = properties.getEncryptorConfig();
 	}
 
 	public Log getLog() {
@@ -125,12 +128,13 @@ public class ConfigClientRequestTemplateFactory {
 		return parseTokenResponse(tokenJson);
 	}
 
-	private String decryptProperty(String prop) {
-		if (prop.startsWith("ENC(")) {
-			prop = prop.substring(4, prop.lastIndexOf(")"));
-			return properties.getEncryptorConfig().getEncryptor().decrypt(prop);
+	private String decryptProperty(String property) {
+		if (encryptorConfig != null) {
+			return encryptorConfig.decryptProperty(property);
 		}
-		return prop;
+		else {
+			return property;
+		}
 	}
 
 	private Optional<AccessTokenResponse> parseTokenResponse(String tokenJson) {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
@@ -92,9 +92,9 @@ public class ConfigClientRequestTemplateFactory {
 		Map<String, String> headers = new HashMap<>(properties.getHeaders());
 		headers.remove(AUTHORIZATION); // To avoid redundant addition of header
 
-		if (properties.getConfigClientOauth2Properties() != null) {
+		if (properties.getConfigClientOAuth2Properties() != null) {
 			Optional<AccessTokenResponse> responseOpt = getOAuthToken(template,
-					properties.getConfigClientOauth2Properties().getTokenUri());
+					properties.getConfigClientOAuth2Properties().getTokenUri());
 			if (responseOpt.isPresent()) {
 				AccessTokenResponse accessTokenResponse = responseOpt.get();
 				headers.put(AUTHORIZATION, accessTokenResponse.getBearerHeader());
@@ -106,7 +106,7 @@ public class ConfigClientRequestTemplateFactory {
 	}
 
 	private Optional<AccessTokenResponse> getOAuthToken(RestTemplate template, String tokenUri) {
-		ConfigClientOauth2Properties oauth2Properties = properties.getConfigClientOauth2Properties();
+		ConfigClientOAuth2Properties oauth2Properties = properties.getConfigClientOAuth2Properties();
 		if (oauth2Properties.getGrantType() == null) {
 			throw new IllegalStateException("OAuth2 Grant Type property required.");
 		}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactory.java
@@ -62,7 +62,7 @@ import static org.springframework.cloud.config.client.ConfigClientProperties.AUT
 
 public class ConfigClientRequestTemplateFactory {
 
-	private SimplePBEStringEncryptor encryptor;
+	private final SimplePBEStringEncryptor encryptor;
 
 	private final Log log;
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -49,6 +49,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -264,7 +265,6 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 		String path = "/{name}/{profile}";
 		String name = properties.getName();
 		String profile = resource.getProfiles();
-		String token = properties.getToken();
 		String[] uris;
 		boolean discoveryEnabled = properties.getDiscovery().isEnabled();
 		ConfigClientProperties bootstrapConfigClientProperties = context.getBootstrapContext()
@@ -319,11 +319,20 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 				HttpHeaders headers = new HttpHeaders();
 				headers.setAccept(acceptHeader);
 				requestTemplateFactory.addAuthorizationToken(headers, username, password);
-				if (StringUtils.hasText(token)) {
-					headers.add(TOKEN_HEADER, token);
-				}
 				if (StringUtils.hasText(state) && properties.isSendState()) {
 					headers.add(STATE_HEADER, state);
+				}
+				if (StringUtils.hasText(properties.getTokenUri()) && !properties.getHeaders().isEmpty()) {
+					List<ClientHttpRequestInterceptor> interceptors = List
+							.of(new ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor(
+									properties.getHeaders()));
+					restTemplate.setInterceptors(interceptors);
+				}
+				else {
+					requestTemplateFactory.addAuthorizationToken(headers, username, password);
+					if (StringUtils.hasText(properties.getToken())) {
+						headers.add(TOKEN_HEADER, properties.getToken());
+					}
 				}
 
 				final HttpEntity<Void> entity = new HttpEntity<>((Void) null, headers);

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -322,7 +322,7 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 				if (StringUtils.hasText(state) && properties.isSendState()) {
 					headers.add(STATE_HEADER, state);
 				}
-				if (properties.getConfigClientOauth2Properties() != null && !properties.getHeaders().isEmpty()) {
+				if (properties.getConfigClientOAuth2Properties() != null && !properties.getHeaders().isEmpty()) {
 					List<ClientHttpRequestInterceptor> interceptors = List
 							.of(new ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor(
 									properties.getHeaders()));

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -322,7 +322,7 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 				if (StringUtils.hasText(state) && properties.isSendState()) {
 					headers.add(STATE_HEADER, state);
 				}
-				if (StringUtils.hasText(properties.getTokenUri()) && !properties.getHeaders().isEmpty()) {
+				if (properties.getConfigClientOauth2Properties() != null && !properties.getHeaders().isEmpty()) {
 					List<ClientHttpRequestInterceptor> interceptors = List
 							.of(new ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor(
 									properties.getHeaders()));

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
@@ -102,10 +102,10 @@ public class ConfigServerConfigDataLocationResolver
 					.orElse("application");
 			configClientProperties.setName(applicationName);
 		}
-		ConfigClientOauth2Properties oauth2Properties = binder
-				.bind(ConfigClientOauth2Properties.PREFIX, Bindable.of(ConfigClientOauth2Properties.class), bindHandler)
+		ConfigClientOAuth2Properties oauth2Properties = binder
+				.bind(ConfigClientOAuth2Properties.PREFIX, Bindable.of(ConfigClientOAuth2Properties.class), bindHandler)
 				.orElse(null);
-		configClientProperties.setConfigClientOauth2Properties(oauth2Properties);
+		configClientProperties.setConfigClientOAuth2Properties(oauth2Properties);
 
 		EncryptorConfig encryptorConfig = binder
 				.bind(EncryptorConfig.PREFIX, Bindable.of(EncryptorConfig.class), bindHandler).orElse(null);

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
@@ -102,13 +102,20 @@ public class ConfigServerConfigDataLocationResolver
 					.orElse("application");
 			configClientProperties.setName(applicationName);
 		}
+		ConfigClientOauth2Properties oauth2Properties = binder
+				.bind(ConfigClientOauth2Properties.PREFIX, Bindable.of(ConfigClientOauth2Properties.class), bindHandler)
+				.orElse(null);
+		configClientProperties.setConfigClientOauth2Properties(oauth2Properties);
+
+		EncryptorConfig encryptorConfig = binder
+				.bind(EncryptorConfig.PREFIX, Bindable.of(EncryptorConfig.class), bindHandler).orElse(null);
+		configClientProperties.setEncryptorConfig(encryptorConfig);
 
 		PropertyHolder holder = new PropertyHolder();
 		holder.properties = configClientProperties;
 		// bind retry, override later
 		holder.retryProperties = binder.bind(RetryProperties.PREFIX, RetryProperties.class)
 				.orElseGet(RetryProperties::new);
-
 		if (StringUtils.hasText(uris)) {
 			String[] uri = StringUtils.commaDelimitedListToStringArray(uris);
 			String paramStr = null;

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/EncryptorConfig.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/EncryptorConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.util.Objects;
+
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEByteEncryptor;
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEStringEncryptor;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.salt.RandomSaltGenerator;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Bruce Randall
+ *
+ */
+@ConfigurationProperties(EncryptorConfig.PREFIX)
+public class EncryptorConfig {
+
+	/**
+	 * Prefix for Spring Cloud Config properties.
+	 */
+	public static final String PREFIX = "spring.cloud.config.encryptor";
+
+	/**
+	 * The Jayspt encryption password System Property.
+	 */
+	public static final String ENCRYPTOR_SYSTEM_PROPERTY = "encryptor-password";
+
+	/**
+	 * The Jayspt Encryptor.
+	 */
+	private StringEncryptor encryptor;
+
+	/**
+	 * The Jasypt encryption algorithm.
+	 */
+	private String encryptorAlgorithm;
+
+	/**
+	 * Encryption iterations. Default = 1000.
+	 */
+	private Integer encryptorIterations;
+
+	public String getEncryptorAlgorithm() {
+		return encryptorAlgorithm;
+	}
+
+	public void setEncryptorAlgorithm(String encryptorAlgorithm) {
+		this.encryptorAlgorithm = encryptorAlgorithm;
+	}
+
+	public Integer getEncryptorIterations() {
+		return encryptorIterations;
+	}
+
+	public void setEncryptorIterations(Integer encryptorIterations) {
+		this.encryptorIterations = encryptorIterations;
+	}
+
+	public StringEncryptor getEncryptor() {
+		if (encryptor == null) {
+			buildEncryptor();
+		}
+		return encryptor;
+	}
+
+	@Override
+	public String toString() {
+		return "EncryptorConfig{" + "encryptorAlgorithm='" + encryptorAlgorithm + '\'' + ", encryptorIterations="
+				+ encryptorIterations + '}';
+	}
+
+	public void buildEncryptor() {
+		SimplePBEByteEncryptor byteEncryptor = new SimplePBEByteEncryptor();
+		byteEncryptor.setPassword(System.getProperty(ENCRYPTOR_SYSTEM_PROPERTY));
+		if (StringUtils.hasText(this.encryptorAlgorithm)) {
+			byteEncryptor.setAlgorithm(this.encryptorAlgorithm);
+		}
+		byteEncryptor.setIterations(Objects.requireNonNullElse(this.encryptorIterations, 1000));
+		byteEncryptor.setSaltGenerator(new RandomSaltGenerator());
+
+		encryptor = new SimplePBEStringEncryptor(byteEncryptor);
+	}
+
+}

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/EncryptorConfig.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/EncryptorConfig.java
@@ -81,6 +81,14 @@ public class EncryptorConfig {
 		return encryptor;
 	}
 
+	public String decryptProperty(String prop) {
+		if (prop.startsWith("ENC(")) {
+			prop = prop.substring(4, prop.lastIndexOf(")"));
+			return getEncryptor().decrypt(prop);
+		}
+		return prop;
+	}
+
 	@Override
 	public String toString() {
 		return "EncryptorConfig{" + "encryptorAlgorithm='" + encryptorAlgorithm + '\'' + ", encryptorIterations="

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
@@ -189,14 +189,14 @@ public class ConfigClientPropertiesTests {
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
 		properties.setUri(new String[] { "https://localhost:8888/" });
 
-		ConfigClientOauth2Properties oauth2Properties = new ConfigClientOauth2Properties();
+		ConfigClientOAuth2Properties oauth2Properties = new ConfigClientOAuth2Properties();
 		oauth2Properties.setTokenUri("http://localhost:9080/realms/test-realm/protocol/openid-connect/token");
 		oauth2Properties.setClientId("clientId");
 		oauth2Properties.setClientSecret("clientSecret");
 		oauth2Properties.setOauthUsername("oauthUsername");
 		oauth2Properties.setOauthPassword("oauthPassword");
 		oauth2Properties.setGrantType("password");
-		properties.setConfigClientOauth2Properties(oauth2Properties);
+		properties.setConfigClientOAuth2Properties(oauth2Properties);
 		EncryptorConfig encryptorConfig = new EncryptorConfig();
 		encryptorConfig.setEncryptorAlgorithm("PBEWITHHMACSHA512ANDAES_256");
 		encryptorConfig.setEncryptorIterations(10000);
@@ -211,7 +211,7 @@ public class ConfigClientPropertiesTests {
 		assertThat(oauth2Properties.getGrantType()).isEqualTo("password");
 		assertThat(encryptorConfig.getEncryptorAlgorithm()).isEqualTo("PBEWITHHMACSHA512ANDAES_256");
 		assertThat(encryptorConfig.getEncryptorIterations()).isEqualTo(10000);
-		assertThat(oauth2Properties.toString()).contains(ConfigClientOauth2Properties.class.getSimpleName());
+		assertThat(oauth2Properties.toString()).contains(ConfigClientOAuth2Properties.class.getSimpleName());
 		assertThat(encryptorConfig.toString()).contains(EncryptorConfig.class.getSimpleName());
 
 		encryptorConfig.setEncryptorAlgorithm(null);

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientPropertiesTests.java
@@ -187,24 +187,36 @@ public class ConfigClientPropertiesTests {
 	@Test
 	void testOauthProperties() {
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
-
 		properties.setUri(new String[] { "https://localhost:8888/" });
-		properties.setTokenUri("http://localhost:9080/realms/test-realm/protocol/openid-connect/token");
-		properties.setClientId("clientId");
-		properties.setClientSecret("clientSecret");
-		properties.setOauthUsername("oauthUsername");
-		properties.setOauthPassword("oauthPassword");
-		properties.setGrantType("password");
-		properties.setEncryptorIterations(10000);
-		assertThat(properties.getTokenUri())
+
+		ConfigClientOauth2Properties oauth2Properties = new ConfigClientOauth2Properties();
+		oauth2Properties.setTokenUri("http://localhost:9080/realms/test-realm/protocol/openid-connect/token");
+		oauth2Properties.setClientId("clientId");
+		oauth2Properties.setClientSecret("clientSecret");
+		oauth2Properties.setOauthUsername("oauthUsername");
+		oauth2Properties.setOauthPassword("oauthPassword");
+		oauth2Properties.setGrantType("password");
+		properties.setConfigClientOauth2Properties(oauth2Properties);
+		EncryptorConfig encryptorConfig = new EncryptorConfig();
+		encryptorConfig.setEncryptorAlgorithm("PBEWITHHMACSHA512ANDAES_256");
+		encryptorConfig.setEncryptorIterations(10000);
+		properties.setEncryptorConfig(encryptorConfig);
+
+		assertThat(oauth2Properties.getTokenUri())
 				.isEqualTo("http://localhost:9080/realms/test-realm/protocol/openid-connect/token");
-		assertThat(properties.getClientId()).isEqualTo("clientId");
-		assertThat(properties.getClientSecret()).isEqualTo("clientSecret");
-		assertThat(properties.getOauthUsername()).isEqualTo("oauthUsername");
-		assertThat(properties.getOauthPassword()).isEqualTo("oauthPassword");
-		assertThat(properties.getGrantType()).isEqualTo("password");
-		assertThat(properties.toString()).contains(ConfigClientProperties.class.getSimpleName());
-		assertThat(properties.getEncryptorIterations()).isEqualTo(10000);
+		assertThat(oauth2Properties.getClientId()).isEqualTo("clientId");
+		assertThat(oauth2Properties.getClientSecret()).isEqualTo("clientSecret");
+		assertThat(oauth2Properties.getOauthUsername()).isEqualTo("oauthUsername");
+		assertThat(oauth2Properties.getOauthPassword()).isEqualTo("oauthPassword");
+		assertThat(oauth2Properties.getGrantType()).isEqualTo("password");
+		assertThat(encryptorConfig.getEncryptorAlgorithm()).isEqualTo("PBEWITHHMACSHA512ANDAES_256");
+		assertThat(encryptorConfig.getEncryptorIterations()).isEqualTo(10000);
+		assertThat(oauth2Properties.toString()).contains(ConfigClientOauth2Properties.class.getSimpleName());
+		assertThat(encryptorConfig.toString()).contains(EncryptorConfig.class.getSimpleName());
+
+		encryptorConfig.setEncryptorAlgorithm(null);
+		encryptorConfig.buildEncryptor();
+		assertThat(encryptorConfig.getEncryptor()).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
@@ -102,12 +102,12 @@ class ConfigClientRequestTemplateFactoryTest {
 	void whenCreate_givenTokenUri_thenGetOAuthToken() {
 		// given
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
-		ConfigClientOauth2Properties oauth2Properties = new ConfigClientOauth2Properties();
+		ConfigClientOAuth2Properties oauth2Properties = new ConfigClientOAuth2Properties();
 		oauth2Properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
 		oauth2Properties.setClientId("clientId");
 		oauth2Properties.setClientSecret("clientSecret");
 		oauth2Properties.setGrantType("client_credentials");
-		properties.setConfigClientOauth2Properties(oauth2Properties);
+		properties.setConfigClientOAuth2Properties(oauth2Properties);
 
 		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
 		Optional<AccessTokenResponse> tokenOpt = ReflectionTestUtils.invokeMethod(templateFactory, "parseTokenResponse",
@@ -142,11 +142,11 @@ class ConfigClientRequestTemplateFactoryTest {
 	void whenCreate_givenNoGrantType_thenIllegalState() {
 		// given
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
-		ConfigClientOauth2Properties oauth2Properties = new ConfigClientOauth2Properties();
+		ConfigClientOAuth2Properties oauth2Properties = new ConfigClientOAuth2Properties();
 		oauth2Properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
 		oauth2Properties.setClientId("clientId");
 		oauth2Properties.setClientSecret("clientSecret");
-		properties.setConfigClientOauth2Properties(oauth2Properties);
+		properties.setConfigClientOAuth2Properties(oauth2Properties);
 
 		// when
 		try {
@@ -164,12 +164,12 @@ class ConfigClientRequestTemplateFactoryTest {
 	void whenCreate_givenBadTokenResponse_thenNoHeaderSet() {
 		// given
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
-		ConfigClientOauth2Properties oauth2Properties = new ConfigClientOauth2Properties();
+		ConfigClientOAuth2Properties oauth2Properties = new ConfigClientOAuth2Properties();
 		oauth2Properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
 		oauth2Properties.setOauthUsername("oauthUsername");
 		oauth2Properties.setOauthPassword("oauthPassword");
 		oauth2Properties.setGrantType("password");
-		properties.setConfigClientOauth2Properties(oauth2Properties);
+		properties.setConfigClientOAuth2Properties(oauth2Properties);
 
 		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
 		mockWebServer.enqueue(new MockResponse().setBody("TOKEN_RESPONSE").setHeader(HttpHeaders.CONTENT_TYPE,
@@ -191,26 +191,26 @@ class ConfigClientRequestTemplateFactoryTest {
 		encryptorConfig.setEncryptorAlgorithm("PBEWITHHMACSHA512ANDAES_256");
 		properties.setEncryptorConfig(encryptorConfig);
 
-		properties.setConfigClientOauth2Properties(new ConfigClientOauth2Properties());
-		properties.getConfigClientOauth2Properties().setGrantType("client_credentials");
-		properties.getConfigClientOauth2Properties()
+		properties.setConfigClientOAuth2Properties(new ConfigClientOAuth2Properties());
+		properties.getConfigClientOAuth2Properties().setGrantType("client_credentials");
+		properties.getConfigClientOAuth2Properties()
 				.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
-		properties.getConfigClientOauth2Properties().setOauthUsername("oauthUsername");
-		properties.getConfigClientOauth2Properties().setOauthPassword("oauthPassword");
+		properties.getConfigClientOAuth2Properties().setOauthUsername("oauthUsername");
+		properties.getConfigClientOAuth2Properties().setOauthPassword("oauthPassword");
 
 		StringEncryptor encryptor = encryptorConfig.getEncryptor();
 		String secret = UUID.randomUUID().toString();
 		String encryptedProp = encryptor.encrypt(secret);
-		properties.getConfigClientOauth2Properties().setClientSecret("ENC(" + encryptedProp + ")");
-		properties.getConfigClientOauth2Properties().setOauthPassword("PLAIN OLD TEXT");
+		properties.getConfigClientOAuth2Properties().setClientSecret("ENC(" + encryptedProp + ")");
+		properties.getConfigClientOAuth2Properties().setOauthPassword("PLAIN OLD TEXT");
 		// when
 
 		String actualSecret = encryptorConfig
-				.decryptProperty(properties.getConfigClientOauth2Properties().getClientSecret());
+				.decryptProperty(properties.getConfigClientOAuth2Properties().getClientSecret());
 
 		// then
 		assertThat(secret).isEqualTo(actualSecret);
-		actualSecret = encryptorConfig.decryptProperty(properties.getConfigClientOauth2Properties().getOauthPassword());
+		actualSecret = encryptorConfig.decryptProperty(properties.getConfigClientOAuth2Properties().getOauthPassword());
 		assertThat("PLAIN OLD TEXT").isEqualTo(actualSecret);
 	}
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.client;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.ulisesbocchio.jasyptspringboot.encryptor.SimplePBEByteEncryptor;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasypt.salt.RandomSaltGenerator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.config.client.ConfigClientProperties.AUTHORIZATION;
+
+/**
+ * @author Bruce Randall
+ *
+ */
+class ConfigClientRequestTemplateFactoryTest {
+
+	private static final Log LOG = LogFactory.getLog(ConfigClientRequestTemplateFactoryTest.class);
+
+	public static MockWebServer mockWebServer;
+
+	private static String idpUrl;
+
+	private static final String TOKEN_RESPONSE = """
+			{"access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJVQ2RaakhjZ0tFU0NFV0w3V1JlMWpnaVRyQVNGbFhndU5CZWVGN1VlUnZJIn0.eyJleHAiOjE3MDE0NDQ2NTcsImlhdCI6MTcwMTQ0NDM1NywianRpIjoiN2IzZTczZTMtZWJlYy00YWE3LWI0MjgtZjRlMmJiYTQxYWNlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo5MDgwL3JlYWxtcy9vc2ludC1yZWFsbSIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiJhN2EyNWZiMC02MzljLTQxYTktYmEwNS04NDlkYTE0Y2NiMzQiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJvc2ludC1rZXljbG9hay1jbGllbnQiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly9sb2NhbGhvc3Q6ODM1MSJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJkZWZhdWx0LXJvbGVzLW9zaW50LXJlYWxtIiwidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJvc2ludC1rZXljbG9hay1jbGllbnQiOnsicm9sZXMiOlsidW1hX3Byb3RlY3Rpb24iLCJtMm0iXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoicHJvZmlsZSBlbWFpbCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiY2xpZW50SG9zdCI6IjE3Mi4xNy4wLjEiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtb3NpbnQta2V5Y2xvYWstY2xpZW50IiwiY2xpZW50QWRkcmVzcyI6IjE3Mi4xNy4wLjEiLCJjbGllbnRfaWQiOiJvc2ludC1rZXljbG9hay1jbGllbnQifQ.AFY1g8_DxAq1eXd-qpJP2PD-8g7-n_gIeScX_ESLWB6UHnZtxe_MvPYvn13X6K4olDsPZ37EGE4-BkdY8pgs-UBCD6EsFD_aZmf9PjZFsHDacAKotcvjsb5U9kqbm0wPuyhrhgSftkrx9AceHe_wETzAPoI775MuyQgSWjihLqLnOZSIMu24t-Ga07Xn0yaOoTD2tS1lfkgXWwRrQF1_KQxHftvJDDhJEN0rfEVJ7SOr9meWH0IQ1w8HgjRFBBkOhtp",
+			"expires_in": 300,
+			"refresh_expires_in": 0,
+			"token_type": "Bearer",
+			"not-before-policy": 0,
+			"scope": "profile email"
+			}""";
+
+	@BeforeAll
+	static void beforeAll() throws IOException {
+		mockWebServer = new MockWebServer();
+		mockWebServer.start();
+		idpUrl = String.format("http://localhost:%s/", mockWebServer.getPort());
+	}
+
+	@AfterAll
+	static void afterAll() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@Test
+	void whenParseTokenResponse_givenValidJson_thenParseToken() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+
+		// when
+		Optional<AccessTokenResponse> tokenOpt = ReflectionTestUtils.invokeMethod(templateFactory, "parseTokenResponse",
+				TOKEN_RESPONSE);
+		// then
+		assertThat(tokenOpt).isPresent();
+		AccessTokenResponse tokenResponse = tokenOpt.get();
+		assertThat(tokenResponse.getAccessToken()).isNotNull();
+		assertThat(tokenResponse.getAccessToken())
+				.startsWith("eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJVQ2RaakhjZ0tFU0NFV0w3V1JlMWpnaVR");
+		assertThat(tokenResponse.getAccessToken()).endsWith("WH0IQ1w8HgjRFBBkOhtp");
+		assertThat(tokenResponse.getTokenType()).isNotNull();
+		assertThat(tokenResponse.getTokenType()).isEqualTo("Bearer");
+		assertThat(tokenResponse.getBearerHeader())
+				.isEqualTo(tokenResponse.getTokenType() + " " + tokenResponse.getAccessToken());
+		assertThat(templateFactory.getLog()).isNotNull();
+		assertThat(templateFactory.getProperties()).isNotNull();
+	}
+
+	@Test
+	void whenCreate_givenTokenUri_thenGetOAuthToken() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
+		properties.setClientId("clientId");
+		properties.setClientSecret("clientSecret");
+		properties.setGrantType("client_credentials");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		Optional<AccessTokenResponse> tokenOpt = ReflectionTestUtils.invokeMethod(templateFactory, "parseTokenResponse",
+				TOKEN_RESPONSE);
+		assertThat(tokenOpt).isPresent();
+		AccessTokenResponse tokenResponse = tokenOpt.get();
+		mockWebServer.enqueue(new MockResponse().setBody(TOKEN_RESPONSE).setHeader(HttpHeaders.CONTENT_TYPE,
+				MediaType.APPLICATION_JSON_VALUE));
+		// when
+		RestTemplate restTemplate = templateFactory.create();
+		List<ClientHttpRequestInterceptor> interceptors = List
+				.of(new ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor(properties.getHeaders()));
+		restTemplate.setInterceptors(interceptors);
+
+		// then
+		assertThat(restTemplate).isNotNull();
+		assertThat(restTemplate.getInterceptors()).isNotNull();
+		assertThat(restTemplate.getInterceptors()).isNotEmpty();
+		ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor genericInterceptor = (ConfigClientRequestTemplateFactory.GenericRequestHeaderInterceptor) restTemplate
+				.getInterceptors().get(0);
+		assertThat(genericInterceptor.getHeaders()).isNotNull();
+		assertThat(properties.getHeaders()).isNotNull();
+		assertThat(properties.getHeaders()).isNotEmpty();
+		String header = properties.getHeaders().get(AUTHORIZATION);
+		assertThat(header).isEqualTo(tokenResponse.getTokenType() + " " + tokenResponse.getAccessToken());
+		assertThat(genericInterceptor.getHeaders().get(AUTHORIZATION))
+				.isEqualTo(properties.getHeaders().get(AUTHORIZATION));
+
+	}
+
+	@Test
+	void whenCreate_givenBadTokenResponse_thenNoHeaderSet() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
+		properties.setOauthUsername("oauthUsername");
+		properties.setOauthPassword("oauthPassword");
+		properties.setGrantType("password");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		mockWebServer.enqueue(new MockResponse().setBody("TOKEN_RESPONSE").setHeader(HttpHeaders.CONTENT_TYPE,
+				MediaType.APPLICATION_JSON_VALUE));
+
+		// when
+		templateFactory.create();
+
+		// then
+		assertThat(properties.getHeaders()).isNotNull();
+	}
+
+	@Test
+	void whenDecryptProperty_givenEncryptedProp_thenDecryptProp() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setEncryptorAlgorithm("PBEWITHHMACSHA512ANDAES_256");
+		System.setProperty("encryptor-password", "YaddaYaddaYadda");
+		SimplePBEByteEncryptor encryptor = buildEncryptor(properties);
+		String secret = UUID.randomUUID().toString();
+		String encryptedProp = new String(
+				Base64.getEncoder().encode(encryptor.encrypt(secret.getBytes(StandardCharsets.UTF_8))));
+		properties.setClientSecret("ENC(" + encryptedProp + ")");
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		// when
+		templateFactory.create();
+		String actualSecret = ReflectionTestUtils.invokeMethod(templateFactory, "decryptProperty",
+				properties.getClientSecret());
+
+		// then
+		assertThat(secret).isEqualTo(actualSecret);
+	}
+
+	private SimplePBEByteEncryptor buildEncryptor(ConfigClientProperties properties) {
+		SimplePBEByteEncryptor byteEncryptor = new SimplePBEByteEncryptor();
+		byteEncryptor.setPassword(System.getProperty("encryptor-password"));
+		byteEncryptor.setSaltGenerator(new RandomSaltGenerator());
+		byteEncryptor.setIterations(1000);
+		if (StringUtils.hasText(properties.getEncryptorAlgorithm())) {
+			byteEncryptor.setAlgorithm(properties.getEncryptorAlgorithm());
+		}
+		return byteEncryptor;
+	}
+
+}

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
@@ -211,7 +211,7 @@ class ConfigClientRequestTemplateFactoryTest {
 		// then
 		assertThat(secret).isEqualTo(actualSecret);
 		actualSecret = encryptorConfig.decryptProperty(properties.getConfigClientOAuth2Properties().getOauthPassword());
-		assertThat("PLAIN OLD TEXT").isEqualTo(actualSecret);
+		assertThat(actualSecret).isEqualTo("PLAIN OLD TEXT");
 	}
 
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigClientRequestTemplateFactoryTest.java
@@ -78,6 +78,25 @@ class ConfigClientRequestTemplateFactoryTest {
 	}
 
 	@Test
+	void whenGetOAuthToken_givenNoGrant_thenThrowExeption() {
+		// given
+		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());
+		properties.setTokenUri(idpUrl + "/realms/test-realm/protocol/openid-connect/token");
+		properties.setOauthUsername("oauthUsername");
+		properties.setOauthPassword("oauthPassword");
+		properties.setGrantType(null);
+		ConfigClientRequestTemplateFactory templateFactory = new ConfigClientRequestTemplateFactory(LOG, properties);
+		try {
+			// when
+			templateFactory.create();
+		}
+		catch (IllegalStateException e) {
+			// then
+			assertThat(e.getMessage()).startsWith("Grant type is required for OAuth2 requests.");
+		}
+	}
+
+	@Test
 	void whenParseTokenResponse_givenValidJson_thenParseToken() {
 		// given
 		ConfigClientProperties properties = new ConfigClientProperties(new MockEnvironment());

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -19,11 +19,14 @@ package org.springframework.cloud.config.client;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -689,6 +692,74 @@ public class ConfigServerConfigDataLoaderTests {
 
 		when(request.getHeaders()).thenReturn(new HttpHeaders());
 		when(request.execute()).thenThrow(IOException.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenOauth_thenAddInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		Map<String, String> tokenHeader = new HashMap<>();
+		tokenHeader.put(AUTHORIZATION, "Bearer " + UUID.randomUUID().toString());
+		properties.setHeaders(tokenHeader);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), null);
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(1)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenOauthNoToken_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		properties.setSendState(false);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenBasicAuth_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void whenRemoteEnvironment_givenBasicAuthToken_thenNoInterceptor() {
+		Environment body = new Environment("test", "local");
+		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setLabel(null);
+		properties.setToken("Basic "
+				+ Arrays.toString(Base64.getEncoder().encode("YaddaYaddaYadda".getBytes(StandardCharsets.UTF_8))));
+		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
+
+		Mockito.verify(this.restTemplate).exchange(anyString(), any(HttpMethod.class),
+				httpEntityArgumentCaptor.capture(), any(Class.class), anyString(), anyString());
+
+		Mockito.verify(this.restTemplate, Mockito.times(0)).setInterceptors(any());
+
 	}
 
 }

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -700,8 +700,8 @@ public class ConfigServerConfigDataLoaderTests {
 		Environment body = new Environment("test", "local");
 		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
 		properties.setLabel(null);
-		properties.setConfigClientOauth2Properties(new ConfigClientOauth2Properties());
-		properties.getConfigClientOauth2Properties()
+		properties.setConfigClientOAuth2Properties(new ConfigClientOAuth2Properties());
+		properties.getConfigClientOAuth2Properties()
 				.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
 		Map<String, String> tokenHeader = new HashMap<>();
 		tokenHeader.put(AUTHORIZATION, "Bearer " + UUID.randomUUID().toString());
@@ -720,9 +720,9 @@ public class ConfigServerConfigDataLoaderTests {
 	void whenRemoteEnvironment_givenOauthNoToken_thenNoInterceptor() {
 		Environment body = new Environment("test", "local");
 		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
-		properties.setConfigClientOauth2Properties(new ConfigClientOauth2Properties());
+		properties.setConfigClientOAuth2Properties(new ConfigClientOAuth2Properties());
 		properties.setLabel(null);
-		properties.getConfigClientOauth2Properties()
+		properties.getConfigClientOAuth2Properties()
 				.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
 		properties.setSendState(false);
 		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -700,7 +700,9 @@ public class ConfigServerConfigDataLoaderTests {
 		Environment body = new Environment("test", "local");
 		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
 		properties.setLabel(null);
-		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		properties.setConfigClientOauth2Properties(new ConfigClientOauth2Properties());
+		properties.getConfigClientOauth2Properties()
+				.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
 		Map<String, String> tokenHeader = new HashMap<>();
 		tokenHeader.put(AUTHORIZATION, "Bearer " + UUID.randomUUID().toString());
 		properties.setHeaders(tokenHeader);
@@ -718,8 +720,10 @@ public class ConfigServerConfigDataLoaderTests {
 	void whenRemoteEnvironment_givenOauthNoToken_thenNoInterceptor() {
 		Environment body = new Environment("test", "local");
 		mockRequestResponseWithoutLabel(new ResponseEntity<>(body, HttpStatus.OK));
+		properties.setConfigClientOauth2Properties(new ConfigClientOauth2Properties());
 		properties.setLabel(null);
-		properties.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
+		properties.getConfigClientOauth2Properties()
+				.setTokenUri("http://localhost:9999/realms/test-realm/protocol/openid-connect/token");
 		properties.setSendState(false);
 		this.loader.getRemoteEnvironment(context, resource, properties.getLabel(), "stale");
 

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolverTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolverTests.java
@@ -183,6 +183,7 @@ public class ConfigServerConfigDataLocationResolverTests {
 		verify(bootstrapContext, times(0)).get(eq(ConfigClientProperties.class));
 		ConfigServerConfigDataResource resource = resources.get(0);
 		assertThat(resource.getProperties().getUri()).isEqualTo(new String[] { "http://locationuri" });
+		assertThat(resource.getLog()).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -88,9 +88,11 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 	private final AwsSecretsManagerEnvironmentRepository labeledRepository = new AwsSecretsManagerEnvironmentRepository(
 			smClient, configServerProperties, labeledEnvironmentProperties);
 
-	private final AwsSecretsManagerEnvironmentProperties ignoreLabelEnvironmentProperties = new AwsSecretsManagerEnvironmentProperties() {{
-		setIgnoreLabel(true);
-	}};
+	private final AwsSecretsManagerEnvironmentProperties ignoreLabelEnvironmentProperties = new AwsSecretsManagerEnvironmentProperties() {
+		{
+			setIgnoreLabel(true);
+		}
+	};
 
 	private final AwsSecretsManagerEnvironmentRepository ignoreLabelRepository = new AwsSecretsManagerEnvironmentRepository(
 			smClient, configServerProperties, ignoreLabelEnvironmentProperties);
@@ -1849,24 +1851,23 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 
 		String fooDefaultPropertiesName = "aws:secrets:/secret/foo-default/";
 		PropertySource fooDefaultProperties = new PropertySource(fooDefaultPropertiesName,
-			getFooDefaultReleaseProperties());
+				getFooDefaultReleaseProperties());
 
 		String applicationProdPropertiesName = "aws:secrets:/secret/application-prod/";
 		PropertySource applicationProdProperties = new PropertySource(applicationProdPropertiesName,
-			getApplicationProdReleaseProperties());
+				getApplicationProdReleaseProperties());
 
 		String applicationDefaultPropertiesName = "aws:secrets:/secret/application-default/";
 		PropertySource applicationDefaultProperties = new PropertySource(applicationDefaultPropertiesName,
-			getApplicationDefaultReleaseProperties());
+				getApplicationDefaultReleaseProperties());
 
 		String applicationPropertiesName = "aws:secrets:/secret/application/";
 		PropertySource applicationProperties = new PropertySource(applicationPropertiesName,
-			getApplicationReleaseProperties());
+				getApplicationReleaseProperties());
 
 		Environment expectedEnv = new Environment(application, profiles, null, null, null);
-		expectedEnv.addAll(Arrays.asList(
-			fooProdProperties, applicationProdProperties, fooDefaultProperties,
-			applicationDefaultProperties, fooProperties, applicationProperties));
+		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooDefaultProperties,
+				applicationDefaultProperties, fooProperties, applicationProperties));
 
 		putSecrets(expectedEnv);
 


### PR DESCRIPTION
- When OAuth2 token property present, call IDP for Bearer Token.
- Add Bearer Token header on config server resource requests.
- Replace deprecated Base64Utils

