### PR TITLE
Ensure last-wins profile order is respected for AWS Parameter Store and Secrets Manager

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepository.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.config.server.environment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -90,7 +91,9 @@ public class AwsParameterStoreEnvironmentRepository implements EnvironmentReposi
 		String profileSeparator = environmentProperties.getProfileSeparator();
 		String defaultProfile = configServerProperties.getDefaultProfile();
 
-		List<String> orderedProfiles = Stream.concat(Arrays.stream(profiles).filter(p -> !p.equals(defaultProfile)),
+		List<String> reversedProfiles = new ArrayList<>(Arrays.asList(profiles));
+		Collections.reverse(reversedProfiles);
+		List<String> orderedProfiles = Stream.concat(reversedProfiles.stream().filter(p -> !p.equals(defaultProfile)),
 				Arrays.stream(new String[] { defaultProfile })).collect(Collectors.toList());
 
 		if (application.equals(defaultApplication)) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -17,8 +17,11 @@
 package org.springframework.cloud.config.server.environment;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -98,7 +101,9 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 			environment.add(new PropertySource("overrides", overrides));
 		}
 
-		for (String profile : profiles) {
+		List<String> reversedProfiles = new ArrayList<>(Arrays.asList(profiles));
+		Collections.reverse(reversedProfiles);
+		for (String profile : reversedProfiles) {
 			addPropertySource(environment, application, profile, label);
 			if (!defaultApplication.equals(application)) {
 				addPropertySource(environment, defaultApplication, profile, label);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsParameterStoreEnvironmentRepositoryTests.java
@@ -560,6 +560,35 @@ public class AwsParameterStoreEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void testFindOneWithExistentApplicationAndMultipleOrderedExistentProfiles() {
+		// Arrange
+		String application = "application";
+		String profile = "profile1,profile2,profile3";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String profile1ParamsPsName = "aws:ssm:parameter:/config/application-profile1/";
+		PropertySource profile1ParamsPs = new PropertySource(profile1ParamsPsName, SHARED_PROPERTIES);
+
+		String profile2ParamsPsName = "aws:ssm:parameter:/config/application-profile2/";
+		PropertySource profile2ParamsPs = new PropertySource(profile2ParamsPsName, SHARED_DEFAULT_PROPERTIES);
+
+		String profile3ParamsPsName = "aws:ssm:parameter:/config/application-profile3/";
+		PropertySource profile3ParamsPs = new PropertySource(profile3ParamsPsName, SHARED_PRODUCTION_PROPERTIES);
+
+		Environment expected = new Environment(application, profiles, null, null, null);
+
+		expected.addAll(Arrays.asList(profile3ParamsPs, profile2ParamsPs, profile1ParamsPs));
+
+		putParameters(expected);
+
+		// Act
+		Environment result = repository.findOne(application, profile, null);
+
+		// Assert
+		assertThat(result).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(expected);
+	}
+
+	@Test
 	public void testFindOneWithOverrides() {
 		// Arrange
 		String application = configServerProperties.getDefaultApplicationName();

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepositoryTests.java
@@ -809,8 +809,8 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastProperties());
 
 		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
+		expectedEnv.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
 				applicationProperties));
 
 		putSecrets(expectedEnv);
@@ -849,8 +849,8 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastProperties());
 
 		Environment expectedEnv = new Environment(application, profiles, defaultLabel, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooProperties, applicationProperties));
+		expectedEnv.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooProperties, applicationProperties));
 
 		putSecrets(expectedEnv);
 
@@ -1786,8 +1786,8 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastReleaseProperties());
 
 		Environment expectedEnv = new Environment(application, profiles, label, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
+		expectedEnv.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
 				applicationProperties));
 
 		putSecrets(expectedEnv);
@@ -1826,8 +1826,8 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastReleaseProperties());
 
 		Environment expectedEnv = new Environment(application, profiles, label, null, null);
-		expectedEnv.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooProperties, applicationProperties));
+		expectedEnv.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooProperties, applicationProperties));
 
 		putSecrets(expectedEnv);
 
@@ -2461,8 +2461,8 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastProperties());
 
 		Environment environment = new Environment(application, profiles, null, null, null);
-		environment.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
+		environment.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooDefaultProperties, applicationDefaultProperties, fooProperties,
 				applicationProperties));
 
 		putSecrets(environment);
@@ -2500,8 +2500,33 @@ public class AwsSecretsManagerEnvironmentRepositoryTests {
 				getApplicationEastProperties());
 
 		Environment environment = new Environment(application, profiles, null, null, null);
-		environment.addAll(Arrays.asList(fooProdProperties, applicationProdProperties, fooEastProperties,
-				applicationEastProperties, fooProperties, applicationProperties));
+		environment.addAll(Arrays.asList(fooEastProperties, applicationEastProperties, fooProdProperties,
+				applicationProdProperties, fooProperties, applicationProperties));
+
+		putSecrets(environment);
+
+		Environment resultEnv = repository.findOne(application, profile, null);
+
+		assertThat(resultEnv).usingRecursiveComparison().withStrictTypeChecking().isEqualTo(environment);
+	}
+
+	@Test
+	public void testFindOneWithExistingApplicationAndOrderedMultipleExistingProfileAndNoDefaults() {
+		String application = "foo";
+		String profile = "profile1,profile2,profile3";
+		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
+
+		String fooProfile1PropertiesName = "aws:secrets:/secret/foo-profile1/";
+		PropertySource fooProfile1Properties = new PropertySource(fooProfile1PropertiesName, getFooDefaultProperties());
+
+		String fooProfile2PropertiesName = "aws:secrets:/secret/foo-profile2/";
+		PropertySource fooProfile2Properties = new PropertySource(fooProfile2PropertiesName, getFooEastProperties());
+
+		String fooProfile3PropertiesName = "aws:secrets:/secret/foo-profile3/";
+		PropertySource fooProfile3Properties = new PropertySource(fooProfile3PropertiesName, getFooProdProperties());
+
+		Environment environment = new Environment(application, profiles, null, null, null);
+		environment.addAll(Arrays.asList(fooProfile3Properties, fooProfile2Properties, fooProfile1Properties));
 
 		putSecrets(environment);
 


### PR DESCRIPTION
Fixes #2385

Note, for Secrets Manager this fix breaks existing tests, which I have corrected.  I don't think the existing tests assert the correct expected profile order, so these have been updated to reflect the changed logic.  However I don't know if this counts as a breaking change?

Also, I would be very grateful, if this is accepted, if it could be backported to the 4.0.x branch as this is the version we are currently using and where it affects us.