### PR TITLE
Uses label when searching secrets in [Spring]VaultEnvironmentRepository

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/vault-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/vault-backend.adoc
@@ -60,7 +60,7 @@ The following table describes configurable Vault properties:
 |application
 
 |defaultLabel
-|master (Only used when `enableLabel` is set to `true`)
+|main (Only used when `enableLabel` is set to `true`)
 
 |enableLabel
 |false
@@ -169,7 +169,7 @@ When `myApp` has the `dev` profile enabled, properties written to all of the abo
 
 By default, Vault backend does not use the label when searching for secrets. You can change this by
 setting the `enableLabel` feature flag to `true` and, optionally, setting the `defaultLabel`.
-When `defaultLabel` is not provided `master` will be used.
+When `defaultLabel` is not provided `main` will be used.
 
 When `enableLabel` feature flag is on, the secrets in Vault should always have all three segments(application name, profile and label) in their paths.
 So the example in previous section, with enabled feature flag, would be like :

--- a/docs/modules/ROOT/pages/server/environment-repository/vault-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/vault-backend.adoc
@@ -59,6 +59,12 @@ The following table describes configurable Vault properties:
 |defaultKey
 |application
 
+|defaultLabel
+|master (Only used when `enableLabel` is set to `true`)
+
+|enableLabel
+|false
+
 |profileSeparator
 |,
 
@@ -157,6 +163,24 @@ secret/application
 Properties written to `secret/application` are available to <<_vault_server,all applications using the Config Server>>.
 An application with the name, `myApp`, would have any properties written to `secret/myApp` and `secret/application` available to it.
 When `myApp` has the `dev` profile enabled, properties written to all of the above paths would be available to it, with properties in the first path in the list taking priority over the others.
+
+[[enabling-serach-by-label]]
+== Enabling Search by Label
+
+By default, Vault backend does not use the label when searching for secrets. You can change this by
+setting the `enableLabel` feature flag to `true` and, optionally, setting the `defaultLabel`.
+When `defaultLabel` is not provided `master` will be used.
+
+When `enableLabel` feature flag is on, the secrets in Vault should always have all three segments(application name, profile and label) in their paths.
+So the example in previous section, with enabled feature flag, would be like :
+
+[source,sh]
+----
+secret/myApp,dev,myLabel
+secret/myApp,default,myLabel       # default profile
+secret/application,dev,myLabel     # default application name
+secret/application,default,myLabel # default application name and default profile.
+----
 
 [[decrypting-vault-secrets]]
 == Decrypting Vault Secrets in Property Sources

--- a/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
+++ b/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
@@ -64,9 +64,9 @@ public class ConfigDataOrderingVaultIntegrationTests {
 				"--server.port=" + configServerPort,
 				"--spring.cloud.config.server.vault.port=" + vaultContainer.getFirstMappedPort());
 
-		execInVault("vault", "kv", "put", "secret/client-app,dev,master", "my.prop=value-in-dev");
-		execInVault("vault", "kv", "put", "secret/client-app,prod,master", "my.prop=value-in-prod");
-		execInVault("vault", "kv", "put", "secret/client-app,master", "my.prop=default-value");
+		execInVault("vault", "kv", "put", "secret/client-app,dev", "my.prop=value-in-dev");
+		execInVault("vault", "kv", "put", "secret/client-app,prod", "my.prop=value-in-prod");
+		execInVault("vault", "kv", "put", "secret/client-app", "my.prop=default-value");
 
 	}
 

--- a/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
+++ b/spring-cloud-config-sample/src/test/java/sample/ConfigDataOrderingVaultIntegrationTests.java
@@ -18,11 +18,11 @@ package sample;
 
 import java.io.IOException;
 
-import org.json.JSONException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -36,9 +36,10 @@ import org.springframework.test.util.TestSocketUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for https://github.com/spring-cloud/spring-cloud-config/issues/1997
- * The error only occurs if a profile specific config imports is used, otherwise
- * reordering does not take place. A profile specific config import is defined in
+ * Integration test for issue
+ * <a href="https://github.com/spring-cloud/spring-cloud-config/issues/1997">#1997</a> The
+ * error only occurs if a profile specific config imports is used, otherwise reordering
+ * does not take place. A profile specific config import is defined in
  * vaultordering/client-dev.yml
  */
 @Testcontainers
