### PR TITLE
fix: configure ssh connect timeout value

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/FileBasedSshSessionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/FileBasedSshSessionFactory.java
@@ -52,6 +52,8 @@ public class FileBasedSshSessionFactory extends SshdSessionFactory {
 				hostEntry.setValue(SshConstants.STRICT_HOST_KEY_CHECKING,
 						sshProperties.isStrictHostKeyChecking() ? SshConstants.YES : SshConstants.NO);
 
+				hostEntry.setValue(SshConstants.CONNECT_TIMEOUT, String.valueOf(sshProperties.getTimeout()));
+
 				return hostEntry;
 			}
 		};

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactory.java
@@ -97,6 +97,8 @@ public class PropertyBasedSshSessionFactory extends SshdSessionFactory {
 			private OpenSshConfigFile.HostEntry updateIfNeeded(OpenSshConfigFile.HostEntry hostEntry, String hostName) {
 				JGitEnvironmentProperties sshProperties = sshKeysByHostname.get(hostName);
 
+				hostEntry.setValue(SshConstants.CONNECT_TIMEOUT, String.valueOf(sshProperties.getTimeout()));
+
 				if (sshProperties.getHostKey() == null || !sshProperties.isStrictHostKeyChecking()) {
 					hostEntry.setValue(SshConstants.STRICT_HOST_KEY_CHECKING, SshConstants.NO);
 				}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/FileBasedSshSessionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/FileBasedSshSessionFactoryTest.java
@@ -82,6 +82,17 @@ public class FileBasedSshSessionFactoryTest {
 		assertThat(configStore).isNull();
 	}
 
+	@Test
+	public void connectTimeoutIsUsed() {
+		JGitEnvironmentProperties sshKey = new JGitEnvironmentProperties();
+		sshKey.setUri("ssh://gitlab.example.local:3322/somerepo.git");
+		setupSessionFactory(sshKey);
+
+		SshConfigStore.HostConfig sshConfig = getSshHostConfig("gitlab.example.local");
+
+		assertThat(sshConfig.getValue("ConnectTimeout")).isEqualTo("5");
+	}
+
 	private SshConfigStore.HostConfig getSshHostConfig(String hostName) {
 		return factory.createSshConfigStore(new File("dummy"), new File("dummy"), "localUserName").lookup(hostName, 22,
 				"userName");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/ssh/PropertyBasedSshSessionFactoryTest.java
@@ -313,6 +313,17 @@ public class PropertyBasedSshSessionFactoryTest {
 	}
 
 	@Test
+	public void connectTimeoutIsUsed() {
+		JGitEnvironmentProperties sshKey = new JGitEnvironmentProperties();
+		sshKey.setUri("ssh://gitlab.example.local:3322/somerepo.git");
+		setupSessionFactory(sshKey);
+
+		SshConfigStore.HostConfig sshConfig = getSshHostConfig("gitlab.example.local");
+
+		assertThat(sshConfig.getValue("ConnectTimeout")).isEqualTo("5");
+	}
+
+	@Test
 	public void sshConfigFileIsNotUsed() {
 		setupSessionFactory(new JGitEnvironmentProperties());
 


### PR DESCRIPTION
Modify `PropertyBasedSshSessionFactory` and `FileBasedSshSessionFactory` to configure `SshConstants.CONNECT_TIMEOUT` based on the supplied timeout property.

This is a work in progress and I'm looking for feedback.

I created https://github.com/spring-cloud/spring-cloud-config/pull/2393 as a temporary solution to https://github.com/spring-cloud/spring-cloud-config/issues/2256#issuecomment-1999580492.

What I'm really after is setting the SSH read timeout for Git.

I'm using the `CONNECT_TIMEOUT` key from [JGit](https://github.com/eclipse-jgit/jgit/blob/master/org.eclipse.jgit.ssh.apache/src/org/eclipse/jgit/transport/sshd/SshdSession.java#L145-L146) to hopefully accomplish this.