### PR TITLE
Fixes the SpringVaultEnvironmentRepository issue with composite profile

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -85,12 +85,15 @@ import org.springframework.cloud.config.server.environment.SvnKitEnvironmentRepo
 import org.springframework.cloud.config.server.environment.VaultEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.VaultEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.VaultEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.vault.SpringVaultClientAuthenticationProvider;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultClientConfiguration;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.vault.SpringVaultEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.vault.SpringVaultTemplateBuilder;
 import org.springframework.cloud.config.server.support.GitCredentialsProviderFactory;
 import org.springframework.cloud.config.server.support.GoogleCloudSourceSupport;
 import org.springframework.cloud.config.server.support.TransportConfigCallbackFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -313,10 +316,15 @@ public class EnvironmentRepositoryConfiguration {
 	static class SpringVaultFactoryConfig {
 
 		@Bean
+		public SpringVaultTemplateBuilder springVaultTemplateBuilder(ConfigTokenProvider configTokenProvider,
+				List<SpringVaultClientAuthenticationProvider> authProviders, ApplicationContext applicationContext) {
+			return new SpringVaultTemplateBuilder(configTokenProvider, authProviders, applicationContext);
+		}
+
+		@Bean
 		public SpringVaultEnvironmentRepositoryFactory vaultEnvironmentRepositoryFactory(
-				ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
-				SpringVaultClientConfiguration vaultClientConfiguration) {
-			return new SpringVaultEnvironmentRepositoryFactory(request, watch, vaultClientConfiguration);
+				ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch, SpringVaultTemplateBuilder springVaultTemplateBuilder) {
+			return new SpringVaultEnvironmentRepositoryFactory(request, watch, springVaultTemplateBuilder);
 		}
 
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java
@@ -37,8 +37,11 @@ public class SpringVaultEnvironmentRepositoryFactory
 
 	private final EnvironmentWatch watch;
 
-	private final SpringVaultClientConfiguration clientConfiguration;
+	private SpringVaultClientConfiguration clientConfiguration;
 
+	private SpringVaultTemplateBuilder vaultTemplateBuilder;
+
+	@Deprecated
 	public SpringVaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch,
 			SpringVaultClientConfiguration clientConfiguration) {
 		this.request = request;
@@ -46,9 +49,16 @@ public class SpringVaultEnvironmentRepositoryFactory
 		this.clientConfiguration = clientConfiguration;
 	}
 
+	public SpringVaultEnvironmentRepositoryFactory(ObjectProvider<HttpServletRequest> request, EnvironmentWatch watch, SpringVaultTemplateBuilder vaultTemplateBuilder) {
+		this.request = request;
+		this.watch = watch;
+		this.vaultTemplateBuilder = vaultTemplateBuilder;
+	}
+
 	@Override
 	public SpringVaultEnvironmentRepository build(VaultEnvironmentProperties vaultProperties) {
-		VaultTemplate vaultTemplate = clientConfiguration.vaultTemplate();
+		VaultTemplate vaultTemplate = this.vaultTemplateBuilder != null
+				? this.vaultTemplateBuilder.build(vaultProperties) : clientConfiguration.vaultTemplate();
 
 		VaultKeyValueOperations accessStrategy = buildVaultAccessStrategy(vaultProperties, vaultTemplate);
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment.vault;
+
+import java.util.List;
+
+import org.springframework.cloud.config.server.environment.ConfigTokenProvider;
+import org.springframework.cloud.config.server.environment.VaultEnvironmentProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.vault.core.VaultTemplate;
+
+/**
+ * @author Kaveh Shamsi
+ */
+public class SpringVaultTemplateBuilder {
+
+	private final ConfigTokenProvider configTokenProvider;
+
+	private final List<SpringVaultClientAuthenticationProvider> authProviders;
+
+	private final ApplicationContext applicationContext;
+
+	public SpringVaultTemplateBuilder(ConfigTokenProvider configTokenProvider,
+			List<SpringVaultClientAuthenticationProvider> authProviders, ApplicationContext applicationContext) {
+
+		this.configTokenProvider = configTokenProvider;
+		this.authProviders = authProviders;
+		this.applicationContext = applicationContext;
+	}
+
+	public VaultTemplate build(VaultEnvironmentProperties vaultProperties) {
+		SpringVaultClientConfiguration clientConfiguration = new SpringVaultClientConfiguration(vaultProperties,
+				configTokenProvider, authProviders);
+		clientConfiguration.setApplicationContext(applicationContext);
+		return clientConfiguration.vaultTemplate();
+	}
+
+}


### PR DESCRIPTION
Fixes #2592

 So the [SpringVaultEnvironmentRepositoryFactory::build ](https://github.com/spring-cloud/spring-cloud-config/blob/6a5c51b62b159e088d1dfbc7584e3b928e5c159a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultEnvironmentRepositoryFactory.java#L50)was being called with the correct instance of `VaultEnvironmentProperties` but it was not using those properties for creation of VaultTemplate. Instead it was using the injected instance of `SpringVaultClientConfiguration` which had only the vault properties provided under `spring.cloud.config.server.vault`. 