### PR TITLE
Resolve placeholders at map level before YAML/JSON serialization

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -49,6 +49,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolveMapPlaceholders;
 import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
 import static org.springframework.cloud.config.server.support.PathUtils.isInvalidEncodedLocation;
 import static org.springframework.cloud.config.server.support.PathUtils.isInvalidProfiles;
@@ -199,10 +200,10 @@ public class EnvironmentController {
 		validateProfiles(profiles);
 		Environment environment = labelled(name, profiles, label);
 		Map<String, Object> properties = convertToMap(environment);
-		String json = this.objectMapper.writeValueAsString(properties);
 		if (resolvePlaceholders) {
-			json = resolvePlaceholders(prepareEnvironment(environment), json);
+			properties = resolveMapPlaceholders(prepareEnvironment(environment), properties);
 		}
+		String json = this.objectMapper.writeValueAsString(properties);
 		return getSuccess(json, MediaType.APPLICATION_JSON);
 	}
 
@@ -230,6 +231,9 @@ public class EnvironmentController {
 		validateProfiles(profiles);
 		Environment environment = labelled(name, profiles, label);
 		Map<String, Object> result = convertToMap(environment);
+		if (resolvePlaceholders) {
+			result = resolveMapPlaceholders(prepareEnvironment(environment), result);
+		}
 		if (this.stripDocument && result.size() == 1 && result.keySet().iterator().next().equals("document")) {
 			Object value = result.get("document");
 			if (value instanceof Collection) {
@@ -240,11 +244,6 @@ public class EnvironmentController {
 			}
 		}
 		String yaml = new Yaml().dumpAsMap(result);
-
-		if (resolvePlaceholders) {
-			yaml = resolvePlaceholders(prepareEnvironment(environment), yaml);
-		}
-
 		return getSuccess(yaml);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
@@ -33,7 +33,8 @@ import org.springframework.util.PropertyPlaceholderHelper;
 public class EnvironmentPropertySource extends PropertySource<Environment> {
 
 	// Use PropertyPlaceholderHelper directly to trim whitespace from keys
-	private static final PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${", "}", ":", null, true);
+	private static final PropertyPlaceholderHelper PROPERTY_PLACEHOLDER_HELPER = new PropertyPlaceholderHelper("${",
+			"}", ":", null, true);
 
 	// "\${" (from text) or "\\${" from JSON to signal escaped placeholder
 	private static final Pattern ESCAPED_PLACEHOLDERS = Pattern.compile("[\\\\]{1,2}\\$\\{");
@@ -104,7 +105,8 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 		}
 		// Mask escaped placeholders
 		String masked = ESCAPED_PLACEHOLDERS.matcher(value).replaceAll("\\$_{");
-		String resolved = helper.replacePlaceholders(masked, (placeholder) -> env.getProperty(placeholder.strip()));
+		String resolved = PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders(masked,
+				(placeholder) -> env.getProperty(placeholder.strip()));
 		return resolved.replace("$_{", "${");
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
@@ -16,12 +16,16 @@
 
 package org.springframework.cloud.config.server.support;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.PropertyPlaceholderHelper;
 
 /**
  * @author Spencer Gibb
@@ -30,6 +34,8 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 
 	// "\${" (from text) or "\\${" from JSON to signal escaped placeholder
 	private static final Pattern ESCAPED_PLACEHOLDERS = Pattern.compile("[\\\\]{1,2}\\$\\{");
+
+	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
 
 	public EnvironmentPropertySource(Environment sources) {
 		super("cloudEnvironment", sources);
@@ -43,10 +49,64 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 		return standardEnvironment;
 	}
 
+	/**
+	 * Resolve placeholders in flat text (used for .properties output). Handles escaped
+	 * placeholders (\${...}) by masking and restoring them.
+	 */
 	public static String resolvePlaceholders(StandardEnvironment preparedEnvironment, String text) {
 		// Mask out escaped placeholders
 		text = ESCAPED_PLACEHOLDERS.matcher(text).replaceAll("\\$_{");
 		return preparedEnvironment.resolvePlaceholders(text).replace("$_{", "${");
+	}
+
+	/**
+	 * Resolve placeholders in a nested Map structure. Walks all values recursively,
+	 * resolving any String values that contain ${...} expressions. Returns a new Map with
+	 * resolved values — the original is not modified.
+	 *
+	 * <p>
+	 * Use this before serializing to YAML or JSON so that the serializer handles
+	 * multiline values and escaping natively.
+	 */
+	@SuppressWarnings("unchecked")
+	public static Map<String, Object> resolveMapPlaceholders(StandardEnvironment env, Map<String, Object> map) {
+		Map<String, Object> resolved = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : map.entrySet()) {
+			resolved.put(entry.getKey(), resolveValue(env, entry.getValue()));
+		}
+		return resolved;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Object resolveValue(StandardEnvironment env, Object value) {
+		if (value instanceof String s) {
+			return resolveStringValue(env, s);
+		}
+		else if (value instanceof Map) {
+			Map<String, Object> mapValue = (Map<String, Object>) value;
+			Map<String, Object> resolved = new LinkedHashMap<>();
+			for (Map.Entry<String, Object> entry : mapValue.entrySet()) {
+				resolved.put(entry.getKey(), resolveValue(env, entry.getValue()));
+			}
+			return resolved;
+		}
+		else if (value instanceof List) {
+			List<Object> listValue = (List<Object>) value;
+			return listValue.stream().map(item -> resolveValue(env, item)).collect(Collectors.toList());
+		}
+		return value;
+	}
+
+	private static String resolveStringValue(StandardEnvironment env, String value) {
+		if (!PLACEHOLDER_PATTERN.matcher(value).find()) {
+			return value;
+		}
+		// Mask escaped placeholders
+		String masked = ESCAPED_PLACEHOLDERS.matcher(value).replaceAll("\\$_{");
+		// Use PropertyPlaceholderHelper directly to trim whitespace from keys
+		PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${", "}", ":", null, true);
+		String resolved = helper.replacePlaceholders(masked, (placeholder) -> env.getProperty(placeholder.strip()));
+		return resolved.replace("$_{", "${");
 	}
 
 	@Override

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/support/EnvironmentPropertySource.java
@@ -32,6 +32,9 @@ import org.springframework.util.PropertyPlaceholderHelper;
  */
 public class EnvironmentPropertySource extends PropertySource<Environment> {
 
+	// Use PropertyPlaceholderHelper directly to trim whitespace from keys
+	private static final PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${", "}", ":", null, true);
+
 	// "\${" (from text) or "\\${" from JSON to signal escaped placeholder
 	private static final Pattern ESCAPED_PLACEHOLDERS = Pattern.compile("[\\\\]{1,2}\\$\\{");
 
@@ -68,7 +71,6 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 	 * Use this before serializing to YAML or JSON so that the serializer handles
 	 * multiline values and escaping natively.
 	 */
-	@SuppressWarnings("unchecked")
 	public static Map<String, Object> resolveMapPlaceholders(StandardEnvironment env, Map<String, Object> map) {
 		Map<String, Object> resolved = new LinkedHashMap<>();
 		for (Map.Entry<String, Object> entry : map.entrySet()) {
@@ -77,7 +79,6 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 		return resolved;
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Object resolveValue(StandardEnvironment env, Object value) {
 		if (value instanceof String s) {
 			return resolveStringValue(env, s);
@@ -103,8 +104,6 @@ public class EnvironmentPropertySource extends PropertySource<Environment> {
 		}
 		// Mask escaped placeholders
 		String masked = ESCAPED_PLACEHOLDERS.matcher(value).replaceAll("\\$_{");
-		// Use PropertyPlaceholderHelper directly to trim whitespace from keys
-		PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${", "}", ":", null, true);
 		String resolved = helper.replacePlaceholders(masked, (placeholder) -> env.getProperty(placeholder.strip()));
 		return resolved.replace("$_{", "${");
 	}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -525,6 +525,31 @@ class EnvironmentControllerTests {
 		when(this.repository.findOne("foo", "bar", null, false)).thenReturn(this.environment);
 	}
 
+	private void whenMultilinePlaceholders() {
+		Map<String, Object> map = new LinkedHashMap<String, Object>();
+		map.put("multiline", "line1\nline2\nline3\n");
+		map.put("ref", "${multiline}");
+		this.environment.add(new PropertySource("one", map));
+		when(this.repository.findOne("foo", "bar", null, false)).thenReturn(this.environment);
+	}
+
+	@Test
+	public void multilinePlaceholderResolvedInYaml() throws Exception {
+		whenMultilinePlaceholders();
+		String yaml = this.controller.yaml("foo", "bar", true).getBody();
+		Map<String, Object> map = new Yaml().load(yaml);
+		assertThat(map).containsEntry("multiline", "line1\nline2\nline3\n");
+		assertThat(map).containsEntry("ref", "line1\nline2\nline3\n");
+	}
+
+	@Test
+	public void multilinePlaceholderResolvedInJson() throws Exception {
+		whenMultilinePlaceholders();
+		String json = this.controller.jsonProperties("foo", "bar", true).getBody();
+		JSONAssert.assertEquals("{\"multiline\":\"line1\\nline2\\nline3\\n\",\"ref\":\"line1\\nline2\\nline3\\n\"}",
+				json, JSONCompareMode.STRICT);
+	}
+
 	@Test
 	public void nameStartsWithSlash() {
 		assertThatThrownBy(() -> this.controller.labelled("(_)spam", "bar", null))

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
@@ -16,11 +16,18 @@
 
 package org.springframework.cloud.config.server.support;
 
-import org.junit.jupiter.api.Test;
+import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.prepareEnvironment;
+import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolveMapPlaceholders;
 import static org.springframework.cloud.config.server.support.EnvironmentPropertySource.resolvePlaceholders;
 
 public class EnvironmentPropertySourceTest {
@@ -32,6 +39,205 @@ public class EnvironmentPropertySourceTest {
 		assertThat(resolvePlaceholders(this.env, "\\${abc}")).isEqualTo("${abc}");
 		// JSON generated from jackson will be double escaped
 		assertThat(resolvePlaceholders(this.env, "\\\\${abc}")).isEqualTo("${abc}");
+	}
+
+	@Test
+	public void singleValuePlaceholderResolved() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("foo", "bar");
+		map.put("ref", "${foo}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("foo", "bar");
+		input.put("ref", "${foo}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("ref")).isEqualTo("bar");
+	}
+
+	@Test
+	public void multilineValuePlaceholderResolved() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("greeting", "hello\nworld\n");
+		map.put("ref", "${greeting}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("greeting", "hello\nworld\n");
+		input.put("ref", "${greeting}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("ref")).isEqualTo("hello\nworld\n");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void nestedMapPlaceholderResolved() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("greeting", "hello\nworld\n");
+		map.put("nested.ref", "${greeting}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> nested = new java.util.LinkedHashMap<>();
+		nested.put("ref", "${greeting}");
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("greeting", "hello\nworld\n");
+		input.put("nested", nested);
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		Map<String, Object> resolvedNested = (Map<String, Object>) resolved.get("nested");
+		assertThat(resolvedNested.get("ref")).isEqualTo("hello\nworld\n");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void listPlaceholderResolved() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("greeting", "hello\nworld\n");
+		map.put("items[0]", "${greeting}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("greeting", "hello\nworld\n");
+		input.put("items", java.util.List.of("${greeting}"));
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		java.util.List<Object> items = (java.util.List<Object>) resolved.get("items");
+		assertThat(items.get(0)).isEqualTo("hello\nworld\n");
+	}
+
+	@Test
+	public void escapedPlaceholderPreservedInMap() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("literal", "\\${not.a.ref}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("literal", "\\${not.a.ref}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("literal")).isEqualTo("${not.a.ref}");
+	}
+
+	@Test
+	public void endToEndMultilineYaml() {
+		// Source YAML has a multiline value and a reference to it
+		String sourceYaml = "greeting: |\n  hello\n  world\nref: ${greeting}\n";
+		@SuppressWarnings("unchecked")
+		Map<String, Object> parsed = new Yaml().load(sourceYaml);
+
+		Environment environment = new Environment("test", "default");
+		environment.add(new PropertySource("one", parsed));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, parsed);
+		String yaml = new Yaml().dumpAsMap(resolved);
+
+		assertThat(yaml).contains("ref: |\n  hello\n  world");
+	}
+
+	@Test
+	public void endToEndMultilinePlaceholderSpanningLines() {
+		// Source YAML has placeholder spanning multiple lines (SnakeYAML folds to spaces)
+		String sourceYaml = "greeting: |\n  hello\n  world\nref: ${\n       greeting\n     }\n";
+		@SuppressWarnings("unchecked")
+		Map<String, Object> parsed = new Yaml().load(sourceYaml);
+
+		Environment environment = new Environment("test", "default");
+		environment.add(new PropertySource("one", parsed));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, parsed);
+		String yaml = new Yaml().dumpAsMap(resolved);
+
+		assertThat(yaml).contains("ref: |\n  hello\n  world");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void endToEndSequenceWithMultilineValue() {
+		String sourceYaml = "greeting: |\n  hello\n  world\nitems:\n- ${greeting}\n- ref: ${greeting}\n";
+		Map<String, Object> parsed = new Yaml().load(sourceYaml);
+
+		Environment environment = new Environment("test", "default");
+		environment.add(new PropertySource("one", parsed));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, parsed);
+		String yaml = new Yaml().dumpAsMap(resolved);
+
+		// Verify YAML is valid and values are resolved
+		Map<String, Object> reparsed = new Yaml().load(yaml);
+		java.util.List<Object> items = (java.util.List<Object>) reparsed.get("items");
+		assertThat(items.get(0)).isEqualTo("hello\nworld\n");
+		Map<String, Object> secondItem = (Map<String, Object>) items.get(1);
+		assertThat(secondItem.get("ref")).isEqualTo("hello\nworld\n");
+	}
+
+	@Test
+	public void defaultValueUsedWhenKeyMissing() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("ref", "${MISSING:fallback value}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("ref", "${MISSING:fallback value}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("ref")).isEqualTo("fallback value");
+	}
+
+	@Test
+	public void defaultValueOverriddenWhenKeyExists() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("greeting", "hello");
+		map.put("ref", "${greeting:fallback}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("greeting", "hello");
+		input.put("ref", "${greeting:fallback}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("ref")).isEqualTo("hello");
+	}
+
+	@Test
+	public void unresolvablePlaceholderLeftIntact() {
+		Environment environment = new Environment("test", "default");
+		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("ref", "${MISSING}");
+		environment.add(new PropertySource("one", map));
+		StandardEnvironment prepared = prepareEnvironment(environment);
+
+		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		input.put("ref", "${MISSING}");
+
+		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
+
+		assertThat(resolved.get("ref")).isEqualTo("${MISSING}");
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.config.server.support;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -44,13 +46,13 @@ public class EnvironmentPropertySourceTest {
 	@Test
 	public void singleValuePlaceholderResolved() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("foo", "bar");
 		map.put("ref", "${foo}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("foo", "bar");
 		input.put("ref", "${foo}");
 
@@ -62,13 +64,13 @@ public class EnvironmentPropertySourceTest {
 	@Test
 	public void multilineValuePlaceholderResolved() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("greeting", "hello\nworld\n");
 		map.put("ref", "${greeting}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("greeting", "hello\nworld\n");
 		input.put("ref", "${greeting}");
 
@@ -78,18 +80,17 @@ public class EnvironmentPropertySourceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void nestedMapPlaceholderResolved() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("greeting", "hello\nworld\n");
 		map.put("nested.ref", "${greeting}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> nested = new java.util.LinkedHashMap<>();
+		Map<String, Object> nested = new LinkedHashMap<>();
 		nested.put("ref", "${greeting}");
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("greeting", "hello\nworld\n");
 		input.put("nested", nested);
 
@@ -100,34 +101,33 @@ public class EnvironmentPropertySourceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void listPlaceholderResolved() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("greeting", "hello\nworld\n");
 		map.put("items[0]", "${greeting}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("greeting", "hello\nworld\n");
-		input.put("items", java.util.List.of("${greeting}"));
+		input.put("items", List.of("${greeting}"));
 
 		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
 
-		java.util.List<Object> items = (java.util.List<Object>) resolved.get("items");
+		List<Object> items = (List<Object>) resolved.get("items");
 		assertThat(items.get(0)).isEqualTo("hello\nworld\n");
 	}
 
 	@Test
 	public void escapedPlaceholderPreservedInMap() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("literal", "\\${not.a.ref}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("literal", "\\${not.a.ref}");
 
 		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
@@ -139,7 +139,6 @@ public class EnvironmentPropertySourceTest {
 	public void endToEndMultilineYaml() {
 		// Source YAML has a multiline value and a reference to it
 		String sourceYaml = "greeting: |\n  hello\n  world\nref: ${greeting}\n";
-		@SuppressWarnings("unchecked")
 		Map<String, Object> parsed = new Yaml().load(sourceYaml);
 
 		Environment environment = new Environment("test", "default");
@@ -170,7 +169,6 @@ public class EnvironmentPropertySourceTest {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void endToEndSequenceWithMultilineValue() {
 		String sourceYaml = "greeting: |\n  hello\n  world\nitems:\n- ${greeting}\n- ref: ${greeting}\n";
 		Map<String, Object> parsed = new Yaml().load(sourceYaml);

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/support/EnvironmentPropertySourceTest.java
@@ -182,7 +182,7 @@ public class EnvironmentPropertySourceTest {
 
 		// Verify YAML is valid and values are resolved
 		Map<String, Object> reparsed = new Yaml().load(yaml);
-		java.util.List<Object> items = (java.util.List<Object>) reparsed.get("items");
+		List<Object> items = (List<Object>) reparsed.get("items");
 		assertThat(items.get(0)).isEqualTo("hello\nworld\n");
 		Map<String, Object> secondItem = (Map<String, Object>) items.get(1);
 		assertThat(secondItem.get("ref")).isEqualTo("hello\nworld\n");
@@ -191,12 +191,12 @@ public class EnvironmentPropertySourceTest {
 	@Test
 	public void defaultValueUsedWhenKeyMissing() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("ref", "${MISSING:fallback value}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("ref", "${MISSING:fallback value}");
 
 		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);
@@ -207,13 +207,13 @@ public class EnvironmentPropertySourceTest {
 	@Test
 	public void defaultValueOverriddenWhenKeyExists() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("greeting", "hello");
 		map.put("ref", "${greeting:fallback}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("greeting", "hello");
 		input.put("ref", "${greeting:fallback}");
 
@@ -225,12 +225,12 @@ public class EnvironmentPropertySourceTest {
 	@Test
 	public void unresolvablePlaceholderLeftIntact() {
 		Environment environment = new Environment("test", "default");
-		java.util.Map<String, Object> map = new java.util.LinkedHashMap<>();
+		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("ref", "${MISSING}");
 		environment.add(new PropertySource("one", map));
 		StandardEnvironment prepared = prepareEnvironment(environment);
 
-		Map<String, Object> input = new java.util.LinkedHashMap<>();
+		Map<String, Object> input = new LinkedHashMap<>();
 		input.put("ref", "${MISSING}");
 
 		Map<String, Object> resolved = resolveMapPlaceholders(prepared, input);


### PR DESCRIPTION
Instead of resolving placeholders by string-manipulating serialized YAML/JSON output, resolve them in the property Map before passing to the serializer. This lets SnakeYAML and Jackson handle multiline values and escaping natively, eliminating the need for:
- OutputFormat enum
- resolveYamlPlaceholders / resolveAsBlockScalar / isStandalonePlaceholder
- resolvePlaceholdersWithTransform with JsonStringEncoder
- joinMultiLinePlaceholders

Add resolveMapPlaceholders() which recursively walks Maps and Lists, resolving ${...} in String values via PropertyPlaceholderHelper with key trimming (handles SnakeYAML-folded multi-line placeholders).

The text-based resolvePlaceholders() remains for .properties output.

Re: https://github.com/spring-cloud/spring-cloud-config/issues/3234