### PR TITLE
Enables defining a base path for CredHub credentials

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/credhub-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/credhub-backend.adoc
@@ -106,3 +106,21 @@ spring:
 
 NOTE: The used UAA client-id should have `credhub.read` as scope.
 
+The following table describes the CredHub configuration properties.
+
+|===
+|Property Name |Remarks
+
+|*url*
+|CredHub server URL.
+
+|*path*
+|Base path for all credentials. Optional, defaults to empty.
+
+|*defaultLabel*
+| Default label to use when is not provided by client application. Optional, defaults to `master`.
+
+|*oauth2*
+| OAuth2 configuration to access CredHub. Optional.
+
+|===

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentProperties.java
@@ -26,16 +26,28 @@ import org.springframework.core.Ordered;
 @ConfigurationProperties("spring.cloud.config.server.credhub")
 public class CredhubEnvironmentProperties implements EnvironmentRepositoryProperties {
 
+	/** The common base path for credentials in CredHub. It is empty by default. */
+	private String path = "";
+
+	/** The default label to be used when is not provided by client applications. */
 	private String defaultLabel = "master";
 
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
-	public void setDefaultLabel(String defaultLabel) {
-		this.defaultLabel = defaultLabel;
+	public String getPath() {
+		return this.path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
 	}
 
 	public String getDefaultLabel() {
 		return defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
 	}
 
 	public int getOrder() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepository.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +46,8 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 
 	private static final String DEFAULT_APPLICATION = "application";
 
+	private final String path;
+
 	private final String defaultLabel;
 
 	private int order;
@@ -58,8 +61,9 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 	public CredhubEnvironmentRepository(CredHubOperations credHubOperations, CredhubEnvironmentProperties properties) {
 		this.credHubOperations = credHubOperations;
 
-		this.order = properties.getOrder();
+		this.path = properties.getPath();
 		this.defaultLabel = properties.getDefaultLabel();
+		this.order = properties.getOrder();
 	}
 
 	@Override
@@ -109,7 +113,7 @@ public class CredhubEnvironmentRepository implements EnvironmentRepository, Orde
 	}
 
 	private Map<Object, Object> findProperties(String application, String profile, String label) {
-		String path = "/" + application + "/" + profile + "/" + label;
+		var path = Path.of("/", this.path, application, profile, label).toString();
 
 		return this.credHubOperations.credentials()
 			.findByPath(path)

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/CredhubEnvironmentRepositoryTests.java
@@ -281,6 +281,28 @@ public class CredhubEnvironmentRepositoryTests {
 		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k2", "v2"));
 	}
 
+	@Test
+	public void shouldUseBasePathIfProvided() {
+		stubCredentials("/base/path/myApp/default/master", credential("c1", "k1", "v1"));
+
+		var credhubOperations = Mockito.mock(CredHubOperations.class);
+		when(credhubOperations.credentials()).thenReturn(this.credhubCredentialOperations);
+
+		var properties = new CredhubEnvironmentProperties();
+		properties.setPath("/base/path");
+
+		var environment = new CredhubEnvironmentRepository(credhubOperations, properties).findOne("myApp", null, null);
+
+		assertThat(environment.getName()).isEqualTo("myApp");
+		assertThat(environment.getProfiles()).containsExactly("default");
+		assertThat(environment.getLabel()).isEqualTo("master");
+
+		assertThat(environment.getPropertySources()).hasSize(1);
+
+		assertThat(environment.getPropertySources().get(0).getName()).isEqualTo("credhub-myApp-default-master");
+		assertThat(environment.getPropertySources().get(0).getSource()).isEqualTo(Map.of("k1", "v1"));
+	}
+
 	@SafeVarargs
 	private void stubCredentials(String path, CredentialDetails<JsonCredential>... details) {
 		when(this.credhubCredentialOperations.findByPath(path)).thenReturn(


### PR DESCRIPTION
When several instances of config-server using the same CredHub server, it is a common practice to separate each config-server credentials with a common base path. 
For example, for given config-servers `foo` and `bar`, we can have following paths in CredHub:
- `/SERVER/FOO/secret/a`
- `/SERVER/FOO/secret/b`
- ...
- `/SERVER/BAR/secret/x`
- `/SERVER/BAR/secret/y`
- ...

This approach even enables CredHub admins to limit access to those base paths to certain servers only. So server `foo` can only access to credentials stored under `/server/foo` and server `bar` can only access credentials under `/server/bar`. 

This PR adds an optional CredHub property called `path` which should prepend to all credentials stored or retrieved by this config server. Default value is empty. 