### PR TITLE
Upgrade AWS SDK Framework to 2.18.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<properties>
 		<bintray.package>config</bintray.package>
 		<spring-cloud-commons.version>4.1.4-SNAPSHOT</spring-cloud-commons.version>
-		<aws-java-sdk.version>2.17.195</aws-java-sdk.version>
+		<aws-java-sdk.version>2.18.41</aws-java-sdk.version>
 		<google-api-services-iam.version>v1-rev20201112-1.30.10</google-api-services-iam.version>
 		<testcontainers.version>1.17.3</testcontainers.version>
 		<wiremock.version>2.31.0</wiremock.version>


### PR DESCRIPTION
MR for issue #2435 
Change the pom.xml to use AWS Sdk framework 2.18.41 instead of 2.17.195.
We have dependency version issues because we need new API available from 2.18 (GetContactInformation).
Thank you.