### PR TITLE
Fix health indicator property names in docs

### DIFF
--- a/docs/modules/ROOT/pages/client.adoc
+++ b/docs/modules/ROOT/pages/client.adoc
@@ -222,7 +222,7 @@ If you use another form of security, you might need to xref:client.adoc#custom-r
 === Health Indicator
 
 The Config Client supplies a Spring Boot Health Indicator that attempts to load configuration from the Config Server.
-The health indicator can be disabled by setting `health.config.enabled=false`.
+The health indicator can be disabled by setting `management.health.config.enabled=false`.
 The response is also cached for performance reasons.
 The default cache time to live is 5 minutes.
 To change that value, set the `health.config.time-to-live` property (in milliseconds).

--- a/docs/modules/ROOT/pages/server/health-indicator.adoc
+++ b/docs/modules/ROOT/pages/server/health-indicator.adoc
@@ -21,7 +21,7 @@ spring:
               profiles: development
 ----
 
-You can disable the Health Indicator by setting `management.health.config.enabled=false`.
+You can disable the Health Indicator by setting `spring.cloud.config.server.health.enabled=false`.
 
 Also, you can provide a custom `down` status of your own by setting property `spring.cloud.config.server.health.down-health-status` (valued to `"DOWN'` by default).
 


### PR DESCRIPTION
Config Server health indicator is `@ConditionalOnProperty("spring.cloud.config.server.health.enabled")`.

https://github.com/spring-cloud/spring-cloud-config/blob/d19576ccdbb933dfde2b82ded86f0ac31f335d4d/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java#L153-L164

Config Client health indicator is `@ConditionalOnEnabledHealthIndicator("config")`.

https://github.com/spring-cloud/spring-cloud-config/blob/d19576ccdbb933dfde2b82ded86f0ac31f335d4d/spring-cloud-config-client/src/main/java/org/springframework/cloud/config/client/ConfigClientAutoConfiguration.java#L57-L73