### PR TITLE
Replace charset string with `java.nio.charset.StandardCharsets` constant

### DIFF
--- a/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
+++ b/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientProperties.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.config.client;
 
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -397,11 +396,11 @@ public class ConfigClientProperties {
 				result.username = explicitCredentials.username;
 			}
 
-			result.password = URLDecoder.decode(result.password, StandardCharsets.UTF_8.toString());
-			result.username = URLDecoder.decode(result.username, StandardCharsets.UTF_8.toString());
+			result.password = URLDecoder.decode(result.password, StandardCharsets.UTF_8);
+			result.username = URLDecoder.decode(result.username, StandardCharsets.UTF_8);
 			return result;
 		}
-		catch (MalformedURLException | UnsupportedEncodingException e) {
+		catch (MalformedURLException e) {
 			throw new IllegalStateException("Invalid URL: " + uri, e);
 		}
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/EncryptionController.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.config.server.encryption;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -175,14 +175,9 @@ public class EncryptionController {
 	private String stripFormData(String data, MediaType type, boolean cipher) {
 
 		if (data.endsWith("=") && !type.equals(MediaType.TEXT_PLAIN)) {
-			try {
-				data = URLDecoder.decode(data, "UTF-8");
-				if (cipher) {
-					data = data.replace(" ", "+");
-				}
-			}
-			catch (UnsupportedEncodingException e) {
-				// Really?
+			data = URLDecoder.decode(data, StandardCharsets.UTF_8);
+			if (cipher) {
+				data = data.replace(" ", "+");
 			}
 			String candidate = data.substring(0, data.length() - 1);
 			if (cipher) {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/AwsCodeCommitCredentialProvider.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.config.server.support;
 
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
@@ -67,8 +68,6 @@ import static org.springframework.util.StringUtils.hasText;
 public class AwsCodeCommitCredentialProvider extends CredentialsProvider {
 
 	private static final String SHA_256 = "SHA-256"; //$NON-NLS-1$
-
-	private static final String UTF8 = "UTF8"; //$NON-NLS-1$
 
 	private static final String HMAC_SHA256 = "HmacSHA256"; //$NON-NLS-1$
 
@@ -142,11 +141,11 @@ public class AwsCodeCommitCredentialProvider extends CredentialsProvider {
 		String algorithm = HMAC_SHA256;
 		Mac mac = Mac.getInstance(algorithm);
 		mac.init(new SecretKeySpec(key, algorithm));
-		return mac.doFinal(data.getBytes(UTF8));
+		return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private static byte[] sign(String secret, String shortDateStamp, String region, String toSign) throws Exception {
-		byte[] kSecret = ("AWS4" + secret).getBytes(UTF8);
+		byte[] kSecret = ("AWS4" + secret).getBytes(StandardCharsets.UTF_8);
 		byte[] kDate = hmacSha256(shortDateStamp, kSecret);
 		byte[] kRegion = hmacSha256(region, kDate);
 		byte[] kService = hmacSha256("codecommit", kRegion);

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PathUtils.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/PathUtils.java
@@ -17,9 +17,9 @@
 package org.springframework.cloud.config.server.support;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -52,7 +52,7 @@ public abstract class PathUtils {
 			try {
 				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8
 				// chars
-				String decodedPath = URLDecoder.decode(location, "UTF-8");
+				String decodedPath = URLDecoder.decode(location, StandardCharsets.UTF_8);
 				if (isInvalidLocation(decodedPath)) {
 					return true;
 				}
@@ -61,7 +61,7 @@ public abstract class PathUtils {
 					return true;
 				}
 			}
-			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
+			catch (IllegalArgumentException ex) {
 				// Should never happen...
 			}
 		}
@@ -94,7 +94,7 @@ public abstract class PathUtils {
 			try {
 				// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8
 				// chars
-				String decodedPath = URLDecoder.decode(path, "UTF-8");
+				String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
 				if (isInvalidPath(decodedPath)) {
 					return true;
 				}
@@ -103,7 +103,7 @@ public abstract class PathUtils {
 					return true;
 				}
 			}
-			catch (IllegalArgumentException | UnsupportedEncodingException ex) {
+			catch (IllegalArgumentException ex) {
 				// Should never happen...
 			}
 		}
@@ -269,7 +269,7 @@ public abstract class PathUtils {
 		}
 		locationPath = (locationPath.endsWith("/") || locationPath.isEmpty() ? locationPath : locationPath + "/");
 		String encodedLocationPath = locationPath.endsWith("/")
-				? locationPath.substring(0, locationPath.length() - 1) + URLEncoder.encode("/", "UTF-8") : locationPath;
+				? locationPath.substring(0, locationPath.length() - 1) + URLEncoder.encode("/", StandardCharsets.UTF_8) : locationPath;
 		return ((resourcePath.startsWith(locationPath) || resourcePath.startsWith(encodedLocationPath))
 				&& !isInvalidEncodedPath(resourcePath));
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.config.server.environment;
 
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -137,7 +136,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findPropertiesObject() throws UnsupportedEncodingException {
+	public void findPropertiesObject() {
 		String propertyContent = "cloudfoundry.enabled=true\n" + "cloudfoundry.accounts[0].name=acc1\n"
 				+ "cloudfoundry.accounts[0].user=user1\n" + "cloudfoundry.accounts[0].password=password1\n"
 				+ "cloudfoundry.accounts[0].api=api.sys.acc1.cf-app.com\n"
@@ -156,7 +155,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findJsonObject() throws UnsupportedEncodingException {
+	public void findJsonObject() {
 		String versionId = putFiles("foo-bar.json", jsonContent);
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
@@ -165,7 +164,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findYamlObject() throws UnsupportedEncodingException {
+	public void findYamlObject() {
 		String versionId = putFiles("foo-bar.yaml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
@@ -174,7 +173,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findYmlObject() throws UnsupportedEncodingException {
+	public void findYmlObject() {
 		String versionId = putFiles("foo-bar.yml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
@@ -183,7 +182,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithDefaultProfile() throws UnsupportedEncodingException {
+	public void findWithDefaultProfile() {
 		String versionId = putFiles("foo.yml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", null, null);
@@ -192,7 +191,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithDefaultProfileUsingSuffix() throws UnsupportedEncodingException {
+	public void findWithDefaultProfileUsingSuffix() {
 		String versionId = putFiles("foo-default.yml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", null, null);
@@ -201,7 +200,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithMultipleProfilesAllFound() throws UnsupportedEncodingException {
+	public void findWithMultipleProfilesAllFound() {
 		putFiles("foo-profile1.yml", yamlContent);
 		String versionId = putFiles("foo-profile2.yml", jsonContent);
 
@@ -211,7 +210,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithMultipleProfilesOneFound() throws UnsupportedEncodingException {
+	public void findWithMultipleProfilesOneFound() {
 		String versionId = putFiles("foo-profile2.yml", jsonContent);
 
 		final Environment env = envRepo.findOne("foo", "profile1,profile2", null);
@@ -220,7 +219,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithOneProfileDefaultOneFound() throws UnsupportedEncodingException {
+	public void findWithOneProfileDefaultOneFound() {
 		putFiles("foo-profile1.yml", jsonContent);
 		String versionId = putFiles("foo.yml", yamlContent);
 
@@ -230,7 +229,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithNoProfileAndNoServerDefaultOneFound() throws UnsupportedEncodingException {
+	public void findWithNoProfileAndNoServerDefaultOneFound() {
 		server.setDefaultProfile(null);
 		String versionId = putFiles("foo.yml", yamlContent);
 
@@ -241,7 +240,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithLabel() throws UnsupportedEncodingException {
+	public void findWithLabel() {
 		String versionId = putFiles("label1/foo-bar.yml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", "bar", "label1");
@@ -250,7 +249,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithVersion() throws UnsupportedEncodingException {
+	public void findWithVersion() {
 		String versionId = putFiles("foo-bar.yml", yamlContent);
 
 		final Environment env = envRepo.findOne("foo", "bar", null);
@@ -259,7 +258,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithMultipleApplicationAllFound() throws UnsupportedEncodingException {
+	public void findWithMultipleApplicationAllFound() {
 		String versionId = putFiles("foo-profile1.yml", jsonContent);
 		putFiles("bar-profile1.yml", jsonContent);
 
@@ -400,7 +399,7 @@ public class AwsS3EnvironmentRepositoryTests {
 	}
 
 	@Test
-	public void findWithMultipleApplicationAllFound_ApplicationDirVariant() throws UnsupportedEncodingException {
+	public void findWithMultipleApplicationAllFound_ApplicationDirVariant() {
 		String versionId = putFiles("foo/application-profile1.yml", jsonContent);
 		putFiles("bar/application-profile1.yml", jsonContent);
 


### PR DESCRIPTION
Passing `Charset` argument as opposed to string eliminates the need to handle `UnsupportedEncodingException`.

This PR replaces all charset strings that I could find, except for the ones in `ResourceControllerTests` since doing so didn't seem to add any value.