### PR TITLE
Only ignore profile activation and inclusion if the property source is profile specific

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -159,7 +159,6 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 							String propertySourceName = propertySource.getName();
 							List<Option> options = new ArrayList<>();
 							options.add(Option.IGNORE_IMPORTS);
-							options.add(Option.IGNORE_PROFILES);
 							// TODO: the profile is now available on the backend
 							// in a future minor, add the profile associated with a
 							// PropertySource see
@@ -180,6 +179,7 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 										&& propertySourceName.matches(".*[-,]" + profile + "\\b.*"))) {
 									// // TODO: switch to Options.with() when implemented
 									options.add(Option.PROFILE_SPECIFIC);
+									options.add(Option.IGNORE_PROFILES);
 								}
 							}
 							return ConfigData.Options.of(options.toArray(new Option[0]));

--- a/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
+++ b/spring-cloud-config-client/src/test/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoaderTests.java
@@ -406,10 +406,16 @@ public class ConfigServerConfigDataLoaderTests {
 		assertThat(configData.getPropertySources()).hasSize(3);
 		assertThat(configData.getOptions(configData.getPropertySources().get(0))
 			.contains(ConfigData.Option.IGNORE_IMPORTS)).isTrue();
+		assertThat(configData.getOptions(configData.getPropertySources().get(0))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(1))
 			.contains(ConfigData.Option.IGNORE_IMPORTS)).isTrue();
+		assertThat(configData.getOptions(configData.getPropertySources().get(1))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(2))
 			.contains(ConfigData.Option.IGNORE_IMPORTS)).isTrue();
+		assertThat(configData.getOptions(configData.getPropertySources().get(2))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 
 	}
 
@@ -532,18 +538,32 @@ public class ConfigServerConfigDataLoaderTests {
 		assertThat(configData.getPropertySources()).hasSize(7);
 		assertThat(configData.getOptions(configData.getPropertySources().get(0))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isFalse();
+		assertThat(configData.getOptions(configData.getPropertySources().get(0))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(1))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isTrue();
+		assertThat(configData.getOptions(configData.getPropertySources().get(1))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isTrue();
 		assertThat(configData.getOptions(configData.getPropertySources().get(2))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isFalse();
+		assertThat(configData.getOptions(configData.getPropertySources().get(2))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(3))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isFalse();
+		assertThat(configData.getOptions(configData.getPropertySources().get(3))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(4))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isFalse();
+		assertThat(configData.getOptions(configData.getPropertySources().get(4))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(5))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isFalse();
+		assertThat(configData.getOptions(configData.getPropertySources().get(5))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isFalse();
 		assertThat(configData.getOptions(configData.getPropertySources().get(6))
 			.contains(ConfigData.Option.PROFILE_SPECIFIC)).isTrue();
+		assertThat(configData.getOptions(configData.getPropertySources().get(6))
+			.contains(ConfigData.Option.IGNORE_PROFILES)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
If we set the flag on all property sources (like we do currently) then any profiles that should be activated via `spring.profiles.active` or `spring.profiles.include` coming from the config server will not be activated in the application.