### PR TITLE
Update encryption-and-decryption.adoc

### DIFF
--- a/docs/modules/ROOT/pages/server/encryption-and-decryption.adoc
+++ b/docs/modules/ROOT/pages/server/encryption-and-decryption.adoc
@@ -2,7 +2,7 @@
 = Encryption and Decryption
 
 IMPORTANT: To use the encryption and decryption features you need the full-strength JCE installed in your JVM (it is not included by default).
-You can download the "`Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files`" from Oracle and follow the installation instructions (essentially, you need to replace the two policy files in the JRE lib/security directory with the ones that you downloaded).
+You can download the "`Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files`" from Oracle and follow the installation instructions (essentially, you need to replace the two policy files in the JRE lib/security directory with the ones that you downloaded). This is only applicable for old versions of Java. Starting from Java 9, and definitively from Java 8u161 onwards, unlimited strength cryptography is enabled by default
 
 If the remote property sources contain encrypted content (values starting with `\{cipher}`), they are decrypted before sending to clients over HTTP.
 The main advantage of this setup is that the property values need not be in plain text when they are "`at rest`" (for example, in a git repository).


### PR DESCRIPTION
Updated the the doco on encryption / decryption for spring config server which still had the old outdated information on 
manually installing JCE unlimited strength Jurisdiction Policy Files for new Java versions above Java 9