### PR TITLE
Add Google Cloud Parameter Manager environment repository

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 *** xref:server/environment-repository/aws-parameter-store-backend.adoc[]
 *** xref:server/environment-repository/aws-secrets-manager-backend.adoc[]
 *** xref:server/environment-repository/gcp-secret-manager-backend.adoc[]
+*** xref:server/environment-repository/gcp-parameter-manager-backend.adoc[]
 *** xref:server/environment-repository/credhub-backend.adoc[]
 *** xref:server/environment-repository/mongo-backend.adoc[]
 *** xref:server/environment-repository/composite-repositories.adoc[]

--- a/docs/modules/ROOT/pages/server/environment-repository/gcp-parameter-manager-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/gcp-parameter-manager-backend.adoc
@@ -1,0 +1,97 @@
+[[gcp-parameter-manager-backend]]
+= Google Cloud Parameter Manager Backend
+
+Spring Cloud Config Server can use link:https://cloud.google.com/parameter-manager[Google Cloud Parameter Manager] as an `EnvironmentRepository`.
+Parameters are exposed as `PropertySource` entries whose values are obtained from the latest parameter versions.
+
+== Enabling the backend
+
+The repository is registered when all of the following hold:
+
+* The Spring profile `parameter-manager` is active.
+* `com.google.cloud.parametermanager.v1.ParameterManagerClient` is on the classpath.
+
+[source,yaml]
+----
+spring:
+  profiles:
+    active: parameter-manager
+  cloud:
+    config:
+      server:
+        gcp-parameter-manager:
+          project-id: my-project
+          location: global
+          order: 0
+          application-label: application
+          profile-label: profile
+          default-label: main
+----
+
+Configuration properties are bound under `spring.cloud.config.server.gcp-parameter-manager`:
+
+|===
+| Property | Default | Description
+
+| `order`
+| Same as other environment repositories
+| Order in a composite repository (`org.springframework.core.Ordered`).
+
+| `application-label`
+| `application`
+| Parameter label key used to match the Config Server `\{application}` name (see <<gcp-parameter-manager-mapping>>).
+
+| `profile-label`
+| `profile`
+| Parameter label key used to match the Config Server profile (see <<gcp-parameter-manager-mapping>>).
+
+| `location`
+| `global`
+| Google Cloud Parameter Manager location.
+
+| `default-label`
+| `main`
+| Label returned by the Config Server when the client does not provide a label.
+
+| `project-id`
+| _empty_
+| Google Cloud project ID containing the parameters. This property must be configured.
+
+|===
+
+[[gcp-parameter-manager-mapping]]
+== Mapping applications and profiles
+
+The repository lists the parameters in the configured Google Cloud project and location once for each Config Client request and filters the result according to the requested application and profiles.
+
+Parameters are matched using their labels:
+
+* The label configured by `application-label` must match the requested `\{application}` name.
+* The label configured by `profile-label` must match the requested profile.
+* Matching is case-insensitive.
+* If an application label is missing, it defaults to `application`.
+* If a profile label is missing, it defaults to `profile`.
+
+When a Config Client requests an application other than `application`, the `application` application is also included first. This allows shared configuration to be provided for all applications.
+
+The configured Config Server default profile is also included before additional requested profiles when necessary.
+
+For every matching parameter, the repository reads the latest version and adds its rendered payload as a property value. The property name is derived from the parameter name.
+
+For example, a parameter with the name:
+
+----
+projects/my-project/locations/global/parameters/my-property
+----
+
+is exposed as:
+
+----
+my-property
+----
+
+== Authentication
+
+The Parameter Manager client is created using the Google Cloud client library's default authentication mechanism. Configure Google Cloud credentials using link:https://cloud.google.com/docs/authentication/application-default-credentials[Application Default Credentials].
+
+This can include credentials provided through environment configuration, local development credentials, or Google Cloud runtime service accounts.

--- a/docs/modules/ROOT/pages/server/environment-repository/gcp-parameter-manager-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/gcp-parameter-manager-backend.adoc
@@ -9,7 +9,7 @@ Parameters are exposed as `PropertySource` entries whose values are obtained fro
 The repository is registered when all of the following hold:
 
 * The Spring profile `parameter-manager` is active.
