### PR TITLE
Ignore release train workflow files in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot opens GitHub Actions update PRs for the release train workflow files, but these files are auto-generated by `github-actions-workflow-generator` and not intended for direct dependency maintenance. Updating them via Dependabot causes noisy churn that gets overwritten the next time the generator runs.

## What changed

Added `exclude-paths` to the `github-actions` update entry in `.github/dependabot.yml` to exclude:
- `.github/workflows/release-train-test.yml`
- `.github/workflows/release-train-build.yml`

All other Dependabot configuration is unchanged.