### PR TITLE
Fixes the order of profiles and application names in CredhubEnvironmentRepository

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,10 +33,6 @@ import org.springframework.credhub.support.CredentialType;
 import org.springframework.credhub.support.SimpleCredentialName;
 import org.springframework.credhub.support.json.JsonCredential;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -58,12 +56,12 @@ public class CredhubEnvironmentRepositoryTests {
 
 	@Test
 	public void shouldDisplayEmptyPropertiesWhenNoPathFound() {
-		when(this.credhubCredentialOperations.findByPath("/myApp/prod/myLabel")).thenReturn(emptyList());
+		stubCredentials("/myApp/prod/myLabel");
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("myApp");
-		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getProfiles()).containsExactly("prod");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
@@ -73,7 +71,7 @@ public class CredhubEnvironmentRepositoryTests {
 
 	@Test
 	public void shouldRetrieveDefaultsWhenNoLabelNorProfileProvided() {
-		stubCredentials("/myApp/default/master", "toggles", "key1", "value1");
+		stubCredentials("/myApp/default/master", credential("c1", "k1", "v1"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", null, null);
 
@@ -84,49 +82,49 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getPropertySources()).hasSize(1);
 
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-default-master");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k1", "v1"));
 	}
 
 	@Test
 	public void shouldRetrieveGivenProfileAndLabel() {
-		stubCredentials("/myApp/prod/myLabel", "toggles", "key1", "value1");
+		stubCredentials("/myApp/prod/myLabel", credential("c1", "k1", "v1"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("myApp");
-		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getProfiles()).containsExactly("prod");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
 
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k1", "v1"));
 	}
 
 	@Test
 	public void shouldRetrieveGivenMultipleProfiles() {
-		stubCredentials("/myApp/prod/myLabel", "toggles", "key1", "value1");
-		stubCredentials("/myApp/cloud/myLabel", "abs", "key2", "value2");
+		stubCredentials("/myApp/prod/myLabel", credential("c1", "k1", "v1"));
+		stubCredentials("/myApp/cloud/myLabel", credential("c2", "k2", "v2"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod,cloud", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("myApp");
-		assertThat(environment.getProfiles()).containsExactly("prod", "cloud", "default");
+		assertThat(environment.getProfiles()).containsExactly("prod", "cloud");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(2);
 
-		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-cloud-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k2", "v2"));
 
-		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-myApp-cloud-myLabel");
-		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-myApp-prod-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(Map.of("k1", "v1"));
 	}
 
 	@Test
 	public void shouldRetrieveGivenMultipleApplicationNames() {
-		stubCredentials("/app1/default/myLabel", "toggles", "key1", "value1");
-		stubCredentials("/app2/default/myLabel", "abs", "key2", "value2");
+		stubCredentials("/app1/default/myLabel", credential("c1", "k1", "v1"));
+		stubCredentials("/app2/default/myLabel", credential("c2", "k2", "v2"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("app1,app2", null, "myLabel");
 
@@ -136,166 +134,147 @@ public class CredhubEnvironmentRepositoryTests {
 
 		assertThat(environment.getPropertySources()).hasSize(2);
 
-		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app1-default-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("key1", "value1"));
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app2-default-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k2", "v2"));
 
-		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app2-default-myLabel");
-		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("key2", "value2"));
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app1-default-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(Map.of("k1", "v1"));
 	}
 
 	@Test
 	public void shouldMergeWhenMoreThanOneCredentialsFound() {
-		String expectedPath = "/myApp/prod/myLabel";
-
-		SimpleCredentialName togglesCredentialName = new SimpleCredentialName(expectedPath + "/toggles");
-		SimpleCredentialName absCredentialName = new SimpleCredentialName(expectedPath + "/abs");
-		when(this.credhubCredentialOperations.findByPath(expectedPath))
-			.thenReturn(asList(new CredentialSummary(togglesCredentialName), new CredentialSummary(absCredentialName)));
-		JsonCredential credentials = new JsonCredential();
-		credentials.put("key1", "value1");
-		when(this.credhubCredentialOperations.getByName(togglesCredentialName, JsonCredential.class))
-			.thenReturn(new CredentialDetails<>("id1", togglesCredentialName, CredentialType.JSON, credentials));
-
-		JsonCredential otherCredentials = new JsonCredential();
-		otherCredentials.put("key2", "value2");
-		when(this.credhubCredentialOperations.getByName(absCredentialName, JsonCredential.class))
-			.thenReturn(new CredentialDetails<>("id2", absCredentialName, CredentialType.JSON, otherCredentials));
+		stubCredentials("/myApp/prod/myLabel", credential("c1", Map.of("k1", "v1")),
+				credential("c2", Map.of("k2", "v2")));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "prod", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("myApp");
-		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getProfiles()).containsExactly("prod");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(1);
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
-		HashMap<Object, Object> expectedValues = new HashMap<>();
-		expectedValues.put("key1", "value1");
-		expectedValues.put("key2", "value2");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(expectedValues);
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k1", "v1", "k2", "v2"));
 	}
 
 	@Test
 	public void shouldIncludeDefaultApplicationWhenOtherProvided() {
-		stubCredentials("/app1/prod/myLabel", "toggles", "app1-prod", "value1");
-		stubCredentials("/app2/prod/myLabel", "toggles", "app2-prod", "value2");
-		stubCredentials("/application/prod/myLabel", "abs", "application-prod", "value3");
-		stubCredentials("/app1/default/myLabel", "toggles", "app1-default", "value4");
-		stubCredentials("/app2/default/myLabel", "toggles", "app2-default", "value5");
-		stubCredentials("/application/default/myLabel", "abs", "application-default", "value6");
+		stubCredentials("/app1/prod/myLabel", credential("c1", "k1", "v1"));
+		stubCredentials("/app2/prod/myLabel", credential("c2", "k2", "v2"));
+		stubCredentials("/application/prod/myLabel", credential("c3", "k3", "v3"));
+		stubCredentials("/app1/default/myLabel", credential("c4", "k4", "v4"));
+		stubCredentials("/app2/default/myLabel", credential("c5", "k5", "v5"));
+		stubCredentials("/application/default/myLabel", credential("c6", "k6", "v6"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("app1,app2", "prod", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("app1,app2");
-		assertThat(environment.getProfiles()).containsExactly("prod", "default");
+		assertThat(environment.getProfiles()).containsExactly("prod");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(6);
 
-		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app1-prod-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("app1-prod", "value1"));
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-app2-prod-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k2", "v2"));
 
-		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app2-prod-myLabel");
-		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(singletonMap("app2-prod", "value2"));
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-app1-prod-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(Map.of("k1", "v1"));
 
 		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-application-prod-myLabel");
-		assertThat(environment.getPropertySources().get(2).getSource())
-			.isEqualTo(singletonMap("application-prod", "value3"));
+		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(Map.of("k3", "v3"));
 
-		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-app1-default-myLabel");
-		assertThat(environment.getPropertySources().get(3).getSource())
-			.isEqualTo(singletonMap("app1-default", "value4"));
+		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-app2-default-myLabel");
+		assertThat(environment.getPropertySources().get(3).getSource()).isEqualTo(Map.of("k5", "v5"));
 
-		assertThat(environment.getPropertySources().get(4).getName()).isEqualTo("credhub-app2-default-myLabel");
-		assertThat(environment.getPropertySources().get(4).getSource())
-			.isEqualTo(singletonMap("app2-default", "value5"));
+		assertThat(environment.getPropertySources().get(4).getName()).isEqualTo("credhub-app1-default-myLabel");
+		assertThat(environment.getPropertySources().get(4).getSource()).isEqualTo(Map.of("k4", "v4"));
 
 		assertThat(environment.getPropertySources().get(5).getName()).isEqualTo("credhub-application-default-myLabel");
-		assertThat(environment.getPropertySources().get(5).getSource())
-			.isEqualTo(singletonMap("application-default", "value6"));
+		assertThat(environment.getPropertySources().get(5).getSource()).isEqualTo(Map.of("k6", "v6"));
 	}
 
 	@Test
 	public void shouldIncludeDefaultProfileWhenOtherProvided() {
-		stubCredentials("/myApp/dev/myLabel", "toggles", "myApp-dev", "value1");
-		stubCredentials("/application/dev/myLabel", "abs", "application-dev", "value2");
-		stubCredentials("/myApp/prod/myLabel", "toggles", "myApp-prod", "value3");
-		stubCredentials("/application/prod/myLabel", "abs", "application-prod", "value4");
-		stubCredentials("/myApp/default/myLabel", "abs", "myApp-default", "value5");
-		stubCredentials("/application/default/myLabel", "abs", "application-default", "value6");
+		stubCredentials("/myApp/dev/myLabel", credential("c1", "k1", "v1"));
+		stubCredentials("/application/dev/myLabel", credential("c2", "k2", "v2"));
+		stubCredentials("/myApp/prod/myLabel", credential("c3", "k3", "v3"));
+		stubCredentials("/application/prod/myLabel", credential("c4", "k4", "v4"));
+		stubCredentials("/myApp/default/myLabel", credential("c5", "k5", "v5"));
+		stubCredentials("/application/default/myLabel", credential("c6", "k6", "v6"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("myApp", "dev,prod", "myLabel");
 
 		assertThat(environment.getName()).isEqualTo("myApp");
-		assertThat(environment.getProfiles()).containsExactly("dev", "prod", "default");
+		assertThat(environment.getProfiles()).containsExactly("dev", "prod");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(6);
 
-		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-dev-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("myApp-dev", "value1"));
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-prod-myLabel");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k3", "v3"));
 
-		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-application-dev-myLabel");
-		assertThat(environment.getPropertySources().get(1).getSource())
-			.isEqualTo(singletonMap("application-dev", "value2"));
+		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-application-prod-myLabel");
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(Map.of("k4", "v4"));
 
-		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-myApp-prod-myLabel");
-		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(singletonMap("myApp-prod", "value3"));
+		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-myApp-dev-myLabel");
+		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(Map.of("k1", "v1"));
 
-		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-prod-myLabel");
-		assertThat(environment.getPropertySources().get(3).getSource())
-			.isEqualTo(singletonMap("application-prod", "value4"));
+		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-dev-myLabel");
+		assertThat(environment.getPropertySources().get(3).getSource()).isEqualTo(Map.of("k2", "v2"));
 
 		assertThat(environment.getPropertySources().get(4).getName()).isEqualTo("credhub-myApp-default-myLabel");
-		assertThat(environment.getPropertySources().get(4).getSource())
-			.isEqualTo(singletonMap("myApp-default", "value5"));
+		assertThat(environment.getPropertySources().get(4).getSource()).isEqualTo(Map.of("k5", "v5"));
 
 		assertThat(environment.getPropertySources().get(5).getName()).isEqualTo("credhub-application-default-myLabel");
-		assertThat(environment.getPropertySources().get(5).getSource())
-			.isEqualTo(singletonMap("application-default", "value6"));
+		assertThat(environment.getPropertySources().get(5).getSource()).isEqualTo(Map.of("k6", "v6"));
 	}
 
 	@Test
 	public void shouldIncludeDefaultProfileAndApplicationNameAtTheEnd() {
-		stubCredentials("/myApp/dev/myLabel", "toggles", "myApp-dev", "value1");
-		stubCredentials("/application/dev/myLabel", "abs", "application-dev", "value2");
-		stubCredentials("/myApp/default/myLabel", "abs", "myApp-default", "value3");
-		stubCredentials("/application/default/myLabel", "abs", "application-default", "value4");
+		stubCredentials("/myApp/dev/myLabel", credential("c1", "k1", "v1"));
+		stubCredentials("/application/dev/myLabel", credential("c2", "k2", "v2"));
+		stubCredentials("/myApp/default/myLabel", credential("c3", "k3", "v3"));
+		stubCredentials("/application/default/myLabel", credential("c4", "k4", "v4"));
 
 		Environment environment = this.credhubEnvironmentRepository.findOne("application,myApp", "default,dev",
 				"myLabel");
 
 		assertThat(environment.getName()).isEqualTo("application,myApp");
-		assertThat(environment.getProfiles()).containsExactly("dev", "default");
+		assertThat(environment.getProfiles()).containsExactly("default", "dev");
 		assertThat(environment.getLabel()).isEqualTo("myLabel");
 
 		assertThat(environment.getPropertySources()).hasSize(4);
 
 		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-dev-myLabel");
-		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(singletonMap("myApp-dev", "value1"));
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k1", "v1"));
 
 		assertThat(environment.getPropertySources().get(1).getName()).isEqualTo("credhub-application-dev-myLabel");
-		assertThat(environment.getPropertySources().get(1).getSource())
-			.isEqualTo(singletonMap("application-dev", "value2"));
+		assertThat(environment.getPropertySources().get(1).getSource()).isEqualTo(Map.of("k2", "v2"));
 
 		assertThat(environment.getPropertySources().get(2).getName()).isEqualTo("credhub-myApp-default-myLabel");
-		assertThat(environment.getPropertySources().get(2).getSource())
-			.isEqualTo(singletonMap("myApp-default", "value3"));
+		assertThat(environment.getPropertySources().get(2).getSource()).isEqualTo(Map.of("k3", "v3"));
 
 		assertThat(environment.getPropertySources().get(3).getName()).isEqualTo("credhub-application-default-myLabel");
-		assertThat(environment.getPropertySources().get(3).getSource())
-			.isEqualTo(singletonMap("application-default", "value4"));
+		assertThat(environment.getPropertySources().get(3).getSource()).isEqualTo(Map.of("k4", "v4"));
 	}
 
-	private void stubCredentials(String expectedPath, String name, String key, String value) {
-		SimpleCredentialName credentialsName = new SimpleCredentialName(expectedPath + "/" + name);
-		when(this.credhubCredentialOperations.findByPath(expectedPath))
-			.thenReturn(singletonList(new CredentialSummary(credentialsName)));
-		JsonCredential credentials = new JsonCredential();
-		credentials.put(key, value);
-		when(this.credhubCredentialOperations.getByName(new SimpleCredentialName(expectedPath + "/" + name),
-				JsonCredential.class))
-			.thenReturn(new CredentialDetails<>("id1", credentialsName, CredentialType.JSON, credentials));
+	@SafeVarargs
+	private void stubCredentials(String path, CredentialDetails<JsonCredential>... details) {
+		when(this.credhubCredentialOperations.findByPath(path)).thenReturn(
+				Arrays.stream(details).map(it -> new CredentialSummary(it.getName())).collect(Collectors.toList()));
+
+		for (CredentialDetails<JsonCredential> d : details) {
+			when(this.credhubCredentialOperations.getByName(d.getName(), JsonCredential.class)).thenReturn(d);
+		}
+	}
+
+	private CredentialDetails<JsonCredential> credential(String name, String key, String value) {
+		return credential(name, Map.of(key, value));
+	}
+
+	private CredentialDetails<JsonCredential> credential(String name, Map<String, String> secrets) {
+		return new CredentialDetails<>("::id::", new SimpleCredentialName(name), CredentialType.JSON,
+				new JsonCredential(secrets));
 	}
 
 }


### PR DESCRIPTION
The order of property sources created by `CredhubEnvironmentRepository` was not correct. They should have been reversed.  

For a given profile string of `p1,p2,p3` in configuration, the property source created for `p3` should be the first in the list followed by `p2`,  `p1` and finally `default` profile.  

The same order applies to application names. 