### PR TITLE
Config Client: Fix logic to try all URLs

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServerConfigDataLoader.java
@@ -369,7 +369,22 @@ public class ConfigServerConfigDataLoader implements ConfigDataLoader<ConfigServ
 				}
 			}
 
-			if (response == null || response.getStatusCode() != HttpStatus.OK) {
+			if (response == null) {
+				if (i < noOfUrls - 1 && properties.getMultipleUriStrategy() == MultipleUriStrategy.ALWAYS) {
+					logger.info("Failed to fetch configs from server at  : " + uri
+							+ ". The response was null. Will try the next url if available.");
+					continue;
+				}
+
+				return null;
+			}
+			else if (response.getStatusCode() != HttpStatus.OK) {
+				if (i < noOfUrls - 1 && properties.getMultipleUriStrategy() == MultipleUriStrategy.ALWAYS) {
+					logger.info("Failed to fetch configs from server at  : " + uri
+							+ ". Will try the next url if available. StatusCode : " + response.getStatusCode());
+					continue;
+				}
+
 				return null;
 			}
 

--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigServicePropertySourceLocator.java
@@ -307,7 +307,22 @@ public class ConfigServicePropertySourceLocator implements PropertySourceLocator
 				}
 			}
 
-			if (response == null || response.getStatusCode() != HttpStatus.OK) {
+			if (response == null) {
+				if (i < noOfUrls - 1 && defaultProperties.getMultipleUriStrategy() == MultipleUriStrategy.ALWAYS) {
+					logger.info("Failed to fetch configs from server at  : " + uri
+							+ ". The response was null. Will try the next url if available.");
+					continue;
+				}
+
+				return null;
+			}
+			else if (response.getStatusCode() != HttpStatus.OK) {
+				if (i < noOfUrls - 1 && defaultProperties.getMultipleUriStrategy() == MultipleUriStrategy.ALWAYS) {
+					logger.info("Failed to fetch configs from server at  : " + uri
+							+ ". Will try the next url if available. StatusCode : " + response.getStatusCode());
+					continue;
+				}
+
 				return null;
 			}
 


### PR DESCRIPTION
There was a miss when implementing the MultipleUriStrategy.ALWAYS. It was not trying the next URL if response was null, or if the HTTP Status Code was not OK, but no exception was thrown.

(This author does not know under what scenario null would be returned as a response, but the code was already checking for it, so I updated the logic to also try the next URL for null response.)

Closes gh-2735