### PR TITLE
Add logic to be more specific about when mark a property source to be profile specific

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -55,6 +55,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import static org.springframework.cloud.config.client.ConfigClientProperties.DEFAULT_PROFILE;
 import static org.springframework.cloud.config.client.ConfigClientProperties.STATE_HEADER;
 import static org.springframework.cloud.config.client.ConfigClientProperties.TOKEN_HEADER;
 
@@ -66,6 +67,8 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 	public static final String CONFIG_CLIENT_PROPERTYSOURCE_NAME = "configClient";
 
 	private static final EnumSet<Option> ALL_OPTIONS = EnumSet.allOf(Option.class);
+
+	private static final String OVERRIDES_NAME = "configserver:overrides";
 
 	protected final Log logger;
 
@@ -168,7 +171,13 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 								// - is the default profile-separator for property sources
 								// TODO This is error prone logic see
 								// https://github.com/spring-cloud/spring-cloud-config/issues/2291
-								if (propertySourceName.matches(".*[-,]" + profile + ".*")) {
+								// When we see the overrides property source name we
+								// should always prioritize those
+								// properties over everything else, even profile specific
+								// property sources so also
+								// label this property source profile specific.
+								if (OVERRIDES_NAME.equals(propertySourceName) || (!DEFAULT_PROFILE.equals(profile)
+										&& propertySourceName.matches(".*[-,]" + profile + "\\b.*"))) {
 									// // TODO: switch to Options.with() when implemented
 									options.add(Option.PROFILE_SPECIFIC);
 								}


### PR DESCRIPTION
Fixes #2417

The problem here two fold.

The profile name (def) is a partial match to the -default in the property source name so we add the Option marking the property source as profile specific. This effects the way Boot orders the property source since profile specific property sources should be ranked higher.
The overrides property source is never marked profile specific and IMO it should always be ranked profile specific so it it always ranked higher.
The logic in the PR is not perfect but honestly it can't be until we add this functionality https://github.com/spring-cloud/spring-cloud-config/issues/2291