### PR TITLE
Support Git-style searchPaths with wildcards in AWS S3 buckets (#2812)

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentProperties.java
@@ -16,11 +16,15 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
 
 /**
  * @author Clay McCoy
+ * @author Geonwook Ham
  */
 @ConfigurationProperties("spring.cloud.config.server.awss3")
 public class AwsS3EnvironmentProperties implements EnvironmentRepositoryProperties {
@@ -47,6 +51,16 @@ public class AwsS3EnvironmentProperties implements EnvironmentRepositoryProperti
 	private boolean useDirectoryLayout;
 
 	private int order = DEFAULT_ORDER;
+
+	private List<String> searchPaths = new ArrayList<>();
+
+	public List<String> getSearchPaths() {
+		return searchPaths;
+	}
+
+	public void setSearchPaths(List<String> searchPaths) {
+		this.searchPaths = searchPaths;
+	}
 
 	public String getRegion() {
 		return region;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepository.java
@@ -20,8 +20,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
@@ -30,6 +33,11 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import org.springframework.beans.factory.config.YamlProcessor;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
@@ -38,17 +46,23 @@ import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepository.PATH_SEPARATOR;
+
 
 /**
  * @author Clay McCoy
  * @author Scott Frederick
  * @author Daniel Aiken
+ * @author Geonwook Ham
  */
 public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordered, SearchPathLocator {
+
+	private final PathMatcher pathMatcher = new AntPathMatcher();
 
 	protected static final String PATH_SEPARATOR = "/";
 
@@ -66,16 +80,24 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 	protected int order = Ordered.LOWEST_PRECEDENCE;
 
+	private final List<String> searchPaths;
+
 	public AwsS3EnvironmentRepository(S3Client s3Client, String bucketName, ConfigServerProperties server) {
 		this(s3Client, bucketName, false, server);
 	}
 
 	public AwsS3EnvironmentRepository(S3Client s3Client, String bucketName, boolean useApplicationAsDirectory,
 			ConfigServerProperties server) {
+		this(s3Client, bucketName, useApplicationAsDirectory, server, null);
+	}
+
+	public AwsS3EnvironmentRepository(S3Client s3Client, String bucketName, boolean useApplicationAsDirectory,
+		ConfigServerProperties server, List<String> searchPaths) {
 		this.s3Client = s3Client;
 		this.bucketName = bucketName;
 		this.serverProperties = server;
 		this.useApplicationAsDirectory = useApplicationAsDirectory;
+		this.searchPaths = (searchPaths == null ? Collections.emptyList() : searchPaths);
 	}
 
 	@Override
@@ -97,8 +119,8 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 		String[] profileArray = parseProfiles(profiles);
 		List<String> apps = Arrays.asList(StringUtils.commaDelimitedListToStringArray(application.replace(" ", "")));
-		Collections.reverse(apps);
-		if (!apps.contains(serverProperties.getDefaultApplicationName())) {
+		if (searchPaths.isEmpty() && !apps.contains(serverProperties.getDefaultApplicationName())) {
+			Collections.reverse(apps);
 			apps = new ArrayList<>(apps);
 			apps.add(serverProperties.getDefaultApplicationName());
 		}
@@ -126,6 +148,17 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 
 	private void addPropertySources(Environment environment, List<String> apps, String[] profiles,
 			List<String> labels) {
+		if (!this.searchPaths.isEmpty()) {
+			for (String label : labels) {
+				for (String profile : profiles) {
+					for (String app : apps) {
+						List<S3ConfigFile> s3ConfigFiles = getS3ConfigFileWithSearchPaths(app, profile, label);
+						addPropertySource(environment, s3ConfigFiles);
+					}
+				}
+			}
+			return;
+		}
 		for (String label : labels) {
 			// If we have profiles, add property sources with those profiles
 			for (String profile : profiles) {
@@ -163,15 +196,21 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 	}
 
 	private void addProfileSpecificPropertySource(Environment environment, String app, String profile, String label) {
-		List<S3ConfigFile> s3ConfigFiles = getS3ConfigFile(app, profile, label, this::getS3PropertiesOrJsonConfigFile,
-				this::getProfileSpecificS3ConfigFileYaml);
+		if (!searchPaths.isEmpty() && app.equals(serverProperties.getDefaultApplicationName())) {
+			return;
+		}
+		List<S3ConfigFile> s3ConfigFiles = searchPaths.isEmpty()
+			? getS3ConfigFile(app, profile, label, this::getS3PropertiesOrJsonConfigFile, this::getProfileSpecificS3ConfigFileYaml)
+			: getS3ConfigFileWithSearchPaths(app, profile, label);
 		addPropertySource(environment, s3ConfigFiles);
 	}
 
-	private void addNonProfileSpecificPropertySource(Environment environment, String app, String profile,
-			String label) {
-		List<S3ConfigFile> s3ConfigFiles = getS3ConfigFile(app, profile, label,
-				this::getNonProfileSpecificPropertiesOrJsonConfigFile, this::getNonProfileSpecificS3ConfigFileYaml);
+	private void addNonProfileSpecificPropertySource(Environment environment, String app, String profile, String label) {
+		List<S3ConfigFile> s3ConfigFiles = searchPaths.isEmpty()
+			? getS3ConfigFile(app, profile, label,
+			this::getNonProfileSpecificPropertiesOrJsonConfigFile,
+			this::getNonProfileSpecificS3ConfigFileYaml)
+			: Collections.emptyList();
 		addPropertySource(environment, s3ConfigFiles);
 	}
 
@@ -214,6 +253,204 @@ public class AwsS3EnvironmentRepository implements EnvironmentRepository, Ordere
 		return new ArrayList<>(yamlCreator.create(application, profile, label));
 
 	}
+
+	private List<S3ConfigFile> getS3ConfigFileWithSearchPaths(
+		String application, String profile, String label) {
+
+		List<S3ConfigFile> result = new ArrayList<>();
+		Set<String> seenKeys = new LinkedHashSet<>();
+
+		for (String template : this.searchPaths) {
+			String pattern = template
+				.replace("{application}", application)
+				.replace("{profile}", profile == null ? "" : profile)
+				.replace("{label}", label == null ? "" : label);
+
+			if (!pathMatcher.isPattern(pattern)) {
+				boolean fileFound = false;
+				for (String ext : List.of(".properties", ".json", ".yml", ".yaml")) {
+					String key = pattern.endsWith(ext) ? pattern : pattern + ext;
+					if (!seenKeys.add(key)) {
+						continue;
+					}
+					try {
+						s3Client.headObject(HeadObjectRequest.builder()
+							.bucket(bucketName)
+							.key(key)
+							.build());
+						result.addAll(wrapKeyWithConfigFiles(key, application, profile, label));
+						fileFound = true;
+						break;
+					}
+					catch (S3Exception e) {
+						int status = e.statusCode();
+						if (status != 404 && status != 403) {
+							throw e;
+						}
+					}
+				}
+				if (fileFound) {
+					continue;
+				}
+
+				String dirPrefix = pattern.endsWith("/") ? pattern : pattern + "/";
+				String token = null;
+				do {
+					ListObjectsV2Response resp = s3Client.listObjectsV2(
+						ListObjectsV2Request.builder()
+							.bucket(bucketName)
+							.prefix(dirPrefix)
+							.continuationToken(token)
+							.build());
+					for (S3Object obj : resp.contents()) {
+						String key = obj.key();
+						if (!hasSupportedExtension(key)) {
+							continue;
+						}
+						if (seenKeys.add(key)) {
+							result.addAll(wrapKeyWithConfigFiles(key, application, profile, label));
+						}
+					}
+					token = resp.nextContinuationToken();
+				} while (token != null);
+
+				continue;
+			}
+
+			if (pattern.endsWith(".*")) {
+				String base = pattern.substring(0, pattern.length() - 2);
+				for (String ext : List.of(".properties", ".json", ".yml", ".yaml")) {
+					String key = base + ext;
+					if (!seenKeys.add(key)) {
+						continue;
+					}
+					try {
+						s3Client.headObject(HeadObjectRequest.builder()
+							.bucket(bucketName)
+							.key(key)
+							.build());
+						result.addAll(wrapKeyWithConfigFiles(key, application, profile, label));
+						break;
+					}
+					catch (S3Exception e) {
+						int status = e.statusCode();
+						if (status != 404 && status != 403) {
+							throw e;
+						}
+					}
+				}
+				continue;
+			}
+
+			String prefix = extractPrefix(pattern);
+			String token = null;
+			do {
+				ListObjectsV2Response resp = s3Client.listObjectsV2(
+					ListObjectsV2Request.builder()
+						.bucket(bucketName)
+						.prefix(prefix)
+						.continuationToken(token)
+						.build());
+				for (S3Object obj : resp.contents()) {
+					String key = obj.key();
+					if (!pathMatcher.match(pattern, key) || !hasSupportedExtension(key)) {
+						continue;
+					}
+					if (seenKeys.add(key)) {
+						result.addAll(wrapKeyWithConfigFiles(key, application, profile, label));
+					}
+				}
+				token = resp.nextContinuationToken();
+			} while (token != null);
+		}
+
+		return result;
+	}
+
+	private boolean hasSupportedExtension(String key) {
+		return key.endsWith(".properties")
+			|| key.endsWith(".json")
+			|| key.endsWith(".yml")
+			|| key.endsWith(".yaml");
+	}
+
+	private List<S3ConfigFile> wrapKeyWithConfigFiles(
+		String key,
+		String application,
+		String profile,
+		String label) {
+
+		if (key.endsWith(".yml") || key.endsWith(".yaml")) {
+			List<S3ConfigFile> files = new ArrayList<>();
+			files.addAll(getProfileSpecificYamlFromKey(key, application, profile, label));
+			files.addAll(getNonProfileSpecificYamlFromKey(key, application, profile, label));
+			return files;
+		}
+		return createConfigFileFromKey(key, application, profile, label)
+			.map(Collections::singletonList)
+			.orElseGet(Collections::emptyList);
+	}
+
+
+	private List<S3ConfigFile> getProfileSpecificYamlFromKey(
+		String key, String application, String profile, String label) {
+
+		YamlConfigFileFromKey config = new YamlConfigFileFromKey(
+			key, application, profile, label,
+			bucketName, useApplicationAsDirectory, s3Client,
+			properties -> YamlS3ConfigFile.profileMatchesActivateProperty(profile, properties)
+				? YamlProcessor.MatchStatus.FOUND
+				: YamlProcessor.MatchStatus.NOT_FOUND
+		);
+		config.setShouldIncludeWithEmptyProperties(false);
+		return List.of(config);
+	}
+
+	private List<S3ConfigFile> getNonProfileSpecificYamlFromKey(
+		String key, String application, String profile, String label) {
+
+		YamlConfigFileFromKey config = new YamlConfigFileFromKey(
+			key, application, profile, label,
+			bucketName, useApplicationAsDirectory, s3Client,
+			properties -> !YamlS3ConfigFile.onProfilePropertyExists(properties)
+				? YamlProcessor.MatchStatus.FOUND
+				: YamlProcessor.MatchStatus.NOT_FOUND
+		);
+		return List.of(config);
+	}
+
+	private String extractPrefix(String pattern) {
+		int idx = pattern.indexOf('*');
+		int q   = pattern.indexOf('?');
+		if (q != -1 && (idx == -1 || q < idx)) {
+			idx = q;
+		}
+		if (idx <= 0) {
+			return "";
+		}
+		int slash = pattern.lastIndexOf('/', idx);
+		return (slash == -1 ? "" : pattern.substring(0, slash + 1));
+	}
+
+
+	private Optional<S3ConfigFile> createConfigFileFromKey(String key,
+		String application, String profile, String label) {
+		String ext = key.substring(key.lastIndexOf('.') + 1);
+		if ("properties".equalsIgnoreCase(ext)) {
+			return Optional.of(new PropertyConfigFileFromKey(
+				key, application, profile, label, bucketName, s3Client));
+		}
+		if ("json".equalsIgnoreCase(ext)) {
+			return Optional.of(new JsonConfigFileFromKey(
+				key, application, profile, label, bucketName, s3Client));
+		}
+		if ("yml".equalsIgnoreCase(ext) || "yaml".equalsIgnoreCase(ext)) {
+			return Optional.of(new YamlConfigFileFromKey(
+				key, application, profile, label, bucketName, s3Client));
+		}
+		return Optional.empty();
+	}
+
 
 	private List<YamlS3ConfigFile> getNonProfileSpecificS3ConfigFileYaml(String application, String profile,
 			String label) {
@@ -434,10 +671,18 @@ abstract class S3ConfigFile {
 
 class PropertyS3ConfigFile extends S3ConfigFile {
 
+	PropertyS3ConfigFile(String application, String profile, String label,
+		String bucketName, boolean useApplicationAsDirectory,
+		S3Client s3Client) {
+		this(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, true);
+	}
+
 	PropertyS3ConfigFile(String application, String profile, String label, String bucketName,
-			boolean useApplicationAsDirectory, S3Client s3Client) {
+			boolean useApplicationAsDirectory, S3Client s3Client, boolean callReadImmediately) {
 		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client);
-		this.properties = read();
+		if (callReadImmediately) {
+			this.properties = read();
+		}
 	}
 
 	@Override
@@ -469,17 +714,18 @@ class YamlS3ConfigFile extends S3ConfigFile {
 
 	YamlS3ConfigFile(String application, String profile, String label, String bucketName,
 			boolean useApplicationAsDirectory, S3Client s3Client) {
-		this(application, profile, label, bucketName, useApplicationAsDirectory, s3Client,
+		this(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, true,
 				new YamlProcessor.DocumentMatcher[] {});
 	}
 
 	YamlS3ConfigFile(String application, String profile, String label, String bucketName,
-			boolean useApplicationAsDirectory, S3Client s3Client,
+			boolean useApplicationAsDirectory, S3Client s3Client, boolean callReadImmediately,
 			final YamlProcessor.DocumentMatcher... documentMatchers) {
 		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client);
 		this.documentMatchers = documentMatchers;
-		this.properties = read();
-
+		if (callReadImmediately) {
+			this.properties = read();
+		}
 	}
 
 	protected static boolean profileMatchesActivateProperty(String profile, Properties properties) {
@@ -520,7 +766,7 @@ class ProfileSpecificYamlDocumentS3ConfigFile extends YamlS3ConfigFile {
 
 	ProfileSpecificYamlDocumentS3ConfigFile(String application, String profile, String label, String bucketName,
 			boolean useApplicationAsDirectory, S3Client s3Client) {
-		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client,
+		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, true,
 				properties -> profileMatchesActivateProperty(profile, properties) ? YamlProcessor.MatchStatus.FOUND
 						: YamlProcessor.MatchStatus.NOT_FOUND);
 	}
@@ -541,7 +787,7 @@ class NonProfileSpecificYamlDocumentS3ConfigFile extends YamlS3ConfigFile {
 
 	NonProfileSpecificYamlDocumentS3ConfigFile(String application, String profile, String label, String bucketName,
 			boolean useApplicationAsDirectory, S3Client s3Client) {
-		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client,
+		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, true,
 				properties -> !onProfilePropertyExists(properties) ? YamlProcessor.MatchStatus.FOUND
 						: YamlProcessor.MatchStatus.NOT_FOUND);
 	}
@@ -552,7 +798,7 @@ class ProfileSpecificYamlS3ConfigFile extends YamlS3ConfigFile {
 
 	ProfileSpecificYamlS3ConfigFile(String application, String profile, String label, String bucketName,
 			boolean useApplicationAsDirectory, S3Client s3Client) {
-		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client,
+		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, true,
 				properties -> !onProfilePropertyExists(properties) ? YamlProcessor.MatchStatus.ABSTAIN
 						: profileMatchesActivateProperty(profile, properties) ? YamlProcessor.MatchStatus.FOUND
 								: YamlProcessor.MatchStatus.NOT_FOUND);
@@ -570,9 +816,102 @@ class JsonS3ConfigFile extends YamlS3ConfigFile {
 		this.properties = read();
 	}
 
+	JsonS3ConfigFile(String application, String profile, String label, String bucketName,
+		boolean useApplicationAsDirectory, S3Client s3Client, boolean callReadImmediately) {
+		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, callReadImmediately);
+	}
+
 	@Override
 	protected List<String> getExtensions() {
 		return List.of("json");
 	}
 
 }
+
+class PropertyConfigFileFromKey extends PropertyS3ConfigFile {
+
+	private final String key;
+
+	PropertyConfigFileFromKey(String key,
+		String application,
+		String profile,
+		String label,
+		String bucketName,
+		S3Client s3Client) {
+		super(application, profile, label, bucketName, false, s3Client, false);
+		this.key = key;
+		this.properties = read();
+	}
+
+	@Override
+	public String getName() {
+		return "s3:" + bucketName + "/" + key;
+	}
+
+	@Override
+	protected String buildObjectKeyPrefix() {
+		return key.substring(0, key.lastIndexOf('.'));
+	}
+}
+
+class YamlConfigFileFromKey extends YamlS3ConfigFile {
+
+	private final String key;
+
+	YamlConfigFileFromKey(String key,
+		String application,
+		String profile,
+		String label,
+		String bucketName,
+		S3Client s3Client) {
+		super(application, profile, label, bucketName, false, s3Client, false);
+		this.key = key;
+		this.properties = read();
+	}
+
+	YamlConfigFileFromKey(String key,
+		String application,
+		String profile,
+		String label,
+		String bucketName,
+		boolean useApplicationAsDirectory,
+		S3Client s3Client,
+		YamlProcessor.DocumentMatcher... matchers) {
+		super(application, profile, label, bucketName, useApplicationAsDirectory, s3Client, false, matchers);
+		this.key = key;
+		this.properties = read();
+	}
+
+	@Override
+	public String getName() {
+		return "s3:" + bucketName + "/" + key;
+	}
+
+	@Override
+	protected String buildObjectKeyPrefix() {
+		return key.substring(0, key.lastIndexOf('.'));
+	}
+}
+
+class JsonConfigFileFromKey extends JsonS3ConfigFile {
+
+	private final String key;
+
+	JsonConfigFileFromKey(String key, String application, String profile,
+		String label, String bucketName, S3Client s3Client) {
+		super(application, profile, label, bucketName, false, s3Client, false);
+		this.key = key;
+		this.properties = read();
+	}
+
+	@Override
+	public String getName() {
+		return "s3:" + bucketName + "/" + key;
+	}
+
+	@Override
+	protected String buildObjectKeyPrefix() {
+		return key.substring(0, key.lastIndexOf('.'));
+	}
+}
+

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsS3EnvironmentRepositoryFactory.java
@@ -23,6 +23,9 @@ import org.springframework.cloud.config.server.config.ConfigServerProperties;
 
 import static org.springframework.cloud.config.server.environment.AwsClientBuilderConfigurer.configureClientBuilder;
 
+/**
+ * @author Geonwook Ham
+ */
 public class AwsS3EnvironmentRepositoryFactory
 		implements EnvironmentRepositoryFactory<AwsS3EnvironmentRepository, AwsS3EnvironmentProperties> {
 
@@ -39,7 +42,7 @@ public class AwsS3EnvironmentRepositoryFactory
 		final S3Client client = clientBuilder.build();
 
 		AwsS3EnvironmentRepository repository = new AwsS3EnvironmentRepository(client,
-				environmentProperties.getBucket(), environmentProperties.isUseDirectoryLayout(), server);
+				environmentProperties.getBucket(), environmentProperties.isUseDirectoryLayout(), server, environmentProperties.getSearchPaths());
 		repository.setOrder(environmentProperties.getOrder());
 		return repository;
 	}


### PR DESCRIPTION

### Summary

Add full Git-style `searchPaths` support (placeholders + wildcards) to the AWS S3 backend so that users can migrate existing Git-based configurations without renaming to `application.*`.

* Implements literal, dot-wildcard (`.*`), single (`?`) and double (`**`) wildcard matching
* Retains the lookup order `.properties → .json → .yml → .yaml` when expanding literals or `.*` patterns
* Scans “directory” patterns for nested files
* Deduplicates identical keys across multiple patterns

This issue (https://github.com/spring-cloud/spring-cloud-config/issues/2812)

---

### Changes

1. **Core Logic**

   * Extended `getS3ConfigFileWithSearchPaths(...)` to treat `{application}` and `{profile}` placeholders identically to the Git backend
   * Added support for:

     * **Literal + auto-ext**: stops at first existing extension
     * **Dot-wildcard (`.*`)**: expands against supported extensions in priority order
     * **Single-character wildcard (`?`)**
     * **Multi-level wildcard (`**`)**
     * **Directory scan** for literal prefixes ending with `/`
   * Ensured **seenKeys** set to avoid duplicate property sources

2. **Tests**
   Added new JUnit 5 tests in `AwsS3EnvironmentRepositoryTests` to cover **all scenarios**:

   * `searchPaths_placeholderOnly_shouldResolveExactFile`
   * `searchPaths_wildcardOnly_shouldResolveAllProperties`
   * `searchPaths_placeholderAndWildcard_shouldResolveMatchingKeys`
   * `searchPaths_orderMatters_forPropertySourceOrder`
   * `searchPath_extensionPreserved` (dynamic tests for each extension)
   * `searchPaths_applicationAsDirectory_shouldStillHonorSearchPaths`
   * `multiDocumentYaml_withSearchPaths_shouldNotSplitDocuments`
   * `getLocations_returnsCorrect`
   * `searchPaths_deduplication_shouldOnlyAddOnce`
   * `searchPaths_singleCharacterWildcard_shouldMatchExactlyOneChar`
   * `searchPaths_withEmptyLabel_shouldUseDefaultLabel`
   * `searchPaths_multipleLabels_shouldApplyForEachLabelInReverseOrder`
   * `searchPaths_literalNotFound_shouldReturnEmpty`

   …plus the additional edge cases for literal-stop, dot-wildcard priority, and nested directory patterns.

3. **Example Usage**

```yaml
spring:
  cloud:
    config:
      server:
        awss3:
          bucket: my-config-bucket
          search-paths:
            - "{label}/{application}"          # literal + auto-ext
            - "{label}/{application}.*"        # dot-wildcard expansion
            - "{label}/common/*.json"          # JSON only in common/
            - "{label}/{application}.yml"      # explicit YML
```
---

## Additional Notes

### Backward Compatibility

This update does **not** break any existing AWS S3 config setups. The default lookup behavior is unchanged if no placeholders or wildcards are used in `searchPaths`.

### Migration

Existing users migrating from Git-backed config servers can now use their current `searchPaths` (including wildcards and placeholders) on S3 with no renaming or convention change required.

### Documentation

Documentation and usage examples for the enhanced `searchPaths` will be updated in the relevant documentation files after the merge.
If there are specific locations that require documentation updates, please let me know—I will be happy to update them.

### Performance and Cost

Using wildcards (such as `*` or `**`) in searchPaths may result in additional AWS S3 API calls (e.g., ListObjects), especially for large buckets or deeply nested directory patterns.
This could lead to increased latency and higher AWS costs.
Users should consider the structure and size of their buckets when designing searchPaths and monitor AWS S3 usage accordingly.

----