### PR TITLE
Fixes the SpringVaultEnvironmentRepository issue with composite profile

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -88,12 +88,15 @@ import org.springframework.cloud.config.server.environment.SvnKitEnvironmentRepo
 import org.springframework.cloud.config.server.environment.VaultEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.VaultEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.VaultEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.vault.SpringVaultClientAuthenticationProvider;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultClientConfiguration;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.vault.SpringVaultTemplateBuilder;
 import org.springframework.cloud.config.server.support.GitCredentialsProviderFactory;
 import org.springframework.cloud.config.server.support.GoogleCloudSourceSupport;
 import org.springframework.cloud.config.server.support.TransportConfigCallbackFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -319,10 +322,18 @@ public class EnvironmentRepositoryConfiguration {
 	static class SpringVaultFactoryConfig {
 
 		@Bean
+		public SpringVaultTemplateBuilder springVaultTemplateBuilder(ConfigTokenProvider configTokenProvider,
+				List<SpringVaultClientAuthenticationProvider> authProviders, ApplicationContext applicationContext) {
+			return new SpringVaultTemplateBuilder(configTokenProvider, authProviders, applicationContext);
+		}
+
+		@Bean
 		public SpringVaultEnvironmentRepositoryFactory vaultEnvironmentRepositoryFactory(
 				ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
-				SpringVaultClientConfiguration vaultClientConfiguration) {
-			return new SpringVaultEnvironmentRepositoryFactory(request, watch, vaultClientConfiguration);
+				SpringVaultClientConfiguration vaultClientConfiguration,
+				SpringVaultTemplateBuilder springVaultTemplateBuilder) {
+			return new SpringVaultEnvironmentRepositoryFactory(request, watch, vaultClientConfiguration,
+					springVaultTemplateBuilder);
 		}
 
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java
@@ -39,6 +39,8 @@ public class SpringVaultEnvironmentRepositoryFactory
 
 	private final SpringVaultClientConfiguration clientConfiguration;
 
+	private SpringVaultTemplateBuilder vaultTemplateBuilder;
+
 	public SpringVaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
 			SpringVaultClientConfiguration clientConfiguration) {
 		this.request = request;
@@ -46,9 +48,18 @@ public class SpringVaultEnvironmentRepositoryFactory
 		this.clientConfiguration = clientConfiguration;
 	}
 
+	public SpringVaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
+			SpringVaultClientConfiguration clientConfiguration, SpringVaultTemplateBuilder vaultTemplateBuilder) {
+		this.request = request;
+		this.watch = watch;
+		this.clientConfiguration = clientConfiguration;
+		this.vaultTemplateBuilder = vaultTemplateBuilder;
+	}
+
 	@Override
 	public SpringVaultEnvironmentRepository build(VaultEnvironmentProperties vaultProperties) {
-		VaultTemplate vaultTemplate = clientConfiguration.vaultTemplate();
+		VaultTemplate vaultTemplate = this.vaultTemplateBuilder != null
+				? this.vaultTemplateBuilder.build(vaultProperties) : clientConfiguration.vaultTemplate();
 
 		VaultKeyValueOperations accessStrategy = buildVaultAccessStrategy(vaultProperties, vaultTemplate);
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment.vault;
+
+import java.util.List;
+
+import org.springframework.cloud.config.server.environment.ConfigTokenProvider;
+import org.springframework.cloud.config.server.environment.VaultEnvironmentProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.vault.core.VaultTemplate;
+
+/**
+ * @author Kaveh Shamsi
+ */
+public class SpringVaultTemplateBuilder {
+
+	private final ConfigTokenProvider configTokenProvider;
+
+	private final List<SpringVaultClientAuthenticationProvider> authProviders;
+
+	private final ApplicationContext applicationContext;
+
+	public SpringVaultTemplateBuilder(ConfigTokenProvider configTokenProvider,
+			List<SpringVaultClientAuthenticationProvider> authProviders, ApplicationContext applicationContext) {
+
+		this.configTokenProvider = configTokenProvider;
+		this.authProviders = authProviders;
+		this.applicationContext = applicationContext;
+	}
+
+	public VaultTemplate build(VaultEnvironmentProperties vaultProperties) {
+		SpringVaultClientConfiguration clientConfiguration = new SpringVaultClientConfiguration(vaultProperties,
+				configTokenProvider, authProviders);
+		clientConfiguration.setApplicationContext(applicationContext);
+		return clientConfiguration.vaultTemplate();
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactoryTests.java
@@ -30,6 +30,8 @@ import org.springframework.vault.core.VaultTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -37,39 +39,73 @@ import static org.mockito.Mockito.when;
  */
 public class SpringVaultEnvironmentRepositoryFactoryTests {
 
+	private final SpringVaultClientConfiguration clientConfiguration = mock(SpringVaultClientConfiguration.class);
+
+	private final SpringVaultTemplateBuilder vaultTemplateBuilder = mock(SpringVaultTemplateBuilder.class);
+
+	private final VaultTemplate vaultTemplate = new VaultTemplate(VaultEndpoint.create("localhost", 8200),
+			new TokenAuthentication("token"));
+
 	@Test
 	public void buildForVersion1() {
 		VaultEnvironmentProperties properties = new VaultEnvironmentProperties();
+		when(clientConfiguration.vaultTemplate()).thenReturn(vaultTemplate);
 
 		SpringVaultEnvironmentRepository environmentRepository = new SpringVaultEnvironmentRepositoryFactory(
-				mockHttpRequest(), new EnvironmentWatch.Default(), mockClientConfiguration())
+				mockHttpRequest(), new EnvironmentWatch.Default(), clientConfiguration)
 			.build(properties);
 
 		VaultKeyValueOperations keyValueTemplate = environmentRepository.getKeyValueTemplate();
 		assertThat(keyValueTemplate.getApiVersion()).isEqualTo(VaultKeyValueOperationsSupport.KeyValueBackend.KV_1);
+		verify(clientConfiguration).vaultTemplate();
+		verifyNoMoreInteractions(clientConfiguration, vaultTemplateBuilder);
+	}
+
+	@Test
+	public void buildForVersion1WithVaultTemplateBuilder() {
+		VaultEnvironmentProperties properties = new VaultEnvironmentProperties();
+		when(vaultTemplateBuilder.build(properties)).thenReturn(vaultTemplate);
+
+		SpringVaultEnvironmentRepository environmentRepository = new SpringVaultEnvironmentRepositoryFactory(
+				mockHttpRequest(), new EnvironmentWatch.Default(), clientConfiguration, vaultTemplateBuilder)
+			.build(properties);
+
+		VaultKeyValueOperations keyValueTemplate = environmentRepository.getKeyValueTemplate();
+		assertThat(keyValueTemplate.getApiVersion()).isEqualTo(VaultKeyValueOperationsSupport.KeyValueBackend.KV_1);
+		verify(vaultTemplateBuilder).build(properties);
+		verifyNoMoreInteractions(clientConfiguration, vaultTemplateBuilder);
 	}
 
 	@Test
 	public void buildForVersion2() {
 		VaultEnvironmentProperties properties = new VaultEnvironmentProperties();
 		properties.setKvVersion(2);
+		when(clientConfiguration.vaultTemplate()).thenReturn(vaultTemplate);
 
 		SpringVaultEnvironmentRepository environmentRepository = new SpringVaultEnvironmentRepositoryFactory(
-				mockHttpRequest(), new EnvironmentWatch.Default(), mockClientConfiguration())
+				mockHttpRequest(), new EnvironmentWatch.Default(), clientConfiguration)
 			.build(properties);
 
 		VaultKeyValueOperations keyValueTemplate = environmentRepository.getKeyValueTemplate();
 		assertThat(keyValueTemplate.getApiVersion()).isEqualTo(VaultKeyValueOperationsSupport.KeyValueBackend.KV_2);
+		verify(clientConfiguration).vaultTemplate();
+		verifyNoMoreInteractions(clientConfiguration, vaultTemplateBuilder);
 	}
 
-	private SpringVaultClientConfiguration mockClientConfiguration() {
-		VaultTemplate vaultTemplate = new VaultTemplate(VaultEndpoint.create("localhost", 8200),
-				new TokenAuthentication("token"));
+	@Test
+	public void buildForVersion2WithVaultTemplateBuilder() {
+		VaultEnvironmentProperties properties = new VaultEnvironmentProperties();
+		properties.setKvVersion(2);
+		when(vaultTemplateBuilder.build(properties)).thenReturn(vaultTemplate);
 
-		SpringVaultClientConfiguration clientConfiguration = mock(SpringVaultClientConfiguration.class);
-		when(clientConfiguration.vaultTemplate()).thenReturn(vaultTemplate);
+		SpringVaultEnvironmentRepository environmentRepository = new SpringVaultEnvironmentRepositoryFactory(
+				mockHttpRequest(), new EnvironmentWatch.Default(), clientConfiguration, vaultTemplateBuilder)
+			.build(properties);
 
-		return clientConfiguration;
+		VaultKeyValueOperations keyValueTemplate = environmentRepository.getKeyValueTemplate();
+		assertThat(keyValueTemplate.getApiVersion()).isEqualTo(VaultKeyValueOperationsSupport.KeyValueBackend.KV_2);
+		verify(vaultTemplateBuilder).build(properties);
+		verifyNoMoreInteractions(clientConfiguration, vaultTemplateBuilder);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes #2592

 So the [SpringVaultEnvironmentRepositoryFactory::build ](https://github.com/spring-cloud/spring-cloud-config/blob/6a5c51b62b159e088d1dfbc7584e3b928e5c159a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java#L50)was being called with the correct instance of `VaultEnvironmentProperties` but it was not using those properties for creation of VaultTemplate. Instead it was using the injected instance of `SpringVaultClientConfiguration` which had only the vault properties provided under `spring.cloud.config.server.vault`. 