### PR TITLE
Fix 'occured' -> 'occurred' typo in JGitEnvironmentRepository clone-error log

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java
@@ -676,7 +676,7 @@ public class JGitEnvironmentRepository extends AbstractScmEnvironmentRepository
 			return clone.call();
 		}
 		catch (GitAPIException e) {
-			this.logger.warn("Error occured cloning to base directory.", e);
+			this.logger.warn("Error occurred cloning to base directory.", e);
 			deleteBaseDirIfExists();
 			throw e;
 		}


### PR DESCRIPTION
`logger.warn` message in `spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/JGitEnvironmentRepository.java:679` emitted when the initial JGit clone to the base directory fails read `Error occured cloning to base directory`. The message reaches operators in `spring-cloud-config-server` logs. String-literal-only change.