### PR TITLE
Support multiple Spring application names for AWS Secrets Manager

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -112,24 +112,26 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 
 		List<String> reversedProfiles = new ArrayList<>(Arrays.asList(profiles));
 		Collections.reverse(reversedProfiles);
+		if (!reversedProfiles.contains(defaultProfile)) {
+			reversedProfiles.add(defaultProfile);
+		}
+
+		List<String> applications = Arrays.asList(StringUtils.commaDelimitedListToStringArray(application));
+		Collections.reverse(applications);
+		if (!applications.contains(defaultApplication)) {
+			applications = new ArrayList<>(applications);
+			applications.add(defaultApplication);
+		}
+
 		for (String l : labels) {
 			for (String profile : reversedProfiles) {
-				addPropertySource(environment, application, profile, l);
-				if (!defaultApplication.equals(application)) {
-					addPropertySource(environment, defaultApplication, profile, l);
+				for (String app : applications) {
+					addPropertySource(environment, app, profile, l);
 				}
 			}
-			if (!Arrays.asList(profiles).contains(defaultProfile)) {
-				addPropertySource(environment, application, defaultProfile, l);
+			for (String app : applications) {
+				addPropertySource(environment, app, null, l);
 			}
-			if (!Arrays.asList(profiles).contains(defaultProfile) && !defaultApplication.equals(application)) {
-				addPropertySource(environment, defaultApplication, defaultProfile, l);
-			}
-
-			if (!defaultApplication.equals(application)) {
-				addPropertySource(environment, application, null, l);
-			}
-			addPropertySource(environment, defaultApplication, null, l);
 		}
 
 		return environment;


### PR DESCRIPTION
### Support multiple spring application names for AWS Secret Manager

Spring Cloud Config supports multiple application names in backends like Git and Vault, but this feature seems to be missing in AWS Secret Manager. This change enables AWS Secret Manager to handle comma-separated application names, aligning with these backends. 

This implementation is similar to PR [#1379](https://github.com/spring-cloud/spring-cloud-config/pull/1379), which added support for multiple applications in the Vault backend, and resolves the limitations discussed in [issue #1356](https://github.com/spring-cloud/spring-cloud-config/issues/1356).

#### What’s Changed
- Enabled processing of comma-separated application names for AWS Secret Manager, allowing it to handle multiple applications like Git and Vault backends.

#### Why This Matters
- Teams migrating from Git or Vault to AWS Secret Manager can now use the same configuration structure.

#### Testing
- Added test cases for:
  - Non-existing profile and label.
  - Default profile with an existing label.
  - Existing profile with null label.

