### PR TITLE
Exclude Micrometer/Observation auto-configs to prevent startup crash …

### DIFF
--- a/spring-cloud-config-client-tls-tests/src/test/java/org/springframework/cloud/config/client/tls/AppRunner.java
+++ b/spring-cloud-config-client-tls-tests/src/test/java/org/springframework/cloud/config/client/tls/AppRunner.java
@@ -48,6 +48,21 @@ public class AppRunner implements AutoCloseable {
 			SpringApplicationBuilder builder = new SpringApplicationBuilder(appClass);
 			builder.properties("spring.jmx.enabled=false");
 			builder.properties(String.format("server.port=%d", availabeTcpPort()));
+
+			// Disable Micrometer/Observation auto-configurations that cause startup
+			// failures
+			// in test environment (ArrayIndexOutOfBoundsException from
+			// SimpleMeterRegistry).
+			// This prevents repeated application restarts and avoids transient port
+			// binding errors.
+			// These metrics-related components are not needed for TLS client/server
+			// tests.
+			builder.properties("spring.autoconfigure.exclude="
+					+ "org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration,"
+					+ "org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration,"
+					+ "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration,"
+					+ "org.springframework.boot.webmvc.autoconfigure.WebMvcObservationAutoConfiguration");
+
 			builder.properties(props());
 
 			app = builder.build().run();


### PR DESCRIPTION
…in TLS tests

🧩 Summary

Exclude problematic Micrometer and Observation auto-configurations during TLS test startup.

🧠 Context

When running ConfigClientConfigDataTlsTests, application startup occasionally failed due to:

ArrayIndexOutOfBoundsException
  at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants


This error originates from Micrometer auto-configs (SimpleMetricsExportAutoConfiguration, ObservationAutoConfiguration, etc.), which cause startup instability and sometimes trigger subsequent PortInUseException due to partial Tomcat initialization.

🔧 Fix

Explicitly disable the following auto-configurations in AppRunner:

MetricsAutoConfiguration

SimpleMetricsExportAutoConfiguration

ObservationAutoConfiguration

WebMvcObservationAutoConfiguration

This ensures Micrometer and Observation are not initialized in the test environment.


🧪 Verification

All TLS tests (ConfigClientTlsTests and ConfigClientConfigDataTlsTests) pass without ArrayIndexOutOfBoundsException or PortInUseException.

No behavioral or configuration regressions observed.

### Validation Script

<details>
<summary>Click to view validation script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

LOG_ROOT="$HOME/logs/logs_config_new"
mkdir -p "$LOG_ROOT"

REPO_DIR="$HOME/myRepo/spring-cloud-config"

NONDEX_VERSION="2.2.1"
NONDEX_RUNS="50"
NONDEX_MODE="FULL"
NONDEX_SEED="123456"

MODULE="spring-cloud-config-client-tls-tests"

TEST_CLASS="org.springframework.cloud.config.client.tls.ConfigClientConfigDataTlsTests"

cd "$REPO_DIR"

SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
TS="$(date +%Y%m%d-%H%M%S)"
LOG_FILE="$LOG_ROOT/tls-ConfigClientConfigDataTlsTests-${TS}-${SHA}.log"


METHOD_PART=""
for m in "${METHODS[@]}"; do
  if [ -z "$METHOD_PART" ]; then
    METHOD_PART="$m"
  else
    METHOD_PART="$METHOD_PART+$m"
  fi
done

NONDEX_TEST="${TEST_CLASS}#${METHOD_PART}"

CMD="./mvnw -pl ${MODULE} \
  edu.illinois:nondex-maven-plugin:${NONDEX_VERSION}:nondex \
  -Dtest=${NONDEX_TEST} \
  -DnondexRuns=${NONDEX_RUNS} \
  -DnondexMode=${NONDEX_MODE} \
  -DnondexSeed=${NONDEX_SEED}"

{
  echo "==== [${MODULE} NonDex - transport tests] $(date) ===="
  echo "repo     : $REPO_DIR"
  echo "module   : $MODULE"
  echo "sha      : $SHA"
  echo "command  : $CMD"
  echo

  eval "$CMD"

  echo
  echo "==== DONE $(date) ===="
} | tee "$LOG_FILE"