-* `com.google.cloud.parametermanager.v1.ParameterManagerClient` is on the classpath.
+* The `com.google.cloud:google-cloud-parameter-manager` dependency is on the classpath.
 
 [source,yaml]
 ----

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -139,6 +139,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-parametermanager</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-iamcredentials</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.config.server.config;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -58,6 +59,9 @@ import org.springframework.cloud.config.server.environment.CredhubEnvironmentRep
 import org.springframework.cloud.config.server.environment.CredhubEnvironmentRepositoryFactory;
 import org.springframework.cloud.config.server.environment.EnvironmentRepository;
 import org.springframework.cloud.config.server.environment.EnvironmentWatch;
+import org.springframework.cloud.config.server.environment.GoogleParameterManagerEnvironmentProperties;
+import org.springframework.cloud.config.server.environment.GoogleParameterManagerEnvironmentRepository;
+import org.springframework.cloud.config.server.environment.GoogleParameterManagerEnvironmentRepositoryFactory;
 import org.springframework.cloud.config.server.environment.GoogleSecretManagerEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.GoogleSecretManagerEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.GoogleSecretManagerEnvironmentRepositoryFactory;
@@ -122,13 +126,15 @@ import org.springframework.vault.core.VaultTemplate;
 		JdbcEnvironmentProperties.class, NativeEnvironmentProperties.class, VaultEnvironmentProperties.class,
 		RedisEnvironmentProperties.class, AwsS3EnvironmentProperties.class,
 		AwsSecretsManagerEnvironmentProperties.class, AwsParameterStoreEnvironmentProperties.class,
