### PR TITLE
Make S3 and Git backends more compatible

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
@@ -34,7 +34,34 @@ It is also possible to specify an AWS URL to link:https://aws.amazon.com/blogs/d
 
 Credentials are found using the link:https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html[Default Credential Provider Chain]. Versioned and encrypted buckets are supported without further configuration.
 
-Configuration files are stored in your bucket as `\{application}-\{profile}.properties`, `\{application}-\{profile}.yml` or `\{application}-\{profile}.json`. An optional label can be provided to specify a directory path to the file.
+By default, configuration files are stored in your bucket as `\{application}-\{profile}.properties`, `\{application}-\{profile}.yml` or `\{application}-\{profile}.json`. An optional label can be provided to specify a directory path to the file.
 
 NOTE: When no profile is specified `default` will be used.
 
+[[directory-layout]]
+== Directory layout
+
+Spring Cloud Config Server also supports per-app directory layout analogous to https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_placeholders_in_git_search_paths[`search-paths: '{application}'`] in Git backend, as shown in the following example:
+
+[source,yaml]
+----
+spring:
+  cloud:
+    config:
+      server:
+        awss3:
+          region: us-east-1
+          bucket: bucket1
+          useDirectoryLayout: true
+----
+
+The preceding listing matches objects stored in your bucket in `/{application}` directory like: `/{application}/application{-profile}.yml`. Then structure of the bucket should look like this:
+
+```
+├── foo
+│   ├── application-test.yml
+│   └── application.yml
+├── bar
+│   ├── application-test.yml
+│   └── application.yml
+```

--- a/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
@@ -41,7 +41,9 @@ NOTE: When no profile is specified `default` will be used.
 [[directory-layout]]
 == Directory layout
 
-Spring Cloud Config Server also supports per-app directory layout analogous to xref:git-backend.adoc#placeholders-in-git-search-paths[`search-paths: '{application}'`] in Git backend, as shown in the following example:
+Spring Cloud Config Server also supports per-app directory layout analogous to xref:git-backend.adoc#placeholders-in-git-search-paths[`search-paths: '{application}'`] in Git backend.
+
+In order to enable it set `useDirectoryLayout` property to `true` as shown in the following example:
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/aws-s3-backend.adoc
@@ -41,7 +41,7 @@ NOTE: When no profile is specified `default` will be used.
 [[directory-layout]]
 == Directory layout
 
-Spring Cloud Config Server also supports per-app directory layout analogous to https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_placeholders_in_git_search_paths[`search-paths: '{application}'`] in Git backend, as shown in the following example:
+Spring Cloud Config Server also supports per-app directory layout analogous to xref:git-backend.adoc#placeholders-in-git-search-paths[`search-paths: '{application}'`] in Git backend, as shown in the following example:
 
 [source,yaml]
 ----

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentProperties.java
@@ -40,6 +40,12 @@ public class AwsS3EnvironmentProperties implements EnvironmentRepositoryProperti
 	 */
 	private String bucket;
 
+	/**
+	 * Use application name as intermediate directory. Analogous to `searchPaths:
+	 * {application}` from Git backend.
+	 */
+	private boolean useDirectoryLayout;
+
 	private int order = DEFAULT_ORDER;
 
 	public String getRegion() {
@@ -64,6 +70,14 @@ public class AwsS3EnvironmentProperties implements EnvironmentRepositoryProperti
 
 	public void setBucket(String bucket) {
 		this.bucket = bucket;
+	}
+
+	public boolean isUseDirectoryLayout() {
+		return useDirectoryLayout;
+	}
+
+	public void setUseDirectoryLayout(boolean useDirectoryLayout) {
+		this.useDirectoryLayout = useDirectoryLayout;
 	}
 
 	public int getOrder() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
@@ -39,7 +39,7 @@ public class AwsS3EnvironmentRepositoryFactory
 		final S3Client client = clientBuilder.build();
 
 		AwsS3EnvironmentRepository repository = new AwsS3EnvironmentRepository(client,
-				environmentProperties.getBucket(), server);
+				environmentProperties.getBucket(), environmentProperties.isUseDirectoryLayout(), server);
 		repository.setOrder(environmentProperties.getOrder());
 		return repository;
 	}


### PR DESCRIPTION
Introduces new property `useDirectoryLayout` for S3 backend:
```
spring:
  cloud:
    config:
      server:
        awss3:
          region: eu-west-1
          bucket: ...
          useDirectoryLayout: true
```
When enabled it behaves analogous to `searchPaths: {application}` in Git backend, i.e. server will search S3 objects like:
```
bucket/{application}/application{-profile}.yml
```
Which match git structure like:
```
├── foo
│   ├── application-test.yml
│   └── application.yml
├── bar
│   ├── application-test.yml
│   └── application.yml
```

---

Fixes https://github.com/spring-cloud/spring-cloud-config/issues/1829