### PR TITLE
feat: github apps support

### DIFF
--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -93,6 +93,31 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk18on</artifactId>
+			<version>${bouncycastle.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>${bouncycastle.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.tmatesoft.svnkit</groupId>
 			<artifactId>svnkit</artifactId>
 			<optional>true</optional>
@@ -296,6 +321,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<jjwt.version>0.13.0</jjwt.version>
+		<bouncycastle.version>1.83</bouncycastle.version>
 	</properties>
 	<build>
 		<plugins>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/GitCredentialsProviderFactory.java
@@ -16,12 +16,32 @@
 
 package org.springframework.cloud.config.server.support;
 
+import java.io.StringReader;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.ClassUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -43,6 +63,40 @@ public class GitCredentialsProviderFactory {
 	 * https://git-codecommit.${AWS_REGION}.amazonaws.com/${repoPath}. Enabled by default.
 	 */
 	protected boolean awsCodeCommitEnabled = true;
+
+	/**
+	 * If the GitHub App mode should be activated.
+	 */
+	@Value("${spring.cloud.config.server.git.app:false}")
+	public boolean isApp;
+
+	/**
+	 * The id of the GitHub app.
+	 */
+	@Value("${spring.cloud.config.server.git.appId:}")
+	public String appId;
+
+	/**
+	 * The uri of the GitHub api.
+	 */
+	@Value("${spring.cloud.config.server.git.apiUri:}")
+	public String apiUri;
+
+	/**
+	 * The installation id of the GitHub app.
+	 */
+	@Value("${spring.cloud.config.server.git.installationId:}")
+	public String installationId;
+
+	/**
+	 * The expiration minutes for the jwt token.
+	 */
+	@Value("${spring.cloud.config.server.git.jwtExpirationMinutes:0}")
+	private int jwtExpirationMinutes;
+
+	private String jwtToken;
+
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	/**
 	 * Search for a credential provider that will handle the specified URI. If not found,
@@ -73,6 +127,7 @@ public class GitCredentialsProviderFactory {
 		}
 		else if (hasText(username) && password != null) {
 			this.logger.debug("Constructing UsernamePasswordCredentialsProvider for URI " + uri);
+			password = appToken(username, password);
 			provider = new UsernamePasswordCredentialsProvider(username, password.toCharArray());
 		}
 		else if (hasText(passphrase)) {
@@ -116,4 +171,90 @@ public class GitCredentialsProviderFactory {
 		this.awsCodeCommitEnabled = awsCodeCommitEnabled;
 	}
 
+	/**
+	 * Gets the app token to be used to perform GitHub repository calls with.
+	 *
+	 * @param username the username to authenticate with
+	 * @param password the password to authenticate with
+	 * @return the token to be used as password
+	 */
+	private String appToken(String username, String password) {
+		if (isApp && "x-access-token".equals(username)) {
+			this.logger.debug("Using GitHub App mode for authentication - please ensure that you use the private key as password.");
+			try {
+				// if jwtToken is null or expired, generate a new one and set it to the field, otherwise use the existing one
+				if (jwtToken == null || Instant.parse(mapper.readTree(jwtToken).get("expires_at").asText()).isBefore(Instant.now())) {
+					PrivateKey privateKey = loadPkcs1PrivateKey(password);
+					HttpHeaders headers = new HttpHeaders();
+					headers.setBearerAuth(generateJwt(appId, privateKey));
+					headers.set("Accept", "application/vnd.github+json");
+					HttpEntity<String> entity = new HttpEntity<>(headers);
+					RestTemplate restTemplate = new RestTemplate();
+					UriComponentsBuilder uriBuilder =
+						UriComponentsBuilder.fromUriString(apiUri)
+							.path("app/installations")
+							.pathSegment(installationId)
+							.path("access_tokens");
+					ResponseEntity<String> response = restTemplate.exchange(
+						uriBuilder.build().toUriString(),
+						HttpMethod.POST,
+						entity,
+						String.class
+					);
+					this.jwtToken = response.getBody();
+				}
+				password = mapper.readTree(jwtToken).get("token").asText();
+			}
+			catch (Exception e) {
+				this.logger.error("Error while retrieving the app token", e);
+			}
+		}
+		return password;
+	}
+
+	/**
+	 * Converts the password into a private key.
+	 *
+	 * @param password the password to convert
+	 * @return the PrivateKey
+	 */
+	private PrivateKey loadPkcs1PrivateKey(String password) {
+		try (PEMParser pemParser = new PEMParser(new StringReader(password))) {
+			Object object = pemParser.readObject();
+			PrivateKeyInfo privateKeyInfo;
+			if (object instanceof PEMKeyPair pemKeyPair) {
+				privateKeyInfo = pemKeyPair.getPrivateKeyInfo();
+			}
+			else if (object instanceof PrivateKeyInfo privateKeyInfo1) {
+				privateKeyInfo = privateKeyInfo1;
+			}
+			else {
+				throw new IllegalArgumentException("Unknown PEM object: " + object.getClass());
+			}
+			byte[] pkcs8Bytes = privateKeyInfo.getEncoded();
+			PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(pkcs8Bytes);
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return kf.generatePrivate(spec);
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("An error occurred while loading the private key", e);
+		}
+	}
+
+	/**
+	 * Generates a jwt token based on the appId and the privateKey.
+	 *
+	 * @param appId the id of the GitHub App
+	 * @param privateKey the private key to sign with
+	 * @return the jwt to be used for the api call
+	 */
+	private String generateJwt(String appId, PrivateKey privateKey) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.issuer(appId)
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(now.plus(jwtExpirationMinutes, ChronoUnit.MINUTES)))
+			.signWith(privateKey)
+			.compact();
+	}
 }


### PR DESCRIPTION
Fix for: https://github.com/spring-cloud/spring-cloud-config/issues/3188

Things need to be done before the feature is ready:
* The dependencies have to be managed in a better way and also may exchanged with alt. integrations (jsonwebtoken / bouncycastle)
* The Properties could be renamed and relocated to a Properties class
* Proxy-Settings for RestTemplate setup should be improved
* Tests should be implemented (if possible)

The config currently would look like this:
```yml
spring:
  cloud:
    config:
      server:
        git:
          uri: https://github.com/organization/my-config-server-repository
          username: x-access-token # used to authenticate with GitHub App access tokens
          password: |
            -----BEGIN RSA PRIVATE KEY
            ...
            -----END RSA PRIVATE KEY-----
          app: true # indicates that an app should be used
          appId: 530 # the id of the app
          apiUri: https://api.github.com/ # the GitHub api uri (might be changed for enterprise customers)
          installationId: 2164 # the app installation id
          jwtExpirationMinutes: 8 # how long the token is valid until a new one is retrieved
```

