### PR TITLE
Fix logger reference in VaultEnvironmentEncryptor

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/vault/VaultEnvironmentEncryptor.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/encryption/vault/VaultEnvironmentEncryptor.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
-import org.springframework.cloud.config.server.encryption.CipherEnvironmentEncryptor;
 import org.springframework.cloud.config.server.encryption.EnvironmentEncryptor;
 import org.springframework.util.ObjectUtils;
 import org.springframework.vault.core.VaultKeyValueOperations;
@@ -40,7 +39,7 @@ import org.springframework.vault.support.VaultResponse;
  */
 public class VaultEnvironmentEncryptor implements EnvironmentEncryptor {
 
-	private static final Log logger = LogFactory.getLog(CipherEnvironmentEncryptor.class);
+	private static final Log logger = LogFactory.getLog(VaultEnvironmentEncryptor.class);
 
 	private final VaultKeyValueOperations keyValueTemplate;
 


### PR DESCRIPTION
HI, I suggest a minor commit, changing the class log to the one that should be there, as you understand, an incorrect class can mislead people when viewing the logs