### PR TITLE
Git shallow clone for better performance

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/git-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/git-backend.adoc
@@ -216,6 +216,20 @@ All other repositories are not cloned until configuration from the repository is
 NOTE: Setting a repository to be cloned when the Config Server starts up can help to identify a misconfigured configuration source (such as an invalid repository URI) quickly, while the Config Server is starting up.
 With `cloneOnStart` not enabled for a configuration source, the Config Server may start successfully with a misconfigured or invalid configuration source and not detect an error until an application requests configuration from that configuration source.
 
+By default, the server clones the entire commit history from a remote repository.
+Downloading a huge commit history might be slow, so the server can be configured to truncate the commit history to a few commits, as shown in the following top-level example:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/spring-cloud-samples/config-repo
+          depth: 1
+----
+
 [[authentication]]
 == Authentication
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentProperties.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.config.server.support.HttpEnvironmentRepository
 /**
  * @author Dylan Roberts
  * @author Gareth Clay
+ * @author Chin Huang
  */
 public class JGitEnvironmentProperties extends AbstractScmAccessorProperties
 		implements HttpEnvironmentRepositoryProperties {
@@ -60,6 +61,13 @@ public class JGitEnvironmentProperties extends AbstractScmAccessorProperties
 	 * Flag to indicate that the submodules in the repository should be cloned.
 	 */
 	private boolean cloneSubmodules = false;
+
+	/**
+	 * If greater than zero, then truncate the history to the specified number of commits.
+	 * Generally leads to faster queries because the entire history is not downloaded from
+	 * the remote.
+	 */
+	private int depth = 0;
 
 	/**
 	 * Flag to indicate that the repository should force pull. If true discard any local
@@ -154,6 +162,14 @@ public class JGitEnvironmentProperties extends AbstractScmAccessorProperties
 
 	public void setCloneSubmodules(boolean cloneSubmodules) {
 		this.cloneSubmodules = cloneSubmodules;
+	}
+
+	public int getDepth() {
+		return this.depth;
+	}
+
+	public void setDepth(int depth) {
+		this.depth = depth;
 	}
 
 	public boolean isForcePull() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -87,6 +87,7 @@ import static org.eclipse.jgit.transport.ReceiveCommand.Type.DELETE;
  * @author Ryan Lynch
  * @author Gareth Clay
  * @author ChaoDong Xi
+ * @author Chin Huang
  */
 public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		implements EnvironmentRepository, SearchPathLocator, InitializingBean {
@@ -176,7 +177,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 		this.deleteUntrackedBranches = properties.isDeleteUntrackedBranches();
 		this.refreshRate = properties.getRefreshRate();
 		this.skipSslValidation = properties.isSkipSslValidation();
-		this.gitFactory = new JGitFactory(properties.isCloneSubmodules());
+		this.gitFactory = new JGitFactory(properties.isCloneSubmodules(), properties.getDepth());
 		this.tryMasterBranch = properties.isTryMasterBranch();
 		this.observationRegistry = observationRegistry;
 	}
@@ -1028,12 +1029,19 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 		private final boolean cloneSubmodules;
 
+		private final int depth;
+
 		public JGitFactory() {
-			this(false);
+			this(false, 0);
 		}
 
 		public JGitFactory(boolean cloneSubmodules) {
+			this(cloneSubmodules, 0);
+		}
+
+		public JGitFactory(boolean cloneSubmodules, int depth) {
 			this.cloneSubmodules = cloneSubmodules;
+			this.depth = depth;
 		}
 
 		public Git getGitByOpen(File file) throws IOException {
@@ -1043,6 +1051,9 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 
 		public CloneCommand getCloneCommandByCloneRepository() {
 			CloneCommand command = Git.cloneRepository().setCloneSubmodules(cloneSubmodules);
+			if (depth > 0) {
+				command.setDepth(depth);
+			}
 			return command;
 		}
 


### PR DESCRIPTION
Do not download the entire commit history from the remote.  Execute the equivalent of `git clone --depth 1`

Fixes #1544