-		GoogleSecretManagerEnvironmentProperties.class, MongoDbEnvironmentProperties.class })
+		GoogleSecretManagerEnvironmentProperties.class, GoogleParameterManagerEnvironmentProperties.class,
+		MongoDbEnvironmentProperties.class })
 @Import({ CompositeRepositoryConfiguration.class, JdbcRepositoryConfiguration.class, VaultConfiguration.class,
 		SpringVaultRepositoryConfiguration.class, CredhubConfiguration.class, CredhubRepositoryConfiguration.class,
 		SvnRepositoryConfiguration.class, NativeRepositoryConfiguration.class, GitRepositoryConfiguration.class,
 		RedisRepositoryConfiguration.class, GoogleCloudSourceConfiguration.class, AwsS3RepositoryConfiguration.class,
 		AwsSecretsManagerRepositoryConfiguration.class, AwsParameterStoreRepositoryConfiguration.class,
-		GoogleSecretManagerRepositoryConfiguration.class, MongoRepositoryConfiguration.class,
+		GoogleSecretManagerRepositoryConfiguration.class, GoogleParameterManagerRepositoryConfiguration.class,
+		MongoRepositoryConfiguration.class,
 		// DefaultRepositoryConfiguration must be last
 		DefaultRepositoryConfiguration.class })
 public class EnvironmentRepositoryConfiguration {
@@ -280,6 +286,17 @@ public class EnvironmentRepositoryConfiguration {
 		public GoogleSecretManagerEnvironmentRepositoryFactory googleSecretManagerEnvironmentRepositoryFactory(
 				ObjectProvider<HttpServletRequest> request) {
 			return new GoogleSecretManagerEnvironmentRepositoryFactory(request);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(ParameterManagerClient.class)
+	static class GoogleParameterManagerFactoryConfig {
+
+		@Bean
+		public GoogleParameterManagerEnvironmentRepositoryFactory googleParameterManagerEnvironmentRepositoryFactory() {
+			return new GoogleParameterManagerEnvironmentRepositoryFactory();
 		}
 
 	}
@@ -557,6 +574,20 @@ class GoogleSecretManagerRepositoryConfiguration {
 	public GoogleSecretManagerEnvironmentRepository googleSecretManagerEnvironmentRepository(
 			GoogleSecretManagerEnvironmentRepositoryFactory factory,
 			GoogleSecretManagerEnvironmentProperties environmentProperties) throws Exception {
+		return factory.build(environmentProperties);
+	}
+
+}
+
+@Configuration(proxyBeanMethods = false)
+@Profile("parameter-manager")
+@ConditionalOnClass(ParameterManagerClient.class)
+class GoogleParameterManagerRepositoryConfiguration {
+
+	@Bean
+	public GoogleParameterManagerEnvironmentRepository googleParameterManagerEnvironmentRepository(
+			GoogleParameterManagerEnvironmentRepositoryFactory factory,
+			GoogleParameterManagerEnvironmentProperties environmentProperties) throws Exception {
 		return factory.build(environmentProperties);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -295,8 +295,9 @@ public class EnvironmentRepositoryConfiguration {
 	static class GoogleParameterManagerFactoryConfig {
 
 		@Bean
-		public GoogleParameterManagerEnvironmentRepositoryFactory googleParameterManagerEnvironmentRepositoryFactory() {
-			return new GoogleParameterManagerEnvironmentRepositoryFactory();
+		public GoogleParameterManagerEnvironmentRepositoryFactory googleParameterManagerEnvironmentRepositoryFactory(
+				ConfigServerProperties server) {
+			return new GoogleParameterManagerEnvironmentRepositoryFactory(server);
 		}
 
 	}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentProperties.java
@@ -33,6 +33,8 @@ public class GoogleParameterManagerEnvironmentProperties implements EnvironmentR
 
 	private String location = "global";
 
+	private String defaultLabel = "main";
+
 	private String projectId;
 
 	public void setOrder(int order) {
@@ -65,6 +67,14 @@ public class GoogleParameterManagerEnvironmentProperties implements EnvironmentR
 
 	public void setLocation(String location) {
 		this.location = location;
+	}
+
+	public String getDefaultLabel() {
+		return this.defaultLabel;
+	}
+
+	public void setDefaultLabel(String defaultLabel) {
+		this.defaultLabel = defaultLabel;
 	}
 
 	public String getProjectId() {

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentProperties.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
+
+/**
+ * @author Yash Chauhan
+ */
+@ConfigurationProperties("spring.cloud.config.server.gcp-parameter-manager")
+public class GoogleParameterManagerEnvironmentProperties implements EnvironmentRepositoryProperties {
+
+	private int order = DEFAULT_ORDER;
+
+	private String applicationLabel = "application";
+
+	private String profileLabel = "profile";
+
+	private String location = "global";
+
+	private String projectId;
+
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	public int getOrder() {
+		return this.order;
+	}
+
+	public String getApplicationLabel() {
+		return this.applicationLabel;
+	}
+
+	public void setApplicationLabel(String applicationLabel) {
+		this.applicationLabel = applicationLabel;
+	}
+
+	public String getProfileLabel() {
+		return this.profileLabel;
+	}
+
+	public void setProfileLabel(String profileLabel) {
+		this.profileLabel = profileLabel;
+	}
+
+	public String getLocation() {
+		return this.location;
+	}
+
+	public void setLocation(String location) {
+		this.location = location;
+	}
+
+	public String getProjectId() {
+		return this.projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
@@ -26,13 +26,16 @@ import com.google.cloud.parametermanager.v1.RenderParameterVersionResponse;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Yash Chauhan
  */
-public class GoogleParameterManagerEnvironmentRepository implements EnvironmentRepository, Ordered {
+public class GoogleParameterManagerEnvironmentRepository implements EnvironmentRepository, Ordered, AutoCloseable {
+
+	private final ConfigServerProperties configServerProperties;
 
 	private final ParameterManagerClient parameterManagerClient;
 
@@ -41,36 +44,60 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 	private final int order;
 
 	public GoogleParameterManagerEnvironmentRepository(ParameterManagerClient parameterManagerClient,
-			GoogleParameterManagerEnvironmentProperties properties) {
+			GoogleParameterManagerEnvironmentProperties properties, ConfigServerProperties configServerProperties) {
 
 		this.parameterManagerClient = parameterManagerClient;
 		this.properties = properties;
+		this.configServerProperties = configServerProperties;
 		this.order = properties.getOrder();
 	}
 
 	@Override
 	public Environment findOne(String application, String profile, String label) {
 		if (!StringUtils.hasText(label)) {
-			label = "master";
+			label = this.properties.getDefaultLabel();
 		}
+
+		String defaultProfile = this.configServerProperties.getDefaultProfile();
 
 		if (!StringUtils.hasText(profile)) {
-			profile = "default";
+			profile = defaultProfile;
 		}
 
-		if (!profile.startsWith("default")) {
-			profile = "default," + profile;
+		if (!profile.startsWith(defaultProfile)) {
+			profile = defaultProfile + "," + profile;
 		}
 
 		String[] profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
 
-		Environment result = new Environment(application, profile, label, null, null);
+		String applications = application;
+		if (!"application".equals(application)) {
+			applications = "application," + application;
+		}
+
+		String[] applicationNames = StringUtils
+			.trimArrayElements(StringUtils.commaDelimitedListToStringArray(applications));
+
+		Environment result = new Environment(application, profiles, label, null, null);
 
 		try {
-			for (String profileUnit : profiles) {
-				Map<String, String> parameters = getParameters(this.parameterManagerClient, application, profileUnit);
-				if (!parameters.isEmpty()) {
-					result.add(new PropertySource("gpm:" + application + "-" + profileUnit, parameters));
+			String projectId = this.properties.getProjectId();
+			if (!StringUtils.hasText(projectId)) {
+				throw new IllegalStateException("Google Cloud project ID must be configured");
+			}
+
+			LocationName locationName = LocationName.of(projectId, this.properties.getLocation());
+
+			Iterable<Parameter> parameterList = this.parameterManagerClient.listParameters(locationName).iterateAll();
+
+			for (String applicationName : applicationNames) {
+				for (String profileUnit : profiles) {
+					Map<String, String> parameters = getParameters(parameterList, applicationName, profileUnit,
+							projectId);
+
+					if (!parameters.isEmpty()) {
+						result.add(new PropertySource("gpm:" + applicationName + "-" + profileUnit, parameters));
+					}
 				}
 			}
 		}
@@ -81,27 +108,23 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 		return result;
 	}
 
-	private Map<String, String> getParameters(ParameterManagerClient client, String application, String profile) {
+	private Map<String, String> getParameters(Iterable<Parameter> parameterList, String application, String profile,
+			String projectId) {
+
 		Map<String, String> result = new HashMap<>();
 
-		String projectId = properties.getProjectId();
-		if (!StringUtils.hasText(projectId)) {
-			throw new IllegalStateException("Google Cloud project ID must be configured");
-		}
-
-		LocationName locationName = LocationName.of(projectId, properties.getLocation());
-
-		for (Parameter parameter : client.listParameters(locationName).iterateAll()) {
-			if (parameter.getLabelsOrDefault(properties.getApplicationLabel(), "application")
+		for (Parameter parameter : parameterList) {
+			if (parameter.getLabelsOrDefault(this.properties.getApplicationLabel(), "application")
 				.equalsIgnoreCase(application)
-					&& parameter.getLabelsOrDefault(properties.getProfileLabel(), "profile")
+					&& parameter.getLabelsOrDefault(this.properties.getProfileLabel(), "profile")
 						.equalsIgnoreCase(profile)) {
 
-				RenderParameterVersionResponse response = client
+				RenderParameterVersionResponse response = this.parameterManagerClient
 					.renderParameterVersion(parameter.getName() + "/versions/latest");
 
 				String parameterName = parameter.getName();
-				String prefix = "projects/" + projectId + "/locations/" + properties.getLocation() + "/parameters/";
+				String prefix = "projects/" + projectId + "/locations/" + this.properties.getLocation()
+						+ "/parameters/";
 
 				if (parameterName.startsWith(prefix)) {
 					parameterName = parameterName.substring(prefix.length());
@@ -116,7 +139,12 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 
 	@Override
 	public int getOrder() {
-		return order;
+		return this.order;
+	}
+
+	@Override
+	public void close() {
+		this.parameterManagerClient.close();
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.cloud.parametermanager.v1.LocationName;
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.RenderParameterVersionResponse;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Yash Chauhan
+ */
+public class GoogleParameterManagerEnvironmentRepository implements EnvironmentRepository, Ordered {
+
+	private final ParameterManagerClient parameterManagerClient;
+
+	private final GoogleParameterManagerEnvironmentProperties properties;
+
+	private final int order;
+
+	public GoogleParameterManagerEnvironmentRepository(ParameterManagerClient parameterManagerClient,
+			GoogleParameterManagerEnvironmentProperties properties) {
+
+		this.parameterManagerClient = parameterManagerClient;
+		this.properties = properties;
+		this.order = properties.getOrder();
+	}
+
+	@Override
+	public Environment findOne(String application, String profile, String label) {
+		if (!StringUtils.hasText(label)) {
+			label = "master";
+		}
+
+		if (!StringUtils.hasText(profile)) {
+			profile = "default";
+		}
+
+		if (!profile.startsWith("default")) {
+			profile = "default," + profile;
+		}
+
+		String[] profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+
+		Environment result = new Environment(application, profile, label, null, null);
+
+		try {
+			for (String profileUnit : profiles) {
+				Map<String, String> parameters = getParameters(this.parameterManagerClient, application, profileUnit);
+				if (!parameters.isEmpty()) {
+					result.add(new PropertySource("gpm:" + application + "-" + profileUnit, parameters));
+				}
+			}
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException("Could not access Google Cloud Parameter Manager", ex);
+		}
+
+		return result;
+	}
+
+	private Map<String, String> getParameters(ParameterManagerClient client, String application, String profile) {
+		Map<String, String> result = new HashMap<>();
+
+		String projectId = properties.getProjectId();
+		if (!StringUtils.hasText(projectId)) {
+			throw new IllegalStateException("Google Cloud project ID must be configured");
+		}
+
+		LocationName locationName = LocationName.of(projectId, properties.getLocation());
+
+		for (Parameter parameter : client.listParameters(locationName).iterateAll()) {
+			if (parameter.getLabelsOrDefault(properties.getApplicationLabel(), "application")
+				.equalsIgnoreCase(application)
+					&& parameter.getLabelsOrDefault(properties.getProfileLabel(), "profile")
+						.equalsIgnoreCase(profile)) {
+
+				RenderParameterVersionResponse response = client
+					.renderParameterVersion(parameter.getName() + "/versions/latest");
+
+				String parameterName = parameter.getName();
+				String prefix = "projects/" + projectId + "/locations/" + properties.getLocation() + "/parameters/";
+
+				if (parameterName.startsWith(prefix)) {
+					parameterName = parameterName.substring(prefix.length());
+				}
+
+				result.put(parameterName, response.getRenderedPayload().toStringUtf8());
+			}
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getOrder() {
+		return order;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepository.java
@@ -16,13 +16,18 @@
 
 package org.springframework.cloud.config.server.environment;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.cloud.parametermanager.v1.LocationName;
 import com.google.cloud.parametermanager.v1.Parameter;
 import com.google.cloud.parametermanager.v1.ParameterManagerClient;
 import com.google.cloud.parametermanager.v1.RenderParameterVersionResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -34,6 +39,8 @@ import org.springframework.util.StringUtils;
  * @author Yash Chauhan
  */
 public class GoogleParameterManagerEnvironmentRepository implements EnvironmentRepository, Ordered, AutoCloseable {
+
+	private static final Log log = LogFactory.getLog(GoogleParameterManagerEnvironmentRepository.class);
 
 	private final ConfigServerProperties configServerProperties;
 
@@ -64,11 +71,12 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 			profile = defaultProfile;
 		}
 
-		if (!profile.startsWith(defaultProfile)) {
-			profile = defaultProfile + "," + profile;
-		}
-
 		String[] profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+
+		if (!Arrays.asList(profiles).contains(defaultProfile)) {
+			profile = defaultProfile + "," + profile;
+			profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+		}
 
 		String applications = application;
 		if (!"application".equals(application)) {
@@ -88,15 +96,22 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 
 			LocationName locationName = LocationName.of(projectId, this.properties.getLocation());
 
-			Iterable<Parameter> parameterList = this.parameterManagerClient.listParameters(locationName).iterateAll();
+			List<Parameter> parameterList = new ArrayList<>();
+			this.parameterManagerClient.listParameters(locationName).iterateAll().forEach(parameterList::add);
 
 			for (String applicationName : applicationNames) {
 				for (String profileUnit : profiles) {
-					Map<String, String> parameters = getParameters(parameterList, applicationName, profileUnit,
-							projectId);
+					try {
+						Map<String, String> parameters = getParameters(parameterList, applicationName, profileUnit,
+								projectId);
 
-					if (!parameters.isEmpty()) {
-						result.add(new PropertySource("gpm:" + applicationName + "-" + profileUnit, parameters));
+						if (!parameters.isEmpty()) {
+							result.add(new PropertySource("gpm:" + applicationName + "-" + profileUnit, parameters));
+						}
+					}
+					catch (Exception ex) {
+						log.warn("Could not retrieve parameters for application " + applicationName + " and profile "
+								+ profileUnit + ", continuing with the remaining combinations", ex);
 					}
 				}
 			}
@@ -104,7 +119,6 @@ public class GoogleParameterManagerEnvironmentRepository implements EnvironmentR
 		catch (Exception ex) {
 			throw new IllegalStateException("Could not access Google Cloud Parameter Manager", ex);
 		}
-
 		return result;
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryFactory.java
@@ -18,16 +18,25 @@ package org.springframework.cloud.config.server.environment;
 
 import com.google.cloud.parametermanager.v1.ParameterManagerClient;
 
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
 /**
  * @author Yash Chauhan
  */
 public class GoogleParameterManagerEnvironmentRepositoryFactory implements
 		EnvironmentRepositoryFactory<GoogleParameterManagerEnvironmentRepository, GoogleParameterManagerEnvironmentProperties> {
 
+	private final ConfigServerProperties configServerProperties;
+
+	public GoogleParameterManagerEnvironmentRepositoryFactory(ConfigServerProperties configServerProperties) {
+		this.configServerProperties = configServerProperties;
+	}
+
 	@Override
 	public GoogleParameterManagerEnvironmentRepository build(
 			GoogleParameterManagerEnvironmentProperties environmentProperties) throws Exception {
-		return new GoogleParameterManagerEnvironmentRepository(ParameterManagerClient.create(), environmentProperties);
+		return new GoogleParameterManagerEnvironmentRepository(ParameterManagerClient.create(), environmentProperties,
+				this.configServerProperties);
 	}
 
 }

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+
+/**
+ * @author Yash Chauhan
+ */
+public class GoogleParameterManagerEnvironmentRepositoryFactory implements
+		EnvironmentRepositoryFactory<GoogleParameterManagerEnvironmentRepository, GoogleParameterManagerEnvironmentProperties> {
+
+	@Override
+	public GoogleParameterManagerEnvironmentRepository build(
+			GoogleParameterManagerEnvironmentProperties environmentProperties) throws Exception {
+		return new GoogleParameterManagerEnvironmentRepository(ParameterManagerClient.create(), environmentProperties);
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.util.List;
+
+import com.google.cloud.parametermanager.v1.LocationName;
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.RenderParameterVersionResponse;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.cloud.config.environment.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GoogleParameterManagerEnvironmentRepositoryTests {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFindOne() {
+		ParameterManagerClient client = mock(ParameterManagerClient.class);
+
+		Parameter parameter = Parameter.newBuilder()
+			.setName("projects/test-project/locations/global/parameters/test-property")
+			.putLabels("application", "application")
+			.putLabels("profile", "default")
+			.build();
+
+		ParameterManagerClient.ListParametersPagedResponse parametersResponse = mock(
+				ParameterManagerClient.ListParametersPagedResponse.class);
+
+		when(parametersResponse.iterateAll()).thenReturn(List.of(parameter));
+		when(client.listParameters(any(LocationName.class))).thenReturn(parametersResponse);
+
+		RenderParameterVersionResponse renderResponse = RenderParameterVersionResponse.newBuilder()
+			.setRenderedPayload(ByteString.copyFromUtf8("test-value"))
+			.build();
+
+		when(client.renderParameterVersion(any(String.class))).thenReturn(renderResponse);
+
+		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
+		properties.setProjectId("test-project");
+
+		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
+				properties);
+
+		Environment environment = repository.findOne("application", "default", null);
+
+		assertThat(environment.getPropertySources()).hasSize(1);
+
+		assertThat(environment.getPropertySources().get(0).getSource().get("test-property")).isEqualTo("test-value");
+		Mockito.verify(client)
+			.renderParameterVersion("projects/test-project/locations/global/parameters/test-property/versions/latest");
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/GoogleParameterManagerEnvironmentRepositoryTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,38 +40,130 @@ public class GoogleParameterManagerEnvironmentRepositoryTests {
 	@SuppressWarnings("unchecked")
 	public void testFindOne() {
 		ParameterManagerClient client = mock(ParameterManagerClient.class);
-
 		Parameter parameter = Parameter.newBuilder()
 			.setName("projects/test-project/locations/global/parameters/test-property")
 			.putLabels("application", "application")
 			.putLabels("profile", "default")
 			.build();
-
 		ParameterManagerClient.ListParametersPagedResponse parametersResponse = mock(
 				ParameterManagerClient.ListParametersPagedResponse.class);
-
 		when(parametersResponse.iterateAll()).thenReturn(List.of(parameter));
 		when(client.listParameters(any(LocationName.class))).thenReturn(parametersResponse);
-
 		RenderParameterVersionResponse renderResponse = RenderParameterVersionResponse.newBuilder()
 			.setRenderedPayload(ByteString.copyFromUtf8("test-value"))
 			.build();
-
 		when(client.renderParameterVersion(any(String.class))).thenReturn(renderResponse);
-
 		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
 		properties.setProjectId("test-project");
-
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
 		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
-				properties);
-
+				properties, configServerProperties);
 		Environment environment = repository.findOne("application", "default", null);
-
+		assertThat(environment.getLabel()).isEqualTo("main");
 		assertThat(environment.getPropertySources()).hasSize(1);
-
 		assertThat(environment.getPropertySources().get(0).getSource().get("test-property")).isEqualTo("test-value");
 		Mockito.verify(client)
 			.renderParameterVersion("projects/test-project/locations/global/parameters/test-property/versions/latest");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFindOneWithCustomDefaultLabel() {
+		ParameterManagerClient client = mock(ParameterManagerClient.class);
+		ParameterManagerClient.ListParametersPagedResponse parametersResponse = mock(
+				ParameterManagerClient.ListParametersPagedResponse.class);
+		when(parametersResponse.iterateAll()).thenReturn(List.of());
+		when(client.listParameters(any(LocationName.class))).thenReturn(parametersResponse);
+		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
+		properties.setProjectId("test-project");
+		properties.setDefaultLabel("custom-default");
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
+				properties, configServerProperties);
+		Environment environment = repository.findOne("application", "default", null);
+		assertThat(environment.getLabel()).isEqualTo("custom-default");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFindOneIncludesDefaultApplication() {
+		ParameterManagerClient client = mock(ParameterManagerClient.class);
+		Parameter defaultApplicationParameter = Parameter.newBuilder()
+			.setName("projects/test-project/locations/global/parameters/default-property")
+			.putLabels("application", "application")
+			.putLabels("profile", "default")
+			.build();
+		Parameter applicationParameter = Parameter.newBuilder()
+			.setName("projects/test-project/locations/global/parameters/application-property")
+			.putLabels("application", "my-application")
+			.putLabels("profile", "default")
+			.build();
+		ParameterManagerClient.ListParametersPagedResponse parametersResponse = mock(
+				ParameterManagerClient.ListParametersPagedResponse.class);
+		when(parametersResponse.iterateAll()).thenReturn(List.of(defaultApplicationParameter, applicationParameter));
+		when(client.listParameters(any(LocationName.class))).thenReturn(parametersResponse);
+		when(client.renderParameterVersion(
+				"projects/test-project/locations/global/parameters/default-property/versions/latest"))
+			.thenReturn(RenderParameterVersionResponse.newBuilder()
+				.setRenderedPayload(ByteString.copyFromUtf8("default-value"))
+				.build());
+		when(client.renderParameterVersion(
+				"projects/test-project/locations/global/parameters/application-property/versions/latest"))
+			.thenReturn(RenderParameterVersionResponse.newBuilder()
+				.setRenderedPayload(ByteString.copyFromUtf8("application-value"))
+				.build());
+		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
+		properties.setProjectId("test-project");
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
+				properties, configServerProperties);
+		Environment environment = repository.findOne("my-application", "default", null);
+		assertThat(environment.getName()).isEqualTo("my-application");
+		assertThat(environment.getPropertySources()).hasSize(2);
+		assertThat(environment.getPropertySources().get(0).getSource().get("default-property"))
+			.isEqualTo("default-value");
+		assertThat(environment.getPropertySources().get(1).getSource().get("application-property"))
+			.isEqualTo("application-value");
+		Mockito.verify(client).listParameters(any(LocationName.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFindOneUsesConfiguredDefaultProfile() {
+		ParameterManagerClient client = mock(ParameterManagerClient.class);
+		Parameter parameter = Parameter.newBuilder()
+			.setName("projects/test-project/locations/global/parameters/test-property")
+			.putLabels("application", "application")
+			.putLabels("profile", "custom-default")
+			.build();
+		ParameterManagerClient.ListParametersPagedResponse parametersResponse = mock(
+				ParameterManagerClient.ListParametersPagedResponse.class);
+		when(parametersResponse.iterateAll()).thenReturn(List.of(parameter));
+		when(client.listParameters(any(LocationName.class))).thenReturn(parametersResponse);
+		when(client.renderParameterVersion(any(String.class))).thenReturn(RenderParameterVersionResponse.newBuilder()
+			.setRenderedPayload(ByteString.copyFromUtf8("test-value"))
+			.build());
+		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
+		properties.setProjectId("test-project");
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+		configServerProperties.setDefaultProfile("custom-default");
+		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
+				properties, configServerProperties);
+		Environment environment = repository.findOne("application", null, null);
+		assertThat(environment.getProfiles()).containsExactly("custom-default");
+		assertThat(environment.getPropertySources()).hasSize(1);
+		assertThat(environment.getPropertySources().get(0).getSource().get("test-property")).isEqualTo("test-value");
+	}
+
+	@Test
+	public void shouldCloseParameterManagerClient() {
+		ParameterManagerClient client = mock(ParameterManagerClient.class);
+		GoogleParameterManagerEnvironmentProperties properties = new GoogleParameterManagerEnvironmentProperties();
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+		GoogleParameterManagerEnvironmentRepository repository = new GoogleParameterManagerEnvironmentRepository(client,
+				properties, configServerProperties);
+		repository.close();
+		Mockito.verify(client).close();
 	}
 
 }


### PR DESCRIPTION
Fixes #2900

## Summary

Adds support for using Google Cloud Parameter Manager as an environment repository.

This change:

- Adds the Google Cloud Parameter Manager dependency.
- Adds configuration properties for project ID, location, parameter labels, and repository order.
- Adds `GoogleParameterManagerEnvironmentRepository`.
- Adds `GoogleParameterManagerEnvironmentRepositoryFactory`.
- Registers the repository when `ParameterManagerClient` is available.
- Loads parameters based on application and profile labels.
- Adds unit test coverage for parameter retrieval and rendering.

## Testing

```text
./mvnw.cmd -pl spring-cloud-config-server -Dtest=GoogleParameterManagerEnvironmentRepositoryTests test