### PR TITLE
Use ConfigInstanceMonitor for connection details

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLocationResolver.java
@@ -123,16 +123,17 @@ public class ConfigServerConfigDataLocationResolver
 				.orElse(false);
 			// In the case where discovery is enabled we need to extract the config server
 			// uris, username, and password
-			// from the properties from the context. These are set in
+			// from the ConfigServiceMonitor. These are set in
 			// ConfigServerInstanceMonitor.refresh which will only
 			// be called the first time we fetch configuration.
+			// They will continue to be updated as HeartbeatEvents are received.
 			if (discoveryEnabled) {
-				ConfigClientProperties bootstrapConfigClientProperties = context.getBootstrapContext()
-					.get(ConfigClientProperties.class);
+				ConfigServerInstanceMonitor instanceMonitor = context.getBootstrapContext()
+					.get(ConfigServerInstanceMonitor.class);
 
-				configClientProperties.setUri(bootstrapConfigClientProperties.getUri());
-				configClientProperties.setPassword(bootstrapConfigClientProperties.getPassword());
-				configClientProperties.setUsername(bootstrapConfigClientProperties.getUsername());
+				configClientProperties.setUri(instanceMonitor.getUri());
+				configClientProperties.setPassword(instanceMonitor.getPassword());
+				configClientProperties.setUsername(instanceMonitor.getUsername());
 			}
 		}
 		else {

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceMonitor.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerInstanceMonitor.java
@@ -82,6 +82,18 @@ final class ConfigServerInstanceMonitor implements SmartApplicationListener {
 		}
 	}
 
+	String[] getUri() {
+		return this.config.getUri();
+	}
+
+	String getUsername() {
+		return this.config.getUsername();
+	}
+
+	String getPassword() {
+		return this.config.getPassword();
+	}
+
 	void refresh() {
 		try {
 			String serviceId = this.config.getDiscovery().getServiceId();


### PR DESCRIPTION
The ConfigInstanceMonitor always has the most up to date connection details for the config server instances.  They are updated by the HeartBeatEvent.  Fixes #2624