### PR TITLE
Makes default-label in CredhubEnvironmentRepository configurable

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/credhub-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/credhub-backend.adoc
@@ -52,7 +52,10 @@ All client applications with the name `spring.cloud.config.name=demo-app` will h
 }
 ----
 
-NOTE: When no profile is specified `default` will be used and when no label is specified `master` will be used as a default value.
+NOTE: When no label is specified `master` will be used as a default value. You can change that by setting `spring.cloud.config.server.credhub.defaultLabel`.
+
+NOTE: When no profile is specified `default` will be used.
+
 NOTE: Values added to `application` will be shared by all the applications.
 
 [[oauth-2-0]]

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentProperties.java
@@ -26,7 +26,17 @@ import org.springframework.core.Ordered;
 @ConfigurationProperties("spring.cloud.config.server.credhub")
 public class CredhubEnvironmentProperties implements EnvironmentRepositoryProperties {
 
+	private String defaultLabel = "master";
+
 	private int order = Ordered.LOWEST_PRECEDENCE;
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
+	}
+
+	public String getDefaultLabel() {
+		return defaultLabel;
+	}
 
 	public int getOrder() {
 		return this.order;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
@@ -43,16 +43,23 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 
 	private static final String DEFAULT_PROFILE = "default";
 
-	private static final String DEFAULT_LABEL = "master";
-
 	private static final String DEFAULT_APPLICATION = "application";
 
-	private int order = Ordered.LOWEST_PRECEDENCE;
+	private final String defaultLabel;
+
+	private int order;
 
 	private final CredHubOperations credHubOperations;
 
 	public CredhubEnvironmentRepository(CredHubOperations credHubOperations) {
+		this(credHubOperations, new CredhubEnvironmentProperties());
+	}
+
+	public CredhubEnvironmentRepository(CredHubOperations credHubOperations, CredhubEnvironmentProperties properties) {
 		this.credHubOperations = credHubOperations;
+
+		this.order = properties.getOrder();
+		this.defaultLabel = properties.getDefaultLabel();
 	}
 
 	@Override
@@ -61,7 +68,7 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 			profile = DEFAULT_PROFILE;
 		}
 		if (ObjectUtils.isEmpty(label)) {
-			label = DEFAULT_LABEL;
+			label = this.defaultLabel;
 		}
 
 		List<String> applications = normalize(application, DEFAULT_APPLICATION);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryFactory.java
@@ -25,7 +25,7 @@ import org.springframework.credhub.core.CredHubOperations;
 public class CredhubEnvironmentRepositoryFactory
 		implements EnvironmentRepositoryFactory<CredhubEnvironmentRepository, CredhubEnvironmentProperties> {
 
-	private CredHubOperations credhubOperations;
+	private final CredHubOperations credhubOperations;
 
 	public CredhubEnvironmentRepositoryFactory(CredHubOperations credhubOperations) {
 		this.credhubOperations = credhubOperations;
@@ -33,9 +33,7 @@ public class CredhubEnvironmentRepositoryFactory
 
 	@Override
 	public CredhubEnvironmentRepository build(CredhubEnvironmentProperties environmentProperties) {
-		CredhubEnvironmentRepository repository = new CredhubEnvironmentRepository(this.credhubOperations);
-		repository.setOrder(environmentProperties.getOrder());
-		return repository;
+		return new CredhubEnvironmentRepository(this.credhubOperations, environmentProperties);
 	}
 
 }


### PR DESCRIPTION
the default-label in `credhub` backend should be configurable, similar to `git`, `jdbc` and other backends. 