### PR TITLE
Disable Micrometer global registry in JDBC config tests

### DIFF
--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JdbcEnvironmentRepositoryConfigurationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/JdbcEnvironmentRepositoryConfigurationTests.java
@@ -42,7 +42,9 @@ public class JdbcEnvironmentRepositoryConfigurationTests {
 	@Test
 	public void jdbcEnvironmentRepositoryBeansConfiguredWhenDefault() throws IOException {
 		new WebApplicationContextRunner().withUserConfiguration(TestConfigServerApplication.class)
-			.withPropertyValues("spring.profiles.active=test,jdbc", "spring.main.web-application-type=none")
+			.withPropertyValues("spring.profiles.active=test,jdbc", "spring.main.web-application-type=none",
+					"management.metrics.use-global-registry=false", "management.metrics.export.simple.enabled=false",
+					"management.observations.enabled=false", "management.tracing.enabled=false")
 			.run(context -> {
 				assertThat(context).hasSingleBean(JdbcEnvironmentRepositoryFactory.class);
 				assertThat(context).hasSingleBean(JdbcEnvironmentRepository.class);
@@ -54,7 +56,9 @@ public class JdbcEnvironmentRepositoryConfigurationTests {
 	public void jdbcEnvironmentRepositoryBeansConfiguredWitCustomResultSetExtractor() {
 		new WebApplicationContextRunner().withUserConfiguration(TestConfigServerApplication.class)
 			.withBean(CustomResultSetExtractor.class, CustomResultSetExtractor::new)
-			.withPropertyValues("spring.profiles.active=test,jdbc", "spring.main.web-application-type=none")
+			.withPropertyValues("spring.profiles.active=test,jdbc", "spring.main.web-application-type=none",
+					"management.metrics.use-global-registry=false", "management.metrics.export.simple.enabled=false",
+					"management.observations.enabled=false", "management.tracing.enabled=false")
 			.run(context -> {
 				assertThat(context).hasSingleBean(JdbcEnvironmentRepositoryFactory.class);
 				assertThat(context).hasSingleBean(JdbcEnvironmentRepository.class);
@@ -88,7 +92,9 @@ public class JdbcEnvironmentRepositoryConfigurationTests {
 		new WebApplicationContextRunner().withUserConfiguration(TestConfigServerApplication.class)
 			.withPropertyValues("spring.profiles.active=test,jdbc", "spring.main.web-application-type=none",
 					"spring.cloud.config.server.git.uri:" + uri,
-					"spring.cloud.config.server.jdbc.enabled:" + jdbcEnabled)
+					"spring.cloud.config.server.jdbc.enabled:" + jdbcEnabled,
+					"management.metrics.use-global-registry=false", "management.metrics.export.simple.enabled=false",
+					"management.observations.enabled=false", "management.tracing.enabled=false")
 			.run(consumer);
 	}
 


### PR DESCRIPTION
🧪 Background & Symptom

While running
JdbcEnvironmentRepositoryConfigurationTests
with NonDex (FULL mode), we occasionally observed a failure during Spring Boot
application context initialization.

The failure manifested as an unexpected context startup error, causing the
AssertableWebApplicationContext to fail and the subsequent assertions on
JdbcEnvironmentRepositoryFactory / JdbcEnvironmentRepository beans to fail.

The relevant stack trace started with:

java.lang.ArrayIndexOutOfBoundsException
at io.micrometer.core.instrument.composite.CompositeMeterRegistry.updateDescendants(...)

🔍 Root Cause (3rd-party nondeterministic behavior)

The failure was triggered inside Micrometer’s CompositeMeterRegistry when a
newly created SimpleMeterRegistry was added to Micrometer’s global
Metrics registry during auto-configuration.

Under certain execution orders — which NonDex helps expose — the internal state
of the composite registry can become inconsistent, leading to an
ArrayIndexOutOfBoundsException.

This behavior is unrelated to the JDBC environment repository configuration
being tested and instead stems from nondeterministic interactions with
Micrometer’s global metrics state.

🛠 Fix

Since these JDBC configuration tests do not rely on Micrometer’s global
metrics registry, we safely disable its usage by adding the following property
to the test configuration:

management.metrics.use-global-registry=false
management.metrics.export.simple.enabled=false
management.observations.enabled=false
management.tracing.enabled=false

This prevents SimpleMeterRegistry instances from being registered in
Metrics.globalRegistry, avoiding the problematic
CompositeMeterRegistry.updateDescendants() code path and ensuring
deterministic Spring Boot context startup for the affected tests.

### Validation Script

<details>
<summary>Click to view validation script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

LOG_ROOT="$HOME/logs/logs_config_new"
mkdir -p "$LOG_ROOT"

REPO_DIR="$HOME/myRepo/spring-cloud-config"

NONDEX_VERSION="2.2.1"
NONDEX_RUNS="60"
NONDEX_MODE="FULL"
NONDEX_SEED="123456"

MODULE="spring-cloud-config-server"

TEST_CLASS="org.springframework.cloud.config.server.environment.JdbcEnvironmentRepositoryConfigurationTests"

METHODS=(
  "jdbcEnvironmentRepositoryBeansConfiguredWhenDefault"
  "jdbcEnvironmentRepositoryBeansConfiguredWhenEnabled"
  "jdbcEnvironmentRepositoryBeansConfiguredWitCustomResultSetExtractor"
  "jdbcEnvironmentRepositoryFactoryNotConfiguredWhenDisabled"
  "jdbcEnvironmentRepositoryNotConfiguredWhenDisabled"
)

cd "$REPO_DIR"

SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
TS="$(date +%Y%m%d-%H%M%S)"
LOG_FILE="$LOG_ROOT/server-JdbcEnvironmentRepositoryConfigurationTests-${TS}-${SHA}.log"

METHOD_PART=""
for m in "${METHODS[@]}"; do
  if [ -z "$METHOD_PART" ]; then
    METHOD_PART="$m"
  else
    METHOD_PART="$METHOD_PART+$m"
  fi
done

NONDEX_TEST="${TEST_CLASS}#${METHOD_PART}"

CMD="./mvnw clean && \
./mvnw -pl ${MODULE} \
  edu.illinois:nondex-maven-plugin:${NONDEX_VERSION}:nondex \
  -Dtest=${NONDEX_TEST} \
  -DnondexRuns=${NONDEX_RUNS} \
  -DnondexMode=${NONDEX_MODE} \
  -DnondexSeed=${NONDEX_SEED}"

{
  echo "==== [${MODULE} NonDex - transport tests] $(date) ===="
  echo "repo     : $REPO_DIR"
  echo "module   : $MODULE"
  echo "sha      : $SHA"
  echo "command  : $CMD"
  echo

  eval "$CMD"

  echo
  echo "==== DONE $(date) ===="
} | tee "$LOG_FILE"