### PR TITLE
Fixes: ConfigClientProperties#uri can't be set correctly as the ConfigClientProperties in BootstrapContext will be replaced  

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceMonitor.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceMonitor.java
@@ -50,6 +50,10 @@ final class ConfigServerInstanceMonitor implements SmartApplicationListener {
 		this.instanceProvider = instanceProvider;
 	}
 
+	public ConfigClientProperties getConfig() {
+		return config;
+	}
+
 	void setRefreshOnStartup(boolean refreshOnStartup) {
 		this.refreshOnStartup = refreshOnStartup;
 	}


### PR DESCRIPTION
Every time org.springframework.cloud.config.client.ConfigServerConfigDataLocationResolver#resolveProfileSpecific be invoked, it will create a new ConfigClientProperties and replace the ConfigClientProperties in the BootstrapContext, but the ConfigClientProperties in the ConfigServerInstanceMonitor will be only set in the first time invoke.
Though, org.springframework.cloud.config.client.ConfigServerConfigDataLocationResolver#loadProperties will replace the org.springframework.cloud.config.client.ConfigClientProperties#uri if spring.cloud.config.discovery.enabled equals true, but the uri is get from the ConfigClientProperties from BootstrapContext which was replaced.