### PR TITLE
Ensure property-defined Vault token is used when auth is TOKEN

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilder.java
@@ -60,7 +60,8 @@ public class SpringVaultTemplateBuilder {
 	private boolean isStaticToken(VaultEnvironmentProperties vaultProperties) {
 		boolean hasToken = StringUtils.hasText(vaultProperties.getToken());
 		boolean isDefaultAuth = vaultProperties.getAuthentication() == null;
-		boolean isTokenAuth = vaultProperties.getAuthentication() == VaultEnvironmentProperties.AuthenticationMethod.TOKEN;
+		boolean isTokenAuth = vaultProperties
+			.getAuthentication() == VaultEnvironmentProperties.AuthenticationMethod.TOKEN;
 
 		return hasToken && (isDefaultAuth || isTokenAuth);
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilderTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/vault/SpringVaultTemplateBuilderTest.java
@@ -44,7 +44,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -137,13 +137,9 @@ class SpringVaultTemplateBuilderTest {
 		ConfigTokenProvider defaultTokenProvider = mock(ConfigTokenProvider.class);
 		ApplicationContext mockContext = mock(ApplicationContext.class);
 
-		SpringVaultTemplateBuilder builder = new SpringVaultTemplateBuilder(
-			defaultTokenProvider,
-			Collections.emptyList(),
-			mockContext
-		);
-
-		assertThrows(Exception.class, () -> builder.build(properties));
+		SpringVaultTemplateBuilder builder = new SpringVaultTemplateBuilder(defaultTokenProvider,
+				Collections.emptyList(), mockContext);
+		assertThatThrownBy(() -> builder.build(properties)).isInstanceOf(Exception.class);
 		verifyNoInteractions(defaultTokenProvider);
 	}
 


### PR DESCRIPTION
Prior to this commit, `SpringVaultTemplateBuilder` ignored the configured static token if `spring.cloud.config.server.vault.authentication` was explicitly set to `TOKEN`. This caused the application to incorrectly fall back to default authentication mechanisms (e.g., filesystem token) even when a token was provided in the properties.

This change updates the `isStaticToken` predicate to return `true` when a token is present and the authentication method is either `null` (default) or explicitly set to `TOKEN`.

A unit test has been added to ensure the default `ConfigTokenProvider` is ignored in this scenario.

Fixes gh-3172