### PR TITLE
feat(config-server): add MongoDB environment repository support

### DIFF
--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -152,6 +152,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -68,6 +68,9 @@ import org.springframework.cloud.config.server.environment.HttpRequestConfigToke
 import org.springframework.cloud.config.server.environment.JdbcEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.JdbcEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.JdbcEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.MongoDbEnvironmentRepository;
+import org.springframework.cloud.config.server.environment.MongoDbEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.MongoEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.MultipleJGitEnvironmentRepositoryFactory;
@@ -98,6 +101,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.credhub.core.CredHubOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.vault.core.VaultTemplate;
@@ -117,13 +121,14 @@ import org.springframework.vault.core.VaultTemplate;
 		JdbcEnvironmentProperties.class, NativeEnvironmentProperties.class, VaultEnvironmentProperties.class,
 		RedisEnvironmentProperties.class, AwsS3EnvironmentProperties.class,
 		AwsSecretsManagerEnvironmentProperties.class, AwsParameterStoreEnvironmentProperties.class,
-		GoogleSecretManagerEnvironmentProperties.class })
+		GoogleSecretManagerEnvironmentProperties.class, MongoEnvironmentProperties.class })
 @Import({ CompositeRepositoryConfiguration.class, JdbcRepositoryConfiguration.class, VaultConfiguration.class,
 		VaultRepositoryConfiguration.class, SpringVaultRepositoryConfiguration.class, CredhubConfiguration.class,
 		CredhubRepositoryConfiguration.class, SvnRepositoryConfiguration.class, NativeRepositoryConfiguration.class,
 		GitRepositoryConfiguration.class, RedisRepositoryConfiguration.class, GoogleCloudSourceConfiguration.class,
 		AwsS3RepositoryConfiguration.class, AwsSecretsManagerRepositoryConfiguration.class,
 		AwsParameterStoreRepositoryConfiguration.class, GoogleSecretManagerRepositoryConfiguration.class,
+		MongoRepositoryConfiguration.class,
 		// DefaultRepositoryConfiguration must be last
 		DefaultRepositoryConfiguration.class })
 public class EnvironmentRepositoryConfiguration {
@@ -376,6 +381,18 @@ public class EnvironmentRepositoryConfiguration {
 
 	}
 
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(MongoTemplate.class)
+	@ConditionalOnProperty(value = "spring.cloud.config.server.mongodb.enabled", matchIfMissing = true)
+	static class MongoDbFactoryConfig {
+
+		@Bean
+		@ConditionalOnBean(MongoTemplate.class)
+		public MongoDbEnvironmentRepositoryFactory mongoDbEnvironmentRepositoryFactory(MongoTemplate mongoTemplate) {
+			return new MongoDbEnvironmentRepositoryFactory(mongoTemplate);
+		}
+	}
+
 }
 
 @Configuration(proxyBeanMethods = false)
@@ -576,4 +593,18 @@ class GoogleSecretManagerRepositoryConfiguration {
 		return factory.build(environmentProperties);
 	}
 
