### PR TITLE
docs: add Custom Environment Repositories and update config sharing

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 *** xref:server/environment-repository/aws-secrets-manager-backend.adoc[]
 *** xref:server/environment-repository/credhub-backend.adoc[]
 *** xref:server/environment-repository/composite-repositories.adoc[]
+*** xref:server/environment-repository/custom-enviroment-repository.adoc[]
 *** xref:server/environment-repository/property-overrides.adoc[]
 *** xref:server/environment-repository/using-bootstrap-to-override-properties.adoc[]
 *** xref:server/environment-repository/overriding-properties-using-placeholders.adoc[]

--- a/docs/modules/ROOT/pages/server/environment-repository/custom-enviroment-repository.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/custom-enviroment-repository.adoc
@@ -29,6 +29,7 @@ public class CustomConfigurationRepository implements EnvironmentRepository, Ord
 }
 
 @Configuration
+@Profile("custom")
 public class AppConfig {
     @Bean
     public CustomConfigurationRepository customConfigurationRepository() {

--- a/docs/modules/ROOT/pages/server/environment-repository/custom-enviroment-repository.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/custom-enviroment-repository.adoc
@@ -1,0 +1,73 @@
+[[custom-environment-repositories]]
+= Custom Environment Repositories
+
+Spring Cloud Config supports enhancing its configuration management by allowing you to create and integrate custom EnvironmentRepository implementations. This enables the addition of unique configuration sources to your application. Implementing the Ordered interface and specifying the getOrder method also lets you set the priority of your custom repository within a composite configuration setup. Without this, custom repositories are considered with the lowest priority by default.
+
+Below is an example of how to create and configure a custom `EnvironmentRepository`:
+
+[source,java]
+----
+public class CustomConfigurationRepository implements EnvironmentRepository, Ordered {
+
+    @Override
+    public Environment findOne(String application, String profile, String label) {
+        // Simulate fetching configuration from a custom source
+        final Map<String, String> properties = Map.of(
+            "key1", "value1",
+            "key2", "value2",
+            "key3", "value3"
+        );
+        Environment environment = new Environment(application, profile);
+        environment.add(new PropertySource("customPropertySource", properties));
+        return environment;
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public CustomConfigurationRepository customConfigurationRepository() {
+        return new CustomConfigurationRepository();
+    }
+}
+----
+
+With this setup, if you activate the `custom` profile within your Spring application's configuration, your custom environment repository will be integrated into the configuration server. For instance, specifying the `custom` profile in your `application.properties` or `application.yml` as follows:
+
+[source,yaml]
+----
+spring:
+  application:
+    name: configserver
+  profiles:
+    active: custom
+----
+
+Now, accessing the configuration server at:
+----
+http://localhost:8080/any-client/dev/latest
+----
+will return default values from the custom repository, as shown below:
+[source,json]
+----
+{
+  "name": "any-client",
+  "profiles": ["dev"],
+  "label": "latest",
+  "propertySources": [
+    {
+      "name": "customPropertySource",
+      "source": {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": "value3"
+      }
+    }
+  ]
+}
+----

--- a/docs/modules/ROOT/pages/server/environment-repository/sharing-configuration-with-all-applications.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/sharing-configuration-with-all-applications.adoc
@@ -5,6 +5,8 @@ Sharing configuration between all applications varies according to which approac
 
 * xref:server/environment-repository/sharing-configuration-with-all-applications.adoc#spring-cloud-config-server-file-based-repositories[File Based Repositories]
 * xref:server/environment-repository/sharing-configuration-with-all-applications.adoc#spring-cloud-config-server-vault-server[Vault Server]
+* xref:server/environment-repository/sharing-configuration-with-all-applications.adoc#credhub-server[CredHub Server]
+* xref:server/environment-repository/sharing-configuration-with-all-applications.adoc#spring-cloud-config-server-jdbc[JDBC Repository]
 
 [[spring-cloud-config-server-file-based-repositories]]
 == File Based Repositories
@@ -47,3 +49,17 @@ credhub set --name "/my-app/default/master/more-shared" --type=json
 value: {"shared.word1": "hello", "shared.word2": "world"}
 ----
 
+[[spring-cloud-config-server-jdbc]]
+== JDBC Environment Repository
+
+To share configurations using the JDBC backend, insert records into your database with `'application'` as the value in the application column for entries intended to be shared across all clients. Application-specific properties can then override these shared configurations, providing flexibility and control over your application environments.
+
+[source,sql]
+----
+INSERT INTO PROPERTIES (APPLICATION, PROFILE, LABEL, KEY, VALUE)
+VALUES ('application', 'default', 'master', 'a.b.c', 'shared-value');
+INSERT INTO PROPERTIES (APPLICATION, PROFILE, LABEL, KEY, VALUE)
+VALUES ('myapp', 'prod', 'master', 'd.e.f', 'specific-value');
+----
+
+Refer to the `JdbcEnvironmentRepository` implementation and associated tests for detailed examples on setup and configuration management using the JDBC repository.


### PR DESCRIPTION
Introduce a new section for "Custom Environment Repositories" to guide users in creating and integrating custom `EnvironmentRepository` implementations. Additionally, update the "Sharing Configuration With All Applications" section.