### PR TITLE
Fix MongoDbEnvironmentRepositoryConfigurationTests failing with Micro…

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepositoryConfigurationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/MongoDbEnvironmentRepositoryConfigurationTests.java
@@ -38,7 +38,8 @@ public class MongoDbEnvironmentRepositoryConfigurationTests {
 	@Test
 	public void mongoDbEnvironmentRepositoryBeansConfiguredWhenDefault() {
 		new WebApplicationContextRunner().withUserConfiguration(TestConfigServerApplication.class)
-			.withPropertyValues("spring.profiles.active=test,mongodb", "spring.main.web-application-type=none")
+			.withPropertyValues("spring.profiles.active=test,mongodb", "spring.main.web-application-type=none",
+					"management.metrics.use-global-registry=false")
 			.run(context -> {
 				assertThat(context).hasSingleBean(MongoDbEnvironmentRepositoryFactory.class);
 				assertThat(context).hasSingleBean(MongoDbEnvironmentRepository.class);
@@ -71,7 +72,8 @@ public class MongoDbEnvironmentRepositoryConfigurationTests {
 		new WebApplicationContextRunner().withUserConfiguration(TestConfigServerApplication.class)
 			.withPropertyValues("spring.profiles.active=test,mongodb", "spring.main.web-application-type=none",
 					"spring.cloud.config.server.git.uri:" + uri,
-					"spring.cloud.config.server.mongodb.enabled:" + mongoDbEnabled)
+					"spring.cloud.config.server.mongodb.enabled:" + mongoDbEnabled,
+					"management.metrics.use-global-registry=false")
 			.run(consumer);
 	}
 


### PR DESCRIPTION
…meter global registry
🧪 Background & Symptom

While running
MongoDbEnvironmentRepositoryConfigurationTests.mongoDbEnvironmentRepositoryBeansConfiguredWhenEnabled
with NonDex (FULL mode), we occasionally observed a failure in Spring Boot context initialization.
The exception appeared only once during our early runs but could not be consistently reproduced afterwards.

The relevant stack trace started with:

java.lang.ArrayIndexOutOfBoundsException
  at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants(...)


This error caused the test’s AssertableWebApplicationContext to fail to start,
therefore the assertion on MongoDbEnvironmentRepositoryFactory /
MongoDbEnvironmentRepository beans also failed.

🔍 Root Cause (3rd-party nondeterministic behavior)

The failure was triggered inside Micrometer’s CompositeMeterRegistry, when
a newly created SimpleMeterRegistry was added to the global Metrics registry during auto-configuration.

Under certain execution orders (which NonDex helps expose), the internal data structure of the composite registry
can enter an inconsistent state and throw an ArrayIndexOutOfBoundsException.

This behavior is not related to the actual business logic of this test,
but is rather a nondeterministic interaction with Micrometer’s global metrics state.

🛠 Fix

Since this test does not depend on Micrometer’s global registry,
we safely disable its usage by adding the following property to the test configuration:

management.metrics.use-global-registry=false


This prevents any SimpleMeterRegistry from being injected into
Metrics.globalRegistry, which avoids triggering CompositeMeterRegistry.updateDescendants()
and ensures deterministic Spring Boot context startup.

### Validation Script

<details>
<summary>Click to view validation script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

LOG_ROOT="$HOME/logs/logs_config_new"
mkdir -p "$LOG_ROOT"

REPO_DIR="$HOME/myRepo/spring-cloud-config"

NONDEX_VERSION="2.2.1"
NONDEX_RUNS="30"
NONDEX_MODE="FULL"
NONDEX_SEED="123456"

MODULE="spring-cloud-config-server"

TEST_CLASS="org.springframework.cloud.config.server.environment.MongoDbEnvironmentRepositoryConfigurationTests"

METHODS=(
  "mongoDbEnvironmentRepositoryBeansConfiguredWhenDefault"
  "mongoDbEnvironmentRepositoryBeansConfiguredWhenEnabled"
  "mongoDbEnvironmentRepositoryFactoryNotConfiguredWhenDisabled"
  "mongoDbEnvironmentRepositoryNotConfiguredWhenDisabled"
)

cd "$REPO_DIR"

SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
TS="$(date +%Y%m%d-%H%M%S)"
LOG_FILE="$LOG_ROOT/server-MongoDbEnvironmentRepositoryConfigurationTests-${TS}-${SHA}.log"

METHOD_PART=""
for m in "${METHODS[@]}"; do
  if [ -z "$METHOD_PART" ]; then
    METHOD_PART="$m"
  else
    METHOD_PART="$METHOD_PART+$m"
  fi
done

NONDEX_TEST="${TEST_CLASS}#${METHOD_PART}"

CMD="./mvnw clean && \
./mvnw -pl ${MODULE} \
  edu.illinois:nondex-maven-plugin:${NONDEX_VERSION}:nondex \
  -Dtest=${NONDEX_TEST} \
  -DnondexRuns=${NONDEX_RUNS} \
  -DnondexMode=${NONDEX_MODE} \
  -DnondexSeed=${NONDEX_SEED}"

{
  echo "==== [${MODULE} NonDex - transport tests] $(date) ===="
  echo "repo     : $REPO_DIR"
  echo "module   : $MODULE"
  echo "sha      : $SHA"
  echo "command  : $CMD"
  echo

  eval "$CMD"

  echo
  echo "==== DONE $(date) ===="
} | tee "$LOG_FILE"
