### PR TITLE
Cleanup VaultEnvironmentRepository unit tests

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepository.java
@@ -71,7 +71,7 @@ public class VaultEnvironmentRepository extends AbstractVaultEnvironmentReposito
 	/** Vault Namespace header value. */
 	private String namespace;
 
-	private VaultKvAccessStrategy accessStrategy;
+	private final VaultKvAccessStrategy accessStrategy;
 
 	private final ConfigTokenProvider tokenProvider;
 
@@ -94,10 +94,6 @@ public class VaultEnvironmentRepository extends AbstractVaultEnvironmentReposito
 
 		this.accessStrategy = VaultKvAccessStrategyFactory.forVersion(rest, baseUrl, properties.getKvVersion(),
 				properties.getPathToKey());
-	}
-
-	/* for testing */ void setAccessStrategy(VaultKvAccessStrategy accessStrategy) {
-		this.accessStrategy = accessStrategy;
 	}
 
 	@Override


### PR DESCRIPTION
I am about to fix the `label` issue in `VaultEnvironmentRepository` and `SpringVaultEnvironmentRepository` and wanted to cleanup the tests before touching the production code. 