### PR TITLE
Handles multiple application names in CredhubEnvironmentRepository

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
@@ -90,7 +90,8 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 
 	private void addPropertySource(Environment environment, String application, String profile, String label) {
 		Map<Object, Object> properties = findProperties(application, profile, label);
-		if (!properties.isEmpty()) {
+		// The main PropertySource (the first one) should be always there, even if it is empty.
+		if (!properties.isEmpty() || environment.getPropertySources().isEmpty()) {
 			PropertySource propertySource = new PropertySource("credhub-" + application + "-" + profile + "-" + label,
 					properties);
 			environment.add(propertySource);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -58,77 +58,92 @@ public class CredhubEnvironmentRepositoryTests {
 
 	@Test
 	public void shouldDisplayEmptyPropertiesWhenNoPathFound() {
-		when(this.credhubCredentialOperations.findByPath("/my-application/production/mylabel")).thenReturn(emptyList());
+		when(this.credhubCredentialOperations.findByPath("/myApp/prod/myLabel")).thenReturn(emptyList());
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production", "mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).containsExactly("production");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
-		assertThat(environment.getPropertySources()).hasSize(1);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEmpty();
+		assertThat(environment.getPropertySources()).isEmpty();
 	}
 
 	@Test
 	public void shouldRetrieveDefaultsWhenNoLabelNorProfileProvided() {
-		stubCredentials("/my-application/default/master", "toggles", "key1", "value1");
+		stubCredentials("/myApp/default/master", "toggles", "key1", "value1");
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", null, null);
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", null, null);
 
-		assertThat(environment.getName()).isEqualTo("my-application");
+		assertThat(environment.getName()).isEqualTo("myApp");
 		assertThat(environment.getProfiles()).containsExactly("default");
 		assertThat(environment.getLabel()).isEqualTo("master");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-default-master");
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-default-master");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
 	}
 
 	@Test
 	public void shouldRetrieveGivenProfileAndLabel() {
-		stubCredentials("/my-application/production/mylabel", "toggles", "key1", "value1");
+		stubCredentials("/myApp/prod/myLabel", "toggles", "key1", "value1");
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production", "mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).containsExactly("production");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
 	}
 
 	@Test
 	public void shouldRetrieveGivenMultipleProfiles() {
-		stubCredentials("/my-application/production/mylabel", "toggles", "key1", "value1");
-		stubCredentials("/my-application/cloud/mylabel", "abs", "key2", "value2");
+		stubCredentials("/myApp/prod/myLabel", "toggles", "key1", "value1");
+		stubCredentials("/myApp/cloud/myLabel", "abs", "key2", "value2");
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production,cloud",
-				"mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod,cloud", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).containsExactly("production", "cloud");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("prod", "cloud", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(2);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
-		assertThat(environment.getPropertySources().get(1).getName())
 
-			.isEqualTo("credhub-my-application-cloud-mylabel");
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-myApp-cloud-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
+	}
+
+	@Test
+	public void shouldRetrieveGivenMultipleApplicationNames() {
+		stubCredentials("/app1/default/myLabel", "toggles", "key1", "value1");
+		stubCredentials("/app2/default/myLabel", "abs", "key2", "value2");
+
+		Environment environment = this.credhubEnvironmentRepository.findOne("app1,app2", null, "myLabel");
+
+		assertThat(environment.getName()).isEqualTo("app1,app2");
+		assertThat(environment.getProfiles()).containsExactly("default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
+
+		assertThat(environment.getPropertySources()).hasSize(2);
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app1-default-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app2-default-myLabel");
 		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
 	}
 
 	@Test
 	public void shouldMergeWhenMoreThanOneCredentialsFound() {
-		String expectedPath = "/my-application/production/mylabel";
+		String expectedPath = "/myApp/prod/myLabel";
 
 		SimpleCredentialName togglesCredentialName = new SimpleCredentialName(expectedPath + "/toggles");
 		SimpleCredentialName absCredentialName = new SimpleCredentialName(expectedPath + "/abs");
@@ -144,15 +159,14 @@ public class CredhubEnvironmentRepositoryTests {
 		when(this.credhubCredentialOperations.getByName(absCredentialName, JsonCredential.class))
 			.thenReturn(new CredentialDetails<>("id2", absCredentialName, CredentialType.JSON, otherCredentials));
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production", "mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).containsExactly("production");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
 		HashMap<Object, Object> expectedValues = new HashMap<>();
 		expectedValues.put("key1", "value1");
 		expectedValues.put("key2", "value2");
@@ -161,49 +175,114 @@ public class CredhubEnvironmentRepositoryTests {
 
 	@Test
 	public void shouldIncludeDefaultApplicationWhenOtherProvided() {
-		stubCredentials("/my-application/production/mylabel", "toggles", "key1", "value1");
-		stubCredentials("/application/production/mylabel", "abs", "key2", "value2");
+		stubCredentials("/app1/prod/myLabel", "toggles", "app1-prod", "value1");
+		stubCredentials("/app2/prod/myLabel", "toggles", "app2-prod", "value2");
+		stubCredentials("/application/prod/myLabel", "abs", "application-prod", "value3");
+		stubCredentials("/app1/default/myLabel", "toggles", "app1-default", "value4");
+		stubCredentials("/app2/default/myLabel", "toggles", "app2-default", "value5");
+		stubCredentials("/application/default/myLabel", "abs", "application-default", "value6");
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production", "mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("app1,app2", "prod", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).containsExactly("production");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("app1,app2");
+		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
-		assertThat(environment.getPropertySources()).hasSize(2);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
-		assertThat(environment.getPropertySources().get(1).getName())
-			.isEqualTo("credhub-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
+		assertThat(environment.getPropertySources()).hasSize(6);
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app1-prod-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("app1-prod", "value1"));
+
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app2-prod-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("app2-prod", "value2"));
+
+		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-application-prod-myLabel");
+		assertThat(environment.getPropertySources().get(2).getSource())
+			.isEqualTo(singletonMap("application-prod", "value3"));
+
+		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-app1-default-myLabel");
+		assertThat(environment.getPropertySources().get(3).getSource())
+			.isEqualTo(singletonMap("app1-default", "value4"));
+
+		assertThat(environment.getPropertySources().get(4).getName()).isEqualTo("credhub-app2-default-myLabel");
+		assertThat(environment.getPropertySources().get(4).getSource())
+			.isEqualTo(singletonMap("app2-default", "value5"));
+
+		assertThat(environment.getPropertySources().get(5).getName()).isEqualTo("credhub-application-default-myLabel");
+		assertThat(environment.getPropertySources().get(5).getSource())
+			.isEqualTo(singletonMap("application-default", "value6"));
 	}
 
 	@Test
 	public void shouldIncludeDefaultProfileWhenOtherProvided() {
-		stubCredentials("/my-application/production/mylabel", "toggles", "key1", "value1");
-		stubCredentials("/application/production/mylabel", "abs", "key2", "value2");
-		stubCredentials("/my-application/default/mylabel", "abs", "key3", "value3");
-		stubCredentials("/application/default/mylabel", "abs", "key4", "value4");
+		stubCredentials("/myApp/dev/myLabel", "toggles", "myApp-dev", "value1");
+		stubCredentials("/application/dev/myLabel", "abs", "application-dev", "value2");
+		stubCredentials("/myApp/prod/myLabel", "toggles", "myApp-prod", "value3");
+		stubCredentials("/application/prod/myLabel", "abs", "application-prod", "value4");
+		stubCredentials("/myApp/default/myLabel", "abs", "myApp-default", "value5");
+		stubCredentials("/application/default/myLabel", "abs", "application-default", "value6");
 
-		Environment environment = this.credhubEnvironmentRepository.findOne("my-application", "production", "mylabel");
+		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "dev,prod", "myLabel");
 
-		assertThat(environment.getName()).isEqualTo("my-application");
-		assertThat(environment.getProfiles()).contains("production");
-		assertThat(environment.getLabel()).isEqualTo("mylabel");
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("dev", "prod", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
+
+		assertThat(environment.getPropertySources()).hasSize(6);
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-dev-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("myApp-dev", "value1"));
+
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-application-dev-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource())
+			.isEqualTo(singletonMap("application-dev", "value2"));
+
+		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-myApp-prod-myLabel");
+		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(singletonMap("myApp-prod", "value3"));
+
+		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-prod-myLabel");
+		assertThat(environment.getPropertySources().get(3).getSource())
+			.isEqualTo(singletonMap("application-prod", "value4"));
+
+		assertThat(environment.getPropertySources().get(4).getName()).isEqualTo("credhub-myApp-default-myLabel");
+		assertThat(environment.getPropertySources().get(4).getSource())
+			.isEqualTo(singletonMap("myApp-default", "value5"));
+
+		assertThat(environment.getPropertySources().get(5).getName()).isEqualTo("credhub-application-default-myLabel");
+		assertThat(environment.getPropertySources().get(5).getSource())
+			.isEqualTo(singletonMap("application-default", "value6"));
+	}
+
+	@Test
+	public void shouldIncludeDefaultProfileAndApplicationNameAtTheEnd() {
+		stubCredentials("/myApp/dev/myLabel", "toggles", "myApp-dev", "value1");
+		stubCredentials("/application/dev/myLabel", "abs", "application-dev", "value2");
+		stubCredentials("/myApp/default/myLabel", "abs", "myApp-default", "value3");
+		stubCredentials("/application/default/myLabel", "abs", "application-default", "value4");
+
+		Environment environment = this.credhubEnvironmentRepository.findOne("application,myApp", "default,dev",
+				"myLabel");
+
+		assertThat(environment.getName()).isEqualTo("application,myApp");
+		assertThat(environment.getProfiles()).containsExactly("dev", "default");
+		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(4);
-		assertThat(environment.getPropertySources().get(0).getName())
-			.isEqualTo("credhub-my-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
-		assertThat(environment.getPropertySources().get(1).getName())
-			.isEqualTo("credhub-application-production-mylabel");
-		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
-		assertThat(environment.getPropertySources().get(2).getName())
-			.isEqualTo("credhub-my-application-default-mylabel");
-		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(singletonMap("key3", "value3"));
-		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-default-mylabel");
-		assertThat(environment.getPropertySources().get(3).getSource()).isEqualTo(singletonMap("key4", "value4"));
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-dev-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("myApp-dev", "value1"));
+
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-application-dev-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource())
+			.isEqualTo(singletonMap("application-dev", "value2"));
+
+		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-myApp-default-myLabel");
+		assertThat(environment.getPropertySources().get(2).getSource())
+			.isEqualTo(singletonMap("myApp-default", "value3"));
+
+		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-default-myLabel");
+		assertThat(environment.getPropertySources().get(3).getSource())
+			.isEqualTo(singletonMap("application-default", "value4"));
 	}
 
 	private void stubCredentials(String expectedPath, String name, String key, String value) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -66,7 +66,9 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getProfiles()).containsExactly("prod", "default");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
-		assertThat(environment.getPropertySources()).isEmpty();
+		assertThat(environment.getPropertySources()).hasSize(1);
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
The PR updates `CredhubEnvironmentRepository` to handle following cases:

1.  application name can be a comma separated string like `foo,bar,baz`. In this case, It should be spilted and each entry should be treated as app name. So the repository should search for `foo/profile/label`, `bar/profile/label`, `baz/profile/label` and finally `application/profile/label`. This was handled in other repositories like JGit or Valut but not in CredHub.

2. If the default application name (`application`)  is included in that comma separated string (like for example: `foo,application,bar`) it should be removed and added back to the end of the list. To make sure the default property source is added to the end of the list.  Again other repositories are taking care of this but not CredHub.

3. same for default profile (`default`). If it's included in the profile string (`profile1,default,profile2`), It should be removed and added back to the end of the list. Again other repositories are taking care of this but not CredHub.


Also, In current implementation, If there are no secrets at all in CredHub an empty `PropertySource` will be added to the environment ( `envrionment.propertySources` will have one `PropertySource` which has no properties) . But this PR skips that and `envrionment.propertySources` will be empty. If this is not desired, I can add that empty `ProperySource` back. 