### PR TITLE
docs: add observability page to nav and fix heading level

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -38,3 +38,4 @@
 ** xref:server/push-notifications-and-bus.adoc[]
 ** xref:server/aot-and-native-image-support.adoc[]
 * xref:client.adoc[]
+* xref:observability.adoc[]

--- a/docs/modules/ROOT/pages/observability.adoc
+++ b/docs/modules/ROOT/pages/observability.adoc
@@ -1,5 +1,5 @@
 [[observability]]
-== Observability metadata
+= Observability
 
 include::partial$_metrics.adoc[]
 


### PR DESCRIPTION
## Problem

The `observability.adoc` page exists in the Antora docs but is not referenced in `nav.adoc`, making it unreachable from the documentation navigation and causing unresolved reference errors when building the release train docs.

Additionally, the page uses a level-2 heading (`== Observability metadata`) instead of a level-1 heading (`= Observability`), which is invalid for a standalone Antora page.

## Changes

- Add `* xref:observability.adoc[]` to `nav.adoc` so the page appears in the sidebar
- Promote the heading from level 2 (`==`) to level 1 (`=`) and update title to match other Spring Cloud projects (e.g. Spring Cloud Stream)

Fixes #2272

🤖 Generated with [Claude Code](https://claude.com/claude-code)