### PR TITLE
Fix link to observability page

### DIFF
--- a/docs/modules/ROOT/pages/client.adoc
+++ b/docs/modules/ROOT/pages/client.adoc
@@ -347,5 +347,5 @@ ifndef::releaseTrain[]
 [[appendix]]
 == Appendices
 
-include:../:_observability.adoc[]
+include::observability.adoc[]
 endif::[]


### PR DESCRIPTION
In order to fix the broken link seen on https://docs.spring.io/spring-cloud-config/reference/client.html#appendix.