### PR TITLE
Include the default application in the Redis backend

### DIFF
--- a/docs/modules/ROOT/pages/server/environment-repository/redis-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/redis-backend.adoc
@@ -46,7 +46,8 @@ HGETALL sample-app
 Properties that are shared by every application can be stored in a hash named `application`,
 optionally with a profile suffix such as `application-dev`, in the same way as `application.yml`
 is used with the Git backend. Values found in the hash of the requested application take
-precedence over the shared ones.
+precedence over the shared ones. A comma-delimited application name such as `app1,app2` reads
+every listed hash, with later names taking precedence over earlier ones.
 
 NOTE: When no profile is specified `default` will be used.
 

--- a/docs/modules/ROOT/pages/server/environment-repository/redis-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/redis-backend.adoc
@@ -43,5 +43,10 @@ HGETALL sample-app
 }
 ----
 
+Properties that are shared by every application can be stored in a hash named `application`,
+optionally with a profile suffix such as `application-dev`, in the same way as `application.yml`
+is used with the Git backend. Values found in the hash of the requested application take
+precedence over the shared ones.
+
 NOTE: When no profile is specified `default` will be used.
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepository.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.config.server.environment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,8 @@ import org.springframework.util.StringUtils;
  * @author KNV Srinivas
  */
 public class RedisEnvironmentRepository implements EnvironmentRepository, Ordered {
+
+	private static final String DEFAULT_APPLICATION = "application";
 
 	private final StringRedisTemplate redis;
 
@@ -59,10 +62,13 @@ public class RedisEnvironmentRepository implements EnvironmentRepository, Ordere
 	}
 
 	private List<String> addKeys(String application, List<String> profiles) {
-		List<String> keys = new ArrayList<>();
-		keys.add(application);
+		List<String> applications = new ArrayList<>(
+				new LinkedHashSet<>(Arrays.asList(DEFAULT_APPLICATION, application)));
+		List<String> keys = new ArrayList<>(applications);
 		for (String profile : profiles) {
-			keys.add(application + "-" + profile);
+			for (String app : applications) {
+				keys.add(app + "-" + profile);
+			}
 		}
 		Collections.reverse(keys);
 		return keys;

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepository.java
@@ -19,9 +19,10 @@ package org.springframework.cloud.config.server.environment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -62,8 +63,16 @@ public class RedisEnvironmentRepository implements EnvironmentRepository, Ordere
 	}
 
 	private List<String> addKeys(String application, List<String> profiles) {
-		List<String> applications = new ArrayList<>(
-				new LinkedHashSet<>(Arrays.asList(DEFAULT_APPLICATION, application)));
+		// Same normalisation as CredhubEnvironmentRepository: `application` may be null
+		// or comma-delimited, and the shared hash goes first so that every requested
+		// application ends up ahead of it once the keys are reversed below.
+		List<String> applications = Stream
+			.concat(Stream.of(DEFAULT_APPLICATION),
+					Arrays.stream(StringUtils.commaDelimitedListToStringArray(application)))
+			.map(String::trim)
+			.filter(StringUtils::hasText)
+			.distinct()
+			.collect(Collectors.toList());
 		List<String> keys = new ArrayList<>(applications);
 		for (String profile : profiles) {
 			for (String app : applications) {

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepositoryIntegrationTests.java
@@ -25,6 +25,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.test.TestConfigServerApplication;
 import org.springframework.data.redis.core.BoundHashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -67,6 +68,25 @@ public class RedisEnvironmentRepositoryIntegrationTests {
 		assertThat(env.getName()).isEqualTo("foo");
 		assertThat(env.getPropertySources()).isNotEmpty();
 		assertThat(env.getPropertySources().get(0).getSource().get("tag")).isEqualTo("myapp");
+	}
+
+	@Test
+	public void defaultApplicationIsIncluded() {
+		BoundHashOperations application = redis.boundHashOps("application");
+		application.put("name", "from-application");
+		application.put("shared", "from-application");
+		BoundHashOperations applicationProfile = redis.boundHashOps("application-prod");
+		applicationProfile.put("name", "from-application-prod");
+		BoundHashOperations app = redis.boundHashOps("myapp-prod");
+		app.put("name", "from-myapp-prod");
+
+		Environment env = new RedisEnvironmentRepository(redis, new RedisEnvironmentProperties()).findOne("myapp",
+				"prod", "");
+
+		assertThat(env.getPropertySources().stream().map(PropertySource::getName)).containsExactly("redis:myapp-prod",
+				"redis:application-prod", "redis:myapp", "redis:application");
+		assertThat(env.getPropertySources().get(0).getSource().get("name")).isEqualTo("from-myapp-prod");
+		assertThat(env.getPropertySources().get(3).getSource().get("shared")).isEqualTo("from-application");
 	}
 
 }

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepositoryIntegrationTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/RedisEnvironmentRepositoryIntegrationTests.java
@@ -89,4 +89,29 @@ public class RedisEnvironmentRepositoryIntegrationTests {
 		assertThat(env.getPropertySources().get(3).getSource().get("shared")).isEqualTo("from-application");
 	}
 
+	@Test
+	public void nullApplicationFallsBackToTheDefaultApplication() {
+		redis.boundHashOps("application").put("name", "from-application");
+
+		Environment env = new RedisEnvironmentRepository(redis, new RedisEnvironmentProperties()).findOne(null, "prod",
+				"");
+
+		assertThat(env.getPropertySources().stream().map(PropertySource::getName))
+			.containsExactly("redis:application-prod", "redis:application");
+		assertThat(env.getPropertySources().get(1).getSource().get("name")).isEqualTo("from-application");
+	}
+
+	@Test
+	public void commaDelimitedApplicationsAreAllIncludedLastOneFirst() {
+		redis.boundHashOps("app1").put("name", "from-app1");
+		redis.boundHashOps("app2").put("name", "from-app2");
+
+		Environment env = new RedisEnvironmentRepository(redis, new RedisEnvironmentProperties())
+			.findOne("app1, app2,app1", "prod", "");
+
+		assertThat(env.getPropertySources().stream().map(PropertySource::getName)).containsExactly("redis:app2-prod",
+				"redis:app1-prod", "redis:application-prod", "redis:app2", "redis:app1", "redis:application");
+		assertThat(env.getPropertySources().get(3).getSource().get("name")).isEqualTo("from-app2");
+	}
+
 }


### PR DESCRIPTION
`RedisEnvironmentRepository` only reads the hashes named after the requested application (`app`, `app-<profile>`), so properties under the shared `application` key are never returned. The other backends include them: jdbc, mongodb, credhub, native and aws-s3.

This adds the default application keys, ordered the way jdbc and credhub do, so the requested application still wins over the shared defaults: `app-p2`, `application-p2`, `app-p1`, `application-p1`, `app`, `application`. When the requested application is `application` the key list is unchanged.

New test in `RedisEnvironmentRepositoryIntegrationTests`: on 5.0.x it fails with `["redis:myapp-prod", "redis:myapp"]` and passes with the change.

Fixes gh-3134
