### PR TITLE
fix: use withLogger of RetryTemplateBuilder to avoid reflections

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/RetryTemplateFactory.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/RetryTemplateFactory.java
@@ -16,43 +16,23 @@
 
 package org.springframework.cloud.config.client;
 
-import java.lang.reflect.Field;
-
 import org.apache.commons.logging.Log;
 
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.ReflectionUtils;
 
 public final class RetryTemplateFactory {
-
-	private static final Field field;
-
-	static {
-		field = ReflectionUtils.findField(RetryTemplate.class, "logger");
-		if (field != null) {
-			ReflectionUtils.makeAccessible(field);
-		}
-	}
 
 	private RetryTemplateFactory() {
 
 	}
 
 	public static RetryTemplate create(RetryProperties properties, Log log) {
-		RetryTemplate retryTemplate = RetryTemplate.builder()
+		return RetryTemplate.builder()
 			.maxAttempts(properties.getMaxAttempts())
 			.exponentialBackoff(properties.getInitialInterval(), properties.getMultiplier(),
 					properties.getMaxInterval(), properties.isUseRandomPolicy())
+			.withLogger(log)
 			.build();
-		try {
-			field.set(retryTemplate, log);
-		}
-		catch (IllegalAccessException e) {
-			if (log.isErrorEnabled()) {
-				log.error("error setting retry log", e);
-			}
-		}
-		return retryTemplate;
 	}
 
 }

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -18,6 +18,7 @@
 		<jgit.version>6.6.1.202309021850-r</jgit.version>
 		<spring-vault.version>3.1.1</spring-vault.version>
 		<spring-credhub.version>2.1.1.RELEASE</spring-credhub.version>
+		<spring-retry.version>2.0.10</spring-retry.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -40,6 +41,11 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-config-monitor</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.retry</groupId>
+				<artifactId>spring-retry</artifactId>
+				<version>${spring-retry.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.vault</groupId>


### PR DESCRIPTION
This PR is using the new `withLogger` method of `RetryTemplateBuilder` to avoid reflections.

**WARNING**: spring-retry needs to be released with version 2.0.10 first.

fixes: https://github.com/spring-cloud/spring-cloud-config/issues/2544