### PR TITLE
fix: allow negative value for jgit environment to disable refresh

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/git-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/git-backend.adoc
@@ -443,7 +443,7 @@ You can control how often the config server will fetch updated configuration dat
 from your Git backend by using `spring.cloud.config.server.git.refreshRate`.  The
 value of this property is specified in seconds.  By default the value is 0, meaning
 the config server will fetch updated configuration from the Git repo every time it
-is requested.
+is requested. If the value is a negative number the refresh will not occur.
 
 [[default-label]]
 == Default Label

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -470,7 +470,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 	protected boolean shouldPull(Git git) throws GitAPIException {
 		boolean shouldPull;
 
-		if (this.refreshRate > 0 && System.currentTimeMillis() - this.lastRefresh < (this.refreshRate * 1000)) {
+		if (this.refreshRate < 0 || (this.refreshRate > 0 && System.currentTimeMillis() - this.lastRefresh < (this.refreshRate * 1000))) {
 			return false;
 		}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepositoryTests.java
@@ -524,6 +524,32 @@ public class JGitEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void shouldNotRefreshWhenNegativeValue() throws Exception {
+		Git git = mock(Git.class);
+		StatusCommand statusCommand = mock(StatusCommand.class);
+		Status status = mock(Status.class);
+		Repository repository = mock(Repository.class);
+		StoredConfig storedConfig = mock(StoredConfig.class);
+
+		when(git.status()).thenReturn(statusCommand);
+		when(git.getRepository()).thenReturn(repository);
+		when(repository.getConfig()).thenReturn(storedConfig);
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(statusCommand.call()).thenReturn(status);
+		when(status.isClean()).thenReturn(true);
+
+		JGitEnvironmentProperties properties = new JGitEnvironmentProperties();
+		properties.setRefreshRate(-1);
+
+		JGitEnvironmentRepository repo = new JGitEnvironmentRepository(this.environment, properties,
+			ObservationRegistry.NOOP);
+
+		boolean shouldPull = repo.shouldPull(git);
+
+		assertThat(shouldPull).as("shouldPull was true").isFalse();
+	}
+
+	@Test
 	public void shouldUpdateLastRefresh() throws Exception {
 		Git git = mock(Git.class);
 		StatusCommand statusCommand = mock(StatusCommand.class);


### PR DESCRIPTION
Modify `JGitEnvironmentRepository` to return `false` on `shouldPull` method when `refreshRate` is a negative value

Fixes gh-2256