### PR TITLE
Remove AWS SDK v1 Dependency since it is not needed anymore for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<spring-cloud-commons.version>4.1.4-SNAPSHOT</spring-cloud-commons.version>
 		<aws-java-sdk.version>2.17.195</aws-java-sdk.version>
 		<google-api-services-iam.version>v1-rev20201112-1.30.10</google-api-services-iam.version>
-		<testcontainers.version>1.17.3</testcontainers.version>
+		<testcontainers.version>1.19.8</testcontainers.version>
 		<wiremock.version>2.31.0</wiremock.version>
 		<spring-cloud-aws.version>3.0.0</spring-cloud-aws.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -211,13 +211,6 @@
 			<artifactId>localstack</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- AWS SDK v1 is required by testcontainers-localstack -->
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
-			<version>1.12.287</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>io.zipkin.brave</groupId>
 			<artifactId>brave-tests</artifactId>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
@@ -118,7 +118,7 @@ public class GitCredentialsProviderFactory {
 
 	/**
 	 * Check to see if the AWS Authentication API is available.
-	 * @return true if the com.amazonaws.auth.DefaultAWSCredentialsProviderChain is
+	 * @return true if the software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain is
 	 * present, false otherwise.
 	 */
 	private boolean awsAvailable() {


### PR DESCRIPTION
Hey, when checking issue regarding new version of Spring Cloud AWS I noticed AWS SDKV1 is used.
As of new version of Testcontainers and Localstack SDKv1 is not needed anymore so making dependency upgrade with removal.