### PR TITLE
Fix native file monitor relative URI handling

### DIFF
--- a/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/FileMonitorConfiguration.java
+++ b/spring-cloud-config-monitor/src/main/java/org/springframework/cloud/config/monitor/FileMonitorConfiguration.java
@@ -202,7 +202,7 @@ public class FileMonitorConfiguration implements SmartLifecycle, ResourceLoaderA
 					}
 					Resource resource = this.resourceLoader.getResource(repositoryUri);
 					if (resource instanceof FileSystemResource || resource instanceof FileUrlResource) {
-						paths.add(Paths.get(resource.getURI()));
+						paths.add(resolvePath(resource));
 					}
 				}
 				return paths;
@@ -217,7 +217,7 @@ public class FileMonitorConfiguration implements SmartLifecycle, ResourceLoaderA
 				Resource resource = this.resourceLoader.getResource(path);
 				if (resource.exists()) {
 					try {
-						paths.add(Paths.get(resource.getURI()));
+						paths.add(resolvePath(resource));
 					}
 					catch (Exception e) {
 						log.error("Cannot resolve URI for path: " + path);
@@ -227,6 +227,13 @@ public class FileMonitorConfiguration implements SmartLifecycle, ResourceLoaderA
 			return paths;
 		}
 		return null;
+	}
+
+	private Path resolvePath(Resource resource) throws IOException {
+		if (resource instanceof FileSystemResource || resource instanceof FileUrlResource) {
+			return resource.getFile().toPath().toAbsolutePath().normalize();
+		}
+		return Paths.get(resource.getURI());
 	}
 
 	private Set<File> filesFromEvents() {

--- a/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/FileMonitorConfigurationTest.java
+++ b/spring-cloud-config-monitor/src/test/java/org/springframework/cloud/config/monitor/FileMonitorConfigurationTest.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.config.monitor;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +28,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.cloud.config.server.environment.AbstractScmEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.JGitEnvironmentProperties;
@@ -53,6 +56,9 @@ public class FileMonitorConfigurationTest {
 	private FileMonitorConfiguration fileMonitorConfiguration = new FileMonitorConfiguration();
 
 	private List<AbstractScmEnvironmentRepository> repositories = new ArrayList<>();
+
+	@TempDir
+	private Path tempDir;
 
 	@BeforeEach
 	public void setup() {
@@ -87,6 +93,22 @@ public class FileMonitorConfigurationTest {
 
 		// then
 		assertOnDirectory(1);
+	}
+
+	@Test
+	public void testStart_withNativeEnvironmentRepositoryAndRelativeFileUri() throws Exception {
+		// given
+		Path relativeLocation = Paths.get("target", "file-monitor", tempDir.getFileName().toString(), "config.d");
+		Files.createDirectories(relativeLocation);
+		NativeEnvironmentRepository repository = createNativeEnvironmentRepository("file:" + relativeLocation);
+		ReflectionTestUtils.setField(fileMonitorConfiguration, "nativeEnvironmentRepository", repository);
+
+		// when
+		fileMonitorConfiguration.start();
+
+		// then
+		Set<Path> directory = getDirectory();
+		assertThat(directory).containsExactly(relativeLocation.toAbsolutePath());
 	}
 
 	@Test
@@ -203,9 +225,13 @@ public class FileMonitorConfigurationTest {
 	}
 
 	private NativeEnvironmentRepository createNativeEnvironmentRepository() {
+		return createNativeEnvironmentRepository("classpath:pathsamples");
+	}
+
+	private NativeEnvironmentRepository createNativeEnvironmentRepository(String... searchLocations) {
 		ConfigurableEnvironment environment = createConfigurableEnvironment();
 		NativeEnvironmentProperties properties = new NativeEnvironmentProperties();
-		properties.setSearchLocations(new String[] { "classpath:pathsamples" });
+		properties.setSearchLocations(searchLocations);
 		return new NativeEnvironmentRepository(environment, properties, ObservationRegistry.NOOP);
 	}
 


### PR DESCRIPTION
Fixes gh-2997

This updates the file monitor path resolution for native search locations that use relative file URIs such as `file:target/config.d` or `file:./config.d`.

Previously, `FileMonitorConfiguration` resolved existing native resources with `Paths.get(resource.getURI())`. For relative file resources this can throw `IllegalArgumentException: URI is not hierarchical`, causing the path to be skipped and local config changes not to be monitored.

The fix resolves `FileSystemResource` and `FileUrlResource` through `resource.getFile().toPath().toAbsolutePath().normalize()`, while keeping the existing URI-based fallback for other resource types.

Verification:
- Red: the new test failed before the fix with `Cannot resolve URI for path: file:target/...` and an empty monitored directory set.
- Green: `./mvnw -pl spring-cloud-config-monitor -Dtest=FileMonitorConfigurationTest#testStart_withNativeEnvironmentRepositoryAndRelativeFileUri -Dstyle.color=never --no-transfer-progress test`
- Regression: `./mvnw -pl spring-cloud-config-monitor -Dtest=FileMonitorConfigurationTest -Dstyle.color=never --no-transfer-progress test`
- `git diff --check`