### PR TITLE
Modifing the documentation about generating the jks file with keytool

### DIFF
--- a/docs/modules/ROOT/pages/server/creating-a-key-store-for-testing.adoc
+++ b/docs/modules/ROOT/pages/server/creating-a-key-store-for-testing.adoc
@@ -6,7 +6,7 @@ To create a keystore for testing, you can use a command resembling the following
 ----
 $ keytool -genkeypair -alias mytestkey -keyalg RSA \
   -dname "CN=Web Server,OU=Unit,O=Organization,L=City,S=State,C=US" \
-  -keypass changeme -keystore server.jks -storepass letmein
+  -keypass changeme -keystore server.jks -storepass letmein -storetype JKS
 ----
 
 NOTE:  When using JDK 11 or above you may get the following warning when using the command above.  In this case
@@ -16,7 +16,7 @@ Warning:  Different store and key passwords not supported for PKCS12 KeyStores. 
 ----
 
 Put the `server.jks` file in the classpath (for instance) and then, in
-your `bootstrap.yml`, for the Config Server, create the following settings:
+your `application.properties`, for the Config Server, create the following settings:
 
 [source,yaml]
 ----
@@ -27,4 +27,6 @@ encrypt:
     alias: mytestkey
     secret: changeme
 ----
-
+----
+Warning: In the erlier versions `bootstrap.yml` was used instead of application.properties (or application.yml or application.yaml)
+----


### PR DESCRIPTION
- The format of the generated jks file is PKCS12 by checking it with 'keytool -list -v -keystore server.jks' and the application fails to start. Adding a parameter for creation of keys in JKS format solved the problem.

- Using bootstrap.yml does not have any impact on the application. Using application.properties gave the expected effect. Changing the description from bootstrap.yml with application.properties.