+}
+
+@Configuration(proxyBeanMethods = false)
+@Profile("mongodb")
+@ConditionalOnClass(MongoTemplate.class)
+@ConditionalOnProperty(value = "spring.cloud.config.server.mongodb.enabled", matchIfMissing = true)
+class MongoRepositoryConfiguration {
+
+	@Bean
+	@ConditionalOnBean(MongoTemplate.class)
+	public MongoDbEnvironmentRepository mongoDbEnvironmentRepository(MongoDbEnvironmentRepositoryFactory factory,
+																	 MongoEnvironmentProperties environmentProperties) {
+		return factory.build(environmentProperties);
+	}
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepository.java
@@ -1,0 +1,72 @@
+package org.springframework.cloud.config.server.environment;
+
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.core.Ordered;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+public class MongoDbEnvironmentRepository implements EnvironmentRepository, Ordered {
+
+	private static final Logger logger = LoggerFactory.getLogger(MongoDbEnvironmentRepository.class);
+
+	private final MongoTemplate mongoTemplate;
+	private final MongoEnvironmentProperties properties;
+
+	public MongoDbEnvironmentRepository(MongoTemplate mongoTemplate, MongoEnvironmentProperties properties) {
+		this.mongoTemplate = mongoTemplate;
+		this.properties = properties;
+	}
+
+	@Override
+	public Environment findOne(String application, String profile, String label) {
+		String config = application;
+		if (profile == null || profile.isEmpty()) {
+			profile = "default";
+		}
+		if (label == null || label.isEmpty()) {
+			label = this.properties.getDefaultLabel();
+		}
+
+		Environment environment = new Environment(application, new String[] {profile}, label, null, null);
+		addPropertySource(environment, application, profile, label);
+		return environment;
+	}
+
+	private void addPropertySource(Environment environment, String application, String profile, String label) {
+		try {
+			Query query = new Query(Criteria.where("application").is(application)
+				.and("profile").is(profile)
+				.and("label").is(label));
+			List<Map> propertyMaps = this.mongoTemplate.find(query, Map.class, this.properties.getCollection());
+
+			for (Map propertyMap : propertyMaps) {
+				String propertySourceName = application + "-" + profile;
+				@SuppressWarnings("unchecked")
+				Map<String, Object> source = (Map<String, Object>) propertyMap.get("properties");
+				if (source != null && !source.isEmpty()) {
+					environment.add(new PropertySource(propertySourceName, source));
+				}
+			}
+		} catch (DataAccessException e) {
+			if (!this.properties.isFailOnError()) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Failed to retrieve configuration from MongoDB", e);
+				}
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	@Override
+	public int getOrder() {
+		return this.properties.getOrder();
+	}
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepositoryFactory.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.config.server.environment;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * Factory for creating instances of MongoDbEnvironmentRepository.
+ */
+public class MongoDbEnvironmentRepositoryFactory
+	implements EnvironmentRepositoryFactory<MongoDbEnvironmentRepository, MongoEnvironmentProperties> {
+
+	private final MongoTemplate mongoTemplate;
+
+	public MongoDbEnvironmentRepositoryFactory(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Override
+	public MongoDbEnvironmentRepository build(MongoEnvironmentProperties environmentProperties) {
+		return new MongoDbEnvironmentRepository(this.mongoTemplate, environmentProperties);
+	}
+}
+

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/MongoEnvironmentProperties.java
@@ -1,0 +1,80 @@
+package org.springframework.cloud.config.server.environment;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
+import org.springframework.core.Ordered;
+
+/**
+ * Properties related to MongoDB environment repository.
+ * @author Alexandros Pappas
+ */
+@ConfigurationProperties("spring.cloud.config.server.mongodb")
+public class MongoEnvironmentProperties implements EnvironmentRepositoryProperties {
+
+	/**
+	 * Flag to indicate that MongoDB environment repository configuration is enabled.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Order of the MongoDB environment repository.
+	 */
+	private int order = Ordered.LOWEST_PRECEDENCE - 10;
+
+	/**
+	 * Name of the MongoDB collection to query for configuration properties.
+	 */
+	private String collection = "properties";
+
+	/**
+	 * Flag to determine how to handle query exceptions.
+	 */
+	private boolean failOnError = true;
+
+	/**
+	 * Default label to use if none is specified.
+	 */
+	private String defaultLabel = "master";
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+
+	@Override
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	public String getCollection() {
+		return collection;
+	}
+
+	public void setCollection(String collection) {
+		this.collection = collection;
+	}
+
+	public boolean isFailOnError() {
+		return failOnError;
+	}
+
+	public void setFailOnError(boolean failOnError) {
+		this.failOnError = failOnError;
+	}
+
+	public String getDefaultLabel() {
+		return defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
+	}
+}
+

--- a/spring-cloud-config-server/src/main/resources/configserver.yml
+++ b/spring-cloud-config-server/src/main/resources/configserver.yml
@@ -4,7 +4,10 @@ info:
 spring:
   application:
     name: configserver
-  autoconfigure.exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
   jmx:
     default_domain: cloud.config.server
   cloud:


### PR DESCRIPTION
This commit introduces MongoDB as a new backend option for the Spring Cloud Config Server, enabling users to store and manage their configuration properties in a MongoDB database.