@@ -46,27 +47,26 @@ public class ConfigDataOrderingVaultIntegrationTests {
 
 	private static final int configServerPort = TestSocketUtils.findAvailableTcpPort();
 
-	private static final int configClientPort = TestSocketUtils.findAvailableTcpPort();
-
 	private static ConfigurableApplicationContext client;
 
 	private static ConfigurableApplicationContext server;
 
 	@Container
-	public static VaultContainer vaultContainer = new VaultContainer<>(DockerImageName.parse("vault:1.13.3"))
+	public static VaultContainer<?> vaultContainer = new VaultContainer<>(DockerImageName.parse("vault:1.13.3"))
 		.withVaultToken("my-root-token")
 		.withClasspathResourceMapping("vaultordering/vault_test_policy.txt", "/tmp/vault_test_policy.txt",
 				BindMode.READ_ONLY);
 
 	@BeforeAll
-	public static void startConfigServer() throws IOException, InterruptedException, JSONException {
+	public static void startConfigServer() throws IOException, InterruptedException {
 		server = SpringApplication.run(TestConfigServerApplication.class,
 				"--spring.config.location=classpath:/vaultordering/", "--spring.config.name=server",
 				"--server.port=" + configServerPort,
 				"--spring.cloud.config.server.vault.port=" + vaultContainer.getFirstMappedPort());
 
-		execInVault("vault", "kv", "put", "secret/client-app,dev", "my.prop=vaultdev");
-		execInVault("vault", "kv", "put", "secret/client-app", "my.prop=vault");
+		execInVault("vault", "kv", "put", "secret/client-app,dev,master", "my.prop=value-in-dev");
+		execInVault("vault", "kv", "put", "secret/client-app,prod,master", "my.prop=value-in-prod");
+		execInVault("vault", "kv", "put", "secret/client-app,master", "my.prop=default-value");
 
 	}
 
@@ -81,22 +81,35 @@ public class ConfigDataOrderingVaultIntegrationTests {
 	}
 
 	@Test
-	void propertyFromVaultIsUsed() {
-		client = SpringApplication.run(TestConfigServerApplication.class, "--server.port=" + configClientPort,
+	void profileSpecificPropertyFromVaultIsUsed() {
+		client = SpringApplication.run(TestConfigServerApplication.class,
+				"--server.port=" + TestSocketUtils.findAvailableTcpPort(),
 				"--spring.config.location=classpath:/vaultordering/", "--spring.config.name=client",
 				"--spring.profiles.active=dev", "--spring.application.name=client-app",
 				"--spring.cloud.config.enabled=true", "--spring.cloud.config.server.enabled=false",
 				"--config.server.port=" + configServerPort);
 
-		assertThat(client.getEnvironment().getProperty("my.prop")).isEqualTo("vaultdev");
+		assertThat(client.getEnvironment().getProperty("my.prop")).isEqualTo("value-in-dev");
 
 	}
 
-	private static String execInVault(String... command) throws IOException, InterruptedException {
-		org.testcontainers.containers.Container.ExecResult execResult = vaultContainer.execInContainer(command);
+	@Test
+	void profileSpecificPropertyFromVaultIsUsedInCorrectOrder() {
+		client = SpringApplication.run(TestConfigServerApplication.class,
+				"--server.port=" + TestSocketUtils.findAvailableTcpPort(),
+				"--spring.config.location=classpath:/vaultordering/", "--spring.config.name=client",
+				"--spring.profiles.active=dev,prod", "--spring.application.name=client-app",
+				"--spring.cloud.config.enabled=true", "--spring.cloud.config.server.enabled=false",
+				"--config.server.port=" + configServerPort);
+
+		assertThat(client.getEnvironment().getProperty("my.prop")).isEqualTo("value-in-prod");
+
+	}
+
+	private static void execInVault(String... command) throws IOException, InterruptedException {
+		ExecResult execResult = vaultContainer.execInContainer(command);
 		assertThat(execResult.getExitCode()).isZero();
 		assertThat(execResult.getStderr()).isEmpty();
-		return execResult.getStdout();
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
@@ -50,8 +50,6 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 
 	private static final String DEFAULT_PROFILE = "default";
 
-	private static final String DEFAULT_LABEL = "master";
-
 	private static final Log log = LogFactory.getLog(AbstractVaultEnvironmentRepository.class);
 
 	// TODO: move to watchState:String on findOne?
@@ -73,6 +71,8 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 
 	protected final boolean enableLabel;
 
+	protected final String defaultLabel;
+
 	protected int order;
 
 	public AbstractVaultEnvironmentRepository(ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
@@ -80,6 +80,7 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 		this.defaultKey = properties.getDefaultKey();
 		this.profileSeparator = properties.getProfileSeparator();
 		this.enableLabel = properties.isEnableLabel();
+		this.defaultLabel = properties.getDefaultLabel();
 		this.order = properties.getOrder();
 		this.request = request;
 		this.watch = watch;
@@ -91,7 +92,7 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 			profile = DEFAULT_PROFILE;
 		}
 		if (ObjectUtils.isEmpty(label)) {
-			label = DEFAULT_LABEL;
+			label = defaultLabel;
 		}
 
 		var environment = new Environment(application, split(profile), label, null, getWatchState());

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
@@ -125,13 +125,15 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 
 	private String vaultKey(String application, String profile, String label) {
 		var key = application;
-		// default profile should not be included in the key.
-		if (!DEFAULT_PROFILE.equals(profile)) {
-			key += this.profileSeparator + profile;
-		}
-		// append label to the key, if flag is enabled.
 		if (this.enableLabel) {
+			// always append profile to the key, if flag is enabled.
+			key += this.profileSeparator + profile;
+			// always append label to the key, if flag is enabled.
 			key += this.profileSeparator + label;
+		}
+		else if (!DEFAULT_PROFILE.equals(profile)) {
+			// default profile should not be included in the key, if flag is not enabled.
+			key += this.profileSeparator + profile;
 		}
 
 		return key;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AbstractVaultEnvironmentRepository.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotEmpty;
@@ -33,6 +33,7 @@ import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.config.client.ConfigClientProperties.STATE_HEADER;
@@ -46,7 +47,11 @@ import static org.springframework.cloud.config.client.ConfigClientProperties.STA
  */
 public abstract class AbstractVaultEnvironmentRepository implements EnvironmentRepository, Ordered {
 
-	private static Log log = LogFactory.getLog(AbstractVaultEnvironmentRepository.class);
+	private static final String DEFAULT_PROFILE = "default";
+
+	private static final String DEFAULT_LABEL = "master";
+
+	private static final Log log = LogFactory.getLog(AbstractVaultEnvironmentRepository.class);
 
 	// TODO: move to watchState:String on findOne?
 	protected final ObjectProvider<HttpServletRequest> request;
@@ -78,24 +83,34 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 
 	@Override
 	public Environment findOne(String application, String profile, String label) {
-		String[] profiles = StringUtils.commaDelimitedListToStringArray(profile);
-		List<String> scrubbedProfiles = scrubProfiles(profiles);
+		if (ObjectUtils.isEmpty(profile)) {
+			profile = DEFAULT_PROFILE;
+		}
+		if (ObjectUtils.isEmpty(label)) {
+			label = DEFAULT_LABEL;
+		}
 
-		List<String> keys = findKeys(application, scrubbedProfiles);
+		var environment = new Environment(application, split(profile), label, null, getWatchState());
 
-		Environment environment = new Environment(application, profiles, label, null, getWatchState());
+		var profiles = normalize(profile, DEFAULT_PROFILE);
+		var applications = normalize(application, this.defaultKey);
 
-		for (String key : keys) {
-			// read raw 'data' key from vault
-			String data = read(key);
-			if (data != null) {
-				// data is in json format of which, yaml is a superset, so parse
-				final YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
-				yaml.setResources(new ByteArrayResource(data.getBytes()));
-				Properties properties = yaml.getObject();
+		for (String prof : profiles) {
+			for (String app : applications) {
+				// default profile should not be included in the key.
+				var key = DEFAULT_PROFILE.equals(prof) ? app + this.profileSeparator + label
+						: app + this.profileSeparator + prof + this.profileSeparator + label;
+				// read raw 'data' key from vault
+				String data = read(key);
+				if (data != null) {
+					// data is in json format of which, yaml is a superset, so parse
+					var yaml = new YamlPropertiesFactoryBean();
+					yaml.setResources(new ByteArrayResource(data.getBytes()));
+					var properties = yaml.getObject();
 
-				if (!properties.isEmpty()) {
-					environment.add(new PropertySource("vault:" + key, properties));
+					if (properties != null && !properties.isEmpty()) {
+						environment.add(new PropertySource("vault:" + key, properties));
+					}
 				}
 			}
 		}
@@ -120,35 +135,22 @@ public abstract class AbstractVaultEnvironmentRepository implements EnvironmentR
 		return null;
 	}
 
-	private List<String> findKeys(String application, List<String> profiles) {
-		List<String> keys = new ArrayList<>();
+	/**
+	 * Splits the comma delimited items and returns the reversed distinct items with given
+	 * default item at the end.
+	 */
+	private List<String> normalize(String commaDelimitedItems, String defaultItem) {
+		var items = Stream.concat(Stream.of(defaultItem), Arrays.stream(split(commaDelimitedItems)))
+			.distinct()
+			.filter(item -> !ObjectUtils.isEmpty(item))
+			.collect(Collectors.toList());
 
-		if (StringUtils.hasText(this.defaultKey) && !this.defaultKey.equals(application)) {
-			keys.add(this.defaultKey);
-			addProfiles(keys, this.defaultKey, profiles);
-		}
-
-		// application may have comma-separated list of names
-		String[] applications = StringUtils.commaDelimitedListToStringArray(application);
-		for (String app : applications) {
-			keys.add(app);
-			addProfiles(keys, app, profiles);
-		}
-
-		Collections.reverse(keys);
-		return keys;
+		Collections.reverse(items);
+		return items;
 	}
 
-	private List<String> scrubProfiles(String[] profiles) {
-		List<String> scrubbedProfiles = new ArrayList<>(Arrays.asList(profiles));
-		scrubbedProfiles.remove("default");
-		return scrubbedProfiles;
-	}
-
-	private void addProfiles(List<String> contexts, String baseContext, List<String> profiles) {
-		for (String profile : profiles) {
-			contexts.add(baseContext + this.profileSeparator + profile);
-		}
+	private String[] split(String str) {
+		return StringUtils.commaDelimitedListToStringArray(str);
 	}
 
 	public void setDefaultKey(String defaultKey) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -110,6 +110,8 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	 */
 	private boolean enableLabel = false;
 
+	private String defaultLabel = "master";
+
 	private AppRoleProperties appRole = new AppRoleProperties();
 
 	private AwsEc2Properties awsEc2 = new AwsEc2Properties();
@@ -244,6 +246,14 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	public void setEnableLabel(boolean enableLabel) {
 		this.enableLabel = enableLabel;
+	}
+
+	public String getDefaultLabel() {
+		return defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
 	}
 
 	public AppRoleProperties getAppRole() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -101,6 +101,15 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	 */
 	private String token;
 
+	/**
+	 * Flag to indicate that the repository should use 'label' as well as
+	 * 'application-name' and 'profile', for vault secrets. By default, the vault secrets
+	 * are expected to be in 'application-name,profile' path. When this flag enabled, they
+	 * are expected to be in `application-name,profile,label' path. To maintain
+	 * compatibility this flag is not enabled by default.
+	 */
+	private boolean enableLabel = false;
+
 	private AppRoleProperties appRole = new AppRoleProperties();
 
 	private AwsEc2Properties awsEc2 = new AwsEc2Properties();
@@ -227,6 +236,14 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 
 	public void setToken(String token) {
 		this.token = token;
+	}
+
+	public boolean isEnableLabel() {
+		return enableLabel;
+	}
+
+	public void setEnableLabel(boolean enableLabel) {
+		this.enableLabel = enableLabel;
 	}
 
 	public AppRoleProperties getAppRole() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/VaultEnvironmentProperties.java
@@ -110,7 +110,7 @@ public class VaultEnvironmentProperties implements HttpEnvironmentRepositoryProp
 	 */
 	private boolean enableLabel = false;
 
-	private String defaultLabel = "master";
+	private String defaultLabel = "main";
 
 	private AppRoleProperties appRole = new AppRoleProperties();
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -302,12 +302,33 @@ public class VaultEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
+		stubRestTemplate("secret/myapp,main", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,main", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+		properties.setDefaultLabel("main");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
 		stubRestTemplate("secret/myapp,my-label", toEntityResponse("foo", "bar"));
 		stubRestTemplate("secret/application,my-label", toEntityResponse(Map.of()));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
+		properties.setDefaultLabel("main");
 
 		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -234,7 +234,7 @@ public class VaultEnvironmentRepositoryTests {
 		var properties = new VaultEnvironmentProperties();
 		properties.setKvVersion(2);
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "label");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
@@ -284,31 +284,11 @@ public class VaultEnvironmentRepositoryTests {
 
 	@Test
 	public void findOneWithDefaultLabelWhenLabelEnabled() {
-		stubRestTemplate("secret/myapp,default,master", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,default,master", toEntityResponse("def-foo", "def-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setEnableLabel(true);
-
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,master");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,master");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
 		stubRestTemplate("secret/myapp,default,main", toEntityResponse("foo", "bar"));
 		stubRestTemplate("secret/application,default,main", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
-		properties.setDefaultLabel("main");
 
 		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
 
@@ -322,13 +302,33 @@ public class VaultEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
+		stubRestTemplate("secret/myapp,default,custom", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,default,custom", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+		properties.setDefaultLabel("custom");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,custom");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,custom");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
 		stubRestTemplate("secret/myapp,default,my-label", toEntityResponse("foo", "bar"));
 		stubRestTemplate("secret/application,default,my-label", toEntityResponse(Map.of()));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
-		properties.setDefaultLabel("main");
+		properties.setDefaultLabel("custom");
 
 		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -57,30 +56,45 @@ public class VaultEnvironmentRepositoryTests {
 	@SuppressWarnings("unchecked")
 	ArgumentCaptor<HttpEntity<?>> requestHeaderCaptor = ArgumentCaptor.forClass(HttpEntity.class);
 
-	@BeforeEach
-	public void init() {
-	}
-
 	@Test
-	public void testFindOneNoDefaultKey() {
-		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+	public void testFindOneWithNoDefaultKey() {
+		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
 
 		var e = vaultEnvironmentRepository().findOne("myapp", null, null);
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 
 		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
 	}
 
 	@Test
+	public void testFindOneWithEmptyDefaultKey() {
+		stubRestTemplate("secret/myapp,my-label", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,my-label", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setDefaultKey("");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(1);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+	}
+
+	@Test
 	public void testBackendWithSlashes() {
-		stubRestTemplate("foo/bar/secret/myapp", toEntityResponse("foo", "bar"));
-		stubRestTemplate("foo/bar/secret/application", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("foo/bar/secret/myapp,master", toEntityResponse("foo", "bar"));
+		stubRestTemplate("foo/bar/secret/application,master", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setBackend("foo/bar/secret");
@@ -90,32 +104,36 @@ public class VaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void testFindOneDefaultKeySetAndDifferentToApplication() {
-		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/mydefaultkey", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,main", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/mydefaultkey,main", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("mydefaultkey");
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:mydefaultkey,main");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void testFindOneDefaultKeySetAndDifferentToMultipleApplications() {
-		stubRestTemplate("secret/myapp", toEntityResponse("myapp-foo", "myapp-bar"));
-		stubRestTemplate("secret/yourapp", toEntityResponse("yourapp-foo", "yourapp-bar"));
-		stubRestTemplate("secret/mydefaultkey", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,master", toEntityResponse("myapp-foo", "myapp-bar"));
+		stubRestTemplate("secret/yourapp,master", toEntityResponse("yourapp-foo", "yourapp-bar"));
+		stubRestTemplate("secret/mydefaultkey,master", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("mydefaultkey");
@@ -126,24 +144,78 @@ public class VaultEnvironmentRepositoryTests {
 
 		assertThat(e.getPropertySources().size()).isEqualTo(3);
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("yourapp-foo", "yourapp-bar"));
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:yourapp,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("myapp-foo", "myapp-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:myapp,master");
 		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:mydefaultkey,master");
 	}
 
 	@Test
 	public void testFindOneDefaultKeySetAndEqualToApplication() {
-		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("myapp");
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(1);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,lbl");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+	}
+
+	@Test
+	public void testFindOneWithProfile() {
+		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/myapp,my-profile,lbl", toEntityResponse("pro-foo", "pro-bar"));
+		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/application,my-profile,lbl", toEntityResponse("def-pro-foo", "def-pro-bar"));
+
+		var e = vaultEnvironmentRepository().findOne("myapp", "my-profile", "lbl");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(4);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-profile,lbl");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pro-foo", "pro-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,my-profile,lbl");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pro-foo", "def-pro-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,lbl");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,lbl");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void testFindOneWithMultipleProfiles() {
+		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/myapp,pr1,master", toEntityResponse("pr1-foo", "pr1-bar"));
+		stubRestTemplate("secret/myapp,pr2,master", toEntityResponse("pr2-foo", "pr2-bar"));
+		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/application,pr1,master", toEntityResponse("def-pr1-foo", "def-pr1-bar"));
+		stubRestTemplate("secret/application,pr2,master", toEntityResponse("def-pr2-foo", "def-pr2-bar"));
+
+		var e = vaultEnvironmentRepository().findOne("myapp", "pr1,pr2", null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(6);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr2,master");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr2-foo", "pr2-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr2,master");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr2-foo", "def-pr2-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,pr1,master");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,pr1,master");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
+		assertThat(e.getPropertySources().get(4).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(4).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(5).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(5).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
@@ -156,51 +228,58 @@ public class VaultEnvironmentRepositoryTests {
 
 	@Test
 	public void testVaultVersioning() {
-		stubRestTemplate("secret/data/myapp", toEntityResponse("data", Map.of("foo", "bar")));
-		stubRestTemplate("secret/data/application", toEntityResponse("data", Map.of("def-foo", "def-bar")));
+		stubRestTemplate("secret/data/myapp,main", toEntityResponse("data", Map.of("foo", "bar")));
+		stubRestTemplate("secret/data/application,main", toEntityResponse("data", Map.of("def-foo", "def-bar")));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setKvVersion(2);
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 
 		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
 	}
 
 	@Test
 	public void testVaultKV2WithPath2Key() {
-		stubRestTemplate("secret/data/myorg/myapp", toEntityResponse("data", Map.of("foo", "bar")));
-		stubRestTemplate("secret/data/myorg/application", toEntityResponse("data", Map.of("def-foo", "def-bar")));
+		stubRestTemplate("secret/data/myorg/myapp,lbl", toEntityResponse("data", Map.of("foo", "bar")));
+		stubRestTemplate("secret/data/myorg/application,lbl", toEntityResponse("data", Map.of("def-foo", "def-bar")));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setKvVersion(2);
 		properties.setPathToKey("myorg");
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,lbl");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,lbl");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void testNamespaceHeaderSent() {
-		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setNamespace("mynamespace");
 
-		vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+		vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
 
 		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Namespace",
 				List.of("mynamespace"));
+		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
 	}
 
 	private VaultEnvironmentRepository vaultEnvironmentRepository() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -284,8 +284,8 @@ public class VaultEnvironmentRepositoryTests {
 
 	@Test
 	public void findOneWithDefaultLabelWhenLabelEnabled() {
-		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,default,master", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,default,master", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -295,16 +295,16 @@ public class VaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,master");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
-		stubRestTemplate("secret/myapp,main", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,main", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/myapp,default,main", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,default,main", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -315,16 +315,16 @@ public class VaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,main");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,main");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
-		stubRestTemplate("secret/myapp,my-label", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,my-label", toEntityResponse(Map.of()));
+		stubRestTemplate("secret/myapp,default,my-label", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,default,my-label", toEntityResponse(Map.of()));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -335,8 +335,33 @@ public class VaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(1);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,my-label");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+	}
+
+	@Test
+	public void findOneWithCustomLabelAndProfileWhenLabelEnabled() {
+		stubRestTemplate("secret/myapp,default,my-label", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/myapp,pr1,my-label", toEntityResponse("pr1-foo", "pr1-bar"));
+		stubRestTemplate("secret/application,default,my-label", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/application,pr1,my-label", toEntityResponse("def-pr1-foo", "def-pr1-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", "pr1", "my-label");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(4);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1,my-label");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,my-label");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,default,my-label");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,default,my-label");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	private VaultEnvironmentRepository vaultEnvironmentRepository() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/VaultEnvironmentRepositoryTests.java
@@ -57,27 +57,27 @@ public class VaultEnvironmentRepositoryTests {
 	ArgumentCaptor<HttpEntity<?>> requestHeaderCaptor = ArgumentCaptor.forClass(HttpEntity.class);
 
 	@Test
-	public void testFindOneWithNoDefaultKey() {
-		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
+	public void findOneWithNoDefaultKey() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
 
 		var e = vaultEnvironmentRepository().findOne("myapp", null, null);
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 
 		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
 	}
 
 	@Test
-	public void testFindOneWithEmptyDefaultKey() {
-		stubRestTemplate("secret/myapp,my-label", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,my-label", toEntityResponse("def-foo", "def-bar"));
+	public void findOneWithEmptyDefaultKey() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("");
@@ -87,17 +87,208 @@ public class VaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(1);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
 	}
 
 	@Test
-	public void testBackendWithSlashes() {
-		stubRestTemplate("foo/bar/secret/myapp,master", toEntityResponse("foo", "bar"));
-		stubRestTemplate("foo/bar/secret/application,master", toEntityResponse("def-foo", "def-bar"));
+	public void findOneWithSlashesInBackend() {
+		stubRestTemplate("foo/bar/secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("foo/bar/secret/application", toEntityResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setBackend("foo/bar/secret");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithDefaultKeySet() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/mydefaultkey", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setDefaultKey("mydefaultkey");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:mydefaultkey");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithDefaultKeyAndMultipleApplicationNames() {
+		stubRestTemplate("secret/myapp", toEntityResponse("myapp-foo", "myapp-bar"));
+		stubRestTemplate("secret/yourapp", toEntityResponse("yourapp-foo", "yourapp-bar"));
+		stubRestTemplate("secret/mydefaultkey", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setDefaultKey("mydefaultkey");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp,yourapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp,yourapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(3);
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("yourapp-foo", "yourapp-bar"));
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:yourapp");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("myapp-foo", "myapp-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:mydefaultkey");
+	}
+
+	@Test
+	public void findOneWithDefaultKeySetToApplicationName() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setDefaultKey("myapp");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(1);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+	}
+
+	@Test
+	public void findOneWithProfile() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/myapp,my-profile", toEntityResponse("pro-foo", "pro-bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/application,my-profile", toEntityResponse("def-pro-foo", "def-pro-bar"));
+
+		var e = vaultEnvironmentRepository().findOne("myapp", "my-profile", "lbl");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(4);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-profile");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pro-foo", "pro-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,my-profile");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pro-foo", "def-pro-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithMultipleProfiles() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/myapp,pr1", toEntityResponse("pr1-foo", "pr1-bar"));
+		stubRestTemplate("secret/myapp,pr2", toEntityResponse("pr2-foo", "pr2-bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+		stubRestTemplate("secret/application,pr1", toEntityResponse("def-pr1-foo", "def-pr1-bar"));
+		stubRestTemplate("secret/application,pr2", toEntityResponse("def-pr2-foo", "def-pr2-bar"));
+
+		var e = vaultEnvironmentRepository().findOne("myapp", "pr1,pr2", null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(6);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr2");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr2-foo", "pr2-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr2");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr2-foo", "def-pr2-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,pr1");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,pr1");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
+		assertThat(e.getPropertySources().get(4).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(4).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(5).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(5).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWhenConfigTokenIsMissing() {
+		ConfigTokenProvider nullTokenProvider = () -> null;
+
+		Assertions.assertThatThrownBy(() -> vaultEnvironmentRepository(nullTokenProvider).findOne("myapp", null, null))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void findOneWithVaultVersioning() {
+		stubRestTemplate("secret/data/myapp", toEntityResponse("data", Map.of("foo", "bar")));
+		stubRestTemplate("secret/data/application", toEntityResponse("data", Map.of("def-foo", "def-bar")));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setKvVersion(2);
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+
+		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
+	}
+
+	@Test
+	public void findOneWithVaultKV2WithPath2Key() {
+		stubRestTemplate("secret/data/myorg/myapp", toEntityResponse("data", Map.of("foo", "bar")));
+		stubRestTemplate("secret/data/myorg/application", toEntityResponse("data", Map.of("def-foo", "def-bar")));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setKvVersion(2);
+		properties.setPathToKey("myorg");
+
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources().size()).isEqualTo(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithNamespaceHeaderSent() {
+		stubRestTemplate("secret/myapp", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setNamespace("mynamespace");
+
+		vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
+
+		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Namespace",
+				List.of("mynamespace"));
+		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
+	}
+
+	@Test
+	public void findOneWithDefaultLabelWhenLabelEnabled() {
+		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
 
 		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, null);
 
@@ -111,175 +302,20 @@ public class VaultEnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void testFindOneDefaultKeySetAndDifferentToApplication() {
-		stubRestTemplate("secret/myapp,main", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/mydefaultkey,main", toEntityResponse("def-foo", "def-bar"));
+	public void findOneWithCustomLabelWhenLabelEnabled() {
+		stubRestTemplate("secret/myapp,my-label", toEntityResponse("foo", "bar"));
+		stubRestTemplate("secret/application,my-label", toEntityResponse(Map.of()));
 
 		var properties = new VaultEnvironmentProperties();
-		properties.setDefaultKey("mydefaultkey");
+		properties.setEnableLabel(true);
 
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:mydefaultkey,main");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void testFindOneDefaultKeySetAndDifferentToMultipleApplications() {
-		stubRestTemplate("secret/myapp,master", toEntityResponse("myapp-foo", "myapp-bar"));
-		stubRestTemplate("secret/yourapp,master", toEntityResponse("yourapp-foo", "yourapp-bar"));
-		stubRestTemplate("secret/mydefaultkey,master", toEntityResponse("def-foo", "def-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setDefaultKey("mydefaultkey");
-
-		var e = vaultEnvironmentRepository(properties).findOne("myapp,yourapp", null, null);
-
-		assertThat(e.getName()).isEqualTo("myapp,yourapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(3);
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("yourapp-foo", "yourapp-bar"));
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:yourapp,master");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("myapp-foo", "myapp-bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:myapp,master");
-		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:mydefaultkey,master");
-	}
-
-	@Test
-	public void testFindOneDefaultKeySetAndEqualToApplication() {
-		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setDefaultKey("myapp");
-
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
+		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources().size()).isEqualTo(1);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,lbl");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-	}
-
-	@Test
-	public void testFindOneWithProfile() {
-		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/myapp,my-profile,lbl", toEntityResponse("pro-foo", "pro-bar"));
-		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
-		stubRestTemplate("secret/application,my-profile,lbl", toEntityResponse("def-pro-foo", "def-pro-bar"));
-
-		var e = vaultEnvironmentRepository().findOne("myapp", "my-profile", "lbl");
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(4);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-profile,lbl");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pro-foo", "pro-bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,my-profile,lbl");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pro-foo", "def-pro-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,lbl");
-		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,lbl");
-		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void testFindOneWithMultipleProfiles() {
-		stubRestTemplate("secret/myapp,master", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/myapp,pr1,master", toEntityResponse("pr1-foo", "pr1-bar"));
-		stubRestTemplate("secret/myapp,pr2,master", toEntityResponse("pr2-foo", "pr2-bar"));
-		stubRestTemplate("secret/application,master", toEntityResponse("def-foo", "def-bar"));
-		stubRestTemplate("secret/application,pr1,master", toEntityResponse("def-pr1-foo", "def-pr1-bar"));
-		stubRestTemplate("secret/application,pr2,master", toEntityResponse("def-pr2-foo", "def-pr2-bar"));
-
-		var e = vaultEnvironmentRepository().findOne("myapp", "pr1,pr2", null);
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(6);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr2,master");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr2-foo", "pr2-bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr2,master");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr2-foo", "def-pr2-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,pr1,master");
-		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,pr1,master");
-		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
-		assertThat(e.getPropertySources().get(4).getName()).isEqualTo("vault:myapp,master");
-		assertThat(e.getPropertySources().get(4).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(5).getName()).isEqualTo("vault:application,master");
-		assertThat(e.getPropertySources().get(5).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void missingConfigToken() {
-		ConfigTokenProvider nullTokenProvider = () -> null;
-
-		Assertions.assertThatThrownBy(() -> vaultEnvironmentRepository(nullTokenProvider).findOne("myapp", null, null))
-			.isInstanceOf(IllegalArgumentException.class);
-	}
-
-	@Test
-	public void testVaultVersioning() {
-		stubRestTemplate("secret/data/myapp,main", toEntityResponse("data", Map.of("foo", "bar")));
-		stubRestTemplate("secret/data/application,main", toEntityResponse("data", Map.of("def-foo", "def-bar")));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setKvVersion(2);
-
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "main");
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-
-		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
-	}
-
-	@Test
-	public void testVaultKV2WithPath2Key() {
-		stubRestTemplate("secret/data/myorg/myapp,lbl", toEntityResponse("data", Map.of("foo", "bar")));
-		stubRestTemplate("secret/data/myorg/application,lbl", toEntityResponse("data", Map.of("def-foo", "def-bar")));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setKvVersion(2);
-		properties.setPathToKey("myorg");
-
-		var e = vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources().size()).isEqualTo(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,lbl");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,lbl");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void testNamespaceHeaderSent() {
-		stubRestTemplate("secret/myapp,lbl", toEntityResponse("foo", "bar"));
-		stubRestTemplate("secret/application,lbl", toEntityResponse("def-foo", "def-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setNamespace("mynamespace");
-
-		vaultEnvironmentRepository(properties).findOne("myapp", null, "lbl");
-
-		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Namespace",
-				List.of("mynamespace"));
-		assertThat(requestHeaderCaptor.getValue().getHeaders()).containsEntry("X-Vault-Token", List.of("token"));
 	}
 
 	private VaultEnvironmentRepository vaultEnvironmentRepository() {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
@@ -252,8 +252,8 @@ public class SpringVaultEnvironmentRepositoryTests {
 
 	@Test
 	public void findOneWithDefaultLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("myapp,default,master")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,default,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -263,17 +263,17 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,master");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void findOneWithProfileAndDefaultLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("myapp,default,master")).thenReturn(withVaultResponse("foo", "bar"));
 		when(keyValueTemplate.get("myapp,pr1,master")).thenReturn(withVaultResponse("pr1-foo", "pr1-bar"));
-		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("application,default,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 		when(keyValueTemplate.get("application,pr1,master"))
 			.thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
 
@@ -289,16 +289,16 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
 		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,master");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,default,master");
 		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,default,master");
 		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,main")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("myapp,default,main")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,default,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -309,16 +309,16 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,main");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,main");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,my-label")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,my-label")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("myapp,default,my-label")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,default,my-label")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
@@ -329,9 +329,9 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,my-label");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,my-label");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,my-label");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
@@ -296,12 +296,33 @@ public class SpringVaultEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,main")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+		properties.setDefaultLabel("main");
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,main");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
 		when(keyValueTemplate.get("myapp,my-label")).thenReturn(withVaultResponse("foo", "bar"));
 		when(keyValueTemplate.get("application,my-label")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
+		properties.setDefaultLabel("main");
 
 		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
@@ -110,7 +110,7 @@ public class SpringVaultEnvironmentRepositoryTests {
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("mydefaultkey");
 
-		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "main");
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "label");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
@@ -129,7 +129,7 @@ public class SpringVaultEnvironmentRepositoryTests {
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("");
 
-		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "main");
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "label");
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
@@ -252,57 +252,11 @@ public class SpringVaultEnvironmentRepositoryTests {
 
 	@Test
 	public void findOneWithDefaultLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,default,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,default,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setEnableLabel(true);
-
-		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,master");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,master");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void findOneWithProfileAndDefaultLabelWhenLabelEnabled() {
-		when(keyValueTemplate.get("myapp,default,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("myapp,pr1,master")).thenReturn(withVaultResponse("pr1-foo", "pr1-bar"));
-		when(keyValueTemplate.get("application,default,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
-		when(keyValueTemplate.get("application,pr1,master"))
-			.thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
-
-		var properties = new VaultEnvironmentProperties();
-		properties.setEnableLabel(true);
-
-		var e = springVaultEnvironmentRepository(properties).findOne("myapp", "pr1", null);
-
-		assertThat(e.getName()).isEqualTo("myapp");
-
-		assertThat(e.getPropertySources()).hasSize(4);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1,master");
-		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,master");
-		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,default,master");
-		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,default,master");
-		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
-	}
-
-	@Test
-	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
 		when(keyValueTemplate.get("myapp,default,main")).thenReturn(withVaultResponse("foo", "bar"));
 		when(keyValueTemplate.get("application,default,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
-		properties.setDefaultLabel("main");
 
 		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
 
@@ -316,13 +270,58 @@ public class SpringVaultEnvironmentRepositoryTests {
 	}
 
 	@Test
+	public void findOneWithProfileAndDefaultLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,default,main")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("myapp,pr1,main")).thenReturn(withVaultResponse("pr1-foo", "pr1-bar"));
+		when(keyValueTemplate.get("application,default,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("application,pr1,main")).thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", "pr1", null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(4);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1,main");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,main");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,default,main");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,default,main");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithCustomDefaultLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,default,custom")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,default,custom")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+		properties.setDefaultLabel("custom");
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,default,custom");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,default,custom");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
 	public void findOneWithCustomLabelWhenLabelEnabled() {
 		when(keyValueTemplate.get("myapp,default,my-label")).thenReturn(withVaultResponse("foo", "bar"));
 		when(keyValueTemplate.get("application,default,my-label")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setEnableLabel(true);
-		properties.setDefaultLabel("main");
+		properties.setDefaultLabel("custom");
 
 		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
 

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryTests.java
@@ -45,17 +45,17 @@ public class SpringVaultEnvironmentRepositoryTests {
 	private final VaultKeyValueOperations keyValueTemplate = mock(VaultKeyValueOperations.class);
 
 	@Test
-	public void testFindOneNoDefaultKey() {
+	public void findOneNoDefaultKey() {
 		defaultKeyTest("", 2);
 	}
 
 	@Test
-	public void testPathKey() {
+	public void findOneWithPathKey() {
 		defaultKeyTest("mypath", 2);
 	}
 
 	@Test
-	public void testPathKeyNotUsedWithVersionOne() {
+	public void findOneWithPathKeyNotUsedWithVersionOne() {
 		defaultKeyTest("mypath", 1);
 	}
 
@@ -65,8 +65,8 @@ public class SpringVaultEnvironmentRepositoryTests {
 			path = myPathKey + "/";
 		}
 
-		when(keyValueTemplate.get(path + "myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get(path + "application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get(path + "myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get(path + "application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setPathToKey(myPathKey);
@@ -77,16 +77,16 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testBackendWithSlashes() {
-		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithSlashesInBackend() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setBackend("foo/bar/secret");
@@ -96,16 +96,16 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testFindOneDefaultKeySetAndDifferentToApplication() {
-		when(keyValueTemplate.get("myapp,main")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("mydefaultkey,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithDefaultKeySet() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("mydefaultkey")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("mydefaultkey");
@@ -115,16 +115,16 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:mydefaultkey,main");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:mydefaultkey");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testFindOneWithEmptyDefaultKey() {
-		when(keyValueTemplate.get("myapp,main")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,main")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithEmptyDefaultKey() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("");
@@ -134,15 +134,15 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(1);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,main");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
 	}
 
 	@Test
-	public void testFindOneDefaultKeySetAndDifferentToMultipleApplications() {
-		when(keyValueTemplate.get("myapp,lbl")).thenReturn(withVaultResponse("myapp-foo", "myapp-bar"));
-		when(keyValueTemplate.get("yourapp,lbl")).thenReturn(withVaultResponse("yourapp-foo", "yourapp-bar"));
-		when(keyValueTemplate.get("mydefaultkey,lbl")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithDefaultKeyAndMultipleApplicationNames() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("myapp-foo", "myapp-bar"));
+		when(keyValueTemplate.get("yourapp")).thenReturn(withVaultResponse("yourapp-foo", "yourapp-bar"));
+		when(keyValueTemplate.get("mydefaultkey")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("mydefaultkey");
@@ -152,37 +152,37 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp,yourapp");
 
 		assertThat(e.getPropertySources()).hasSize(3);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:yourapp,lbl");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:yourapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("yourapp-foo", "yourapp-bar"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:myapp,lbl");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("myapp-foo", "myapp-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:mydefaultkey,lbl");
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:mydefaultkey");
 		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testFindOneDefaultKeySetAndEqualToApplication() {
-		when(keyValueTemplate.get("myapp,foo")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,foo")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithDefaultKeySetToApplicationName() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setDefaultKey("myapp");
 
-		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "foo");
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
 
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(1);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,foo");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
 	}
 
 	@Test
-	public void testFindOneWithProfile() {
-		when(keyValueTemplate.get("myapp,lbl")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("myapp,pr1,lbl")).thenReturn(withVaultResponse("foo-pr1", "bar-pr1"));
-		when(keyValueTemplate.get("application,lbl")).thenReturn(withVaultResponse("def-foo", "def-bar"));
-		when(keyValueTemplate.get("application,pr1,lbl")).thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
+	public void findOneWithProfile() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("myapp,pr1")).thenReturn(withVaultResponse("foo-pr1", "bar-pr1"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("application,pr1")).thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 
@@ -191,24 +191,24 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(4);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1,lbl");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo-pr1", "bar-pr1"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,lbl");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,lbl");
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,lbl");
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application");
 		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testFindOneWithMultipleProfiles() {
-		when(keyValueTemplate.get("myapp,lbl")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("myapp,pr1,lbl")).thenReturn(withVaultResponse("foo-pr1", "bar-pr1"));
-		when(keyValueTemplate.get("myapp,pr2,lbl")).thenReturn(withVaultResponse("foo-pr2", "bar-pr2"));
-		when(keyValueTemplate.get("application,lbl")).thenReturn(withVaultResponse("def-foo", "def-bar"));
-		when(keyValueTemplate.get("application,pr1,lbl")).thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
-		when(keyValueTemplate.get("application,pr2,lbl")).thenReturn(withVaultResponse("def-pr2-foo", "def-pr2-bar"));
+	public void findOneWithMultipleProfiles() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("myapp,pr1")).thenReturn(withVaultResponse("foo-pr1", "bar-pr1"));
+		when(keyValueTemplate.get("myapp,pr2")).thenReturn(withVaultResponse("foo-pr2", "bar-pr2"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("application,pr1")).thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
+		when(keyValueTemplate.get("application,pr2")).thenReturn(withVaultResponse("def-pr2-foo", "def-pr2-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 
@@ -217,24 +217,24 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(6);
-		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr2,lbl");
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr2");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo-pr2", "bar-pr2"));
-		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr2,lbl");
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr2");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr2-foo", "def-pr2-bar"));
-		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,pr1,lbl");
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,pr1");
 		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo-pr1", "bar-pr1"));
-		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,pr1,lbl");
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,pr1");
 		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
-		assertThat(e.getPropertySources().get(4).getName()).isEqualTo("vault:myapp,lbl");
+		assertThat(e.getPropertySources().get(4).getName()).isEqualTo("vault:myapp");
 		assertThat(e.getPropertySources().get(4).getSource()).isEqualTo(Map.of("foo", "bar"));
-		assertThat(e.getPropertySources().get(5).getName()).isEqualTo("vault:application,lbl");
+		assertThat(e.getPropertySources().get(5).getName()).isEqualTo("vault:application");
 		assertThat(e.getPropertySources().get(5).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 
 	@Test
-	public void testVaultVersioning() {
-		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
-		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+	public void findOneWithVaultVersioning() {
+		when(keyValueTemplate.get("myapp")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application")).thenReturn(withVaultResponse("def-foo", "def-bar"));
 
 		var properties = new VaultEnvironmentProperties();
 		properties.setKvVersion(2);
@@ -244,9 +244,73 @@ public class SpringVaultEnvironmentRepositoryTests {
 		assertThat(e.getName()).isEqualTo("myapp");
 
 		assertThat(e.getPropertySources()).hasSize(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithDefaultLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(2);
 		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,master");
 		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
 		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithProfileAndDefaultLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,master")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("myapp,pr1,master")).thenReturn(withVaultResponse("pr1-foo", "pr1-bar"));
+		when(keyValueTemplate.get("application,master")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+		when(keyValueTemplate.get("application,pr1,master"))
+			.thenReturn(withVaultResponse("def-pr1-foo", "def-pr1-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", "pr1", null);
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(4);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,pr1,master");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("pr1-foo", "pr1-bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,pr1,master");
+		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-pr1-foo", "def-pr1-bar"));
+		assertThat(e.getPropertySources().get(2).getName()).isEqualTo("vault:myapp,master");
+		assertThat(e.getPropertySources().get(2).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(3).getName()).isEqualTo("vault:application,master");
+		assertThat(e.getPropertySources().get(3).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
+	}
+
+	@Test
+	public void findOneWithCustomLabelWhenLabelEnabled() {
+		when(keyValueTemplate.get("myapp,my-label")).thenReturn(withVaultResponse("foo", "bar"));
+		when(keyValueTemplate.get("application,my-label")).thenReturn(withVaultResponse("def-foo", "def-bar"));
+
+		var properties = new VaultEnvironmentProperties();
+		properties.setEnableLabel(true);
+
+		var e = springVaultEnvironmentRepository(properties).findOne("myapp", null, "my-label");
+
+		assertThat(e.getName()).isEqualTo("myapp");
+
+		assertThat(e.getPropertySources()).hasSize(2);
+		assertThat(e.getPropertySources().get(0).getName()).isEqualTo("vault:myapp,my-label");
+		assertThat(e.getPropertySources().get(0).getSource()).isEqualTo(Map.of("foo", "bar"));
+		assertThat(e.getPropertySources().get(1).getName()).isEqualTo("vault:application,my-label");
 		assertThat(e.getPropertySources().get(1).getSource()).isEqualTo(Map.of("def-foo", "def-bar"));
 	}
 


### PR DESCRIPTION
Like other EnvironmentRepositories, `VaultEnvironmentRepository::findOne` and `SpringVaultEnvironmentRepository::findOne` should use the `label` argument passed to them when searching for secrets in vault.

So calling `findOne("my-app", "my-profile", "my-label")` should search for secrets in vault in the following locations with the **exact order**:
- `secret/myapp,my-profile,my-label`
- `secret/application,my-profile,my-label` (Assuming `application` is the default-key)
- `secret/myapp,my-label`
- `secret/application,my-label` (Assuming `application` is the default-key)

Currently the search locations are the followings (note the missing label):
- `secret/myapp,my-profile`
- `secret/application,my-profile` (Assuming `application` is the default-key)
- `secret/myapp`
- `secret/application` (Assuming `application` is the default-key)

This PR fixes the above issue. 

## Breaking Change
Since this wrong behaviour has been there from the day one, based on my knowledge, everyone using the vault backend has been relying on it and they have been adding their vault secrets in the wrong location (without label). Fixing this behaviour is going to break all those applications using the vault backend.  

## Update 23 Sep. 2024
I've updated the PR with the following changes:

- Added a feature flag (`enableLabel`) for the new changes (using label in search). The feature flag (`enableLabel`) is `off` by default. 

- Added the `defaultLabel` to Vault properties. It is `master` by default and only used when above feature flag is `on`.

- When above feature flag is `on`, the vault secrets should have always all three segments ( `[application name | 'application'],[profile | 'default'],[label | 'master']` )  in their paths. 

- Updated the vault docs.   