### PR TITLE
Add Azure Key Vault environment repository

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,6 +14,7 @@
 *** xref:server/environment-repository/aws-s3-backend.adoc[]
 *** xref:server/environment-repository/aws-parameter-store-backend.adoc[]
 *** xref:server/environment-repository/aws-secrets-manager-backend.adoc[]
+*** xref:server/environment-repository/azure-key-vault-backend.adoc[]
 *** xref:server/environment-repository/gcp-secret-manager-backend.adoc[]
 *** xref:server/environment-repository/credhub-backend.adoc[]
 *** xref:server/environment-repository/mongo-backend.adoc[]

--- a/docs/modules/ROOT/pages/server/environment-repository/azure-key-vault-backend.adoc
+++ b/docs/modules/ROOT/pages/server/environment-repository/azure-key-vault-backend.adoc
@@ -1,0 +1,126 @@
+[[azure-key-vault-backend]]
+= Azure Key Vault Backend
+
+Spring Cloud Config Server supports link:https://azure.microsoft.com/products/key-vault/[Azure Key Vault] as a backend for configuration properties.
+
+You can enable this feature by adding the Azure Key Vault Secrets dependency to your application.
+
+[source,xml,indent=0]
+.pom.xml
+----
+<dependency>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-security-keyvault-secrets</artifactId>
+</dependency>
+----
+
+The following configuration uses Azure Key Vault to access secrets.
+
+[source,yaml]
+----
+spring:
+  profiles:
+    active: azurekeyvault
+  cloud:
+    config:
+      server:
+        azure-keyvault:
+          vault-uri: https://my-vault.vault.azure.net/
+          prefix: ""
+          profile-separator: "-"
+          property-separator: "--"
+          origin: "azure:keyvault:"
+----
+
+== Secret Naming
+
+Azure Key Vault secret names are mapped to Spring configuration property names using the configured `profile-separator` and `property-separator`.
+
+With the default configuration:
+
+[source,yaml]
+----
+profile-separator: "-"
+property-separator: "--"
+----
+
+A secret for an application and profile follows this pattern:
+
+----
+{application}-{profile}-{property-name}
+----
+
+For example:
+
+----
+foo-default-s3--accessKey
+----
+
+is exposed as:
+
+[source,properties]
+----
+s3.accessKey=<secret-value>
+----
+
+Secrets that are not associated with a specific profile follow this pattern:
+
+----
+{application}-{property-name}
+----
+
+For example:
+
+----
+foo-s3--accessKey
+----
+
+is also exposed as:
+
+[source,properties]
+----
+s3.accessKey=<secret-value>
+----
+
+Azure Key Vault authentication uses Azure Identity's `DefaultAzureCredential`.
+
+.Azure Key Vault Configuration Properties
+|===
+|Property Name |Required |Default Value |Remarks
+
+|*vault-uri*
+|yes
+|
+|The URI of the Azure Key Vault.
+
+|*prefix*
+|no
+|``
+|The prefix used for Azure Key Vault secret names.
+
+|*profile-separator*
+|no
+|`-`
+|String that separates the application and profile in secret names.
+
+|*property-separator*
+|no
+|`--`
+|String used to represent dots in property names stored in Azure Key Vault.
+
+|*origin*
+|no
+|`azure:keyvault:`
+|The prefix added to the property source name to show its provenance.
+
+|*order*
+|no
+|`Ordered.LOWEST_PRECEDENCE`
+|The order of the environment repository.
+
+|===
+
+[NOTE]
+====
+When no application is specified, `application` is used as the default application, and when no profile is specified, `default` is used.
+====

--- a/spring-cloud-config-dependencies/pom.xml
+++ b/spring-cloud-config-dependencies/pom.xml
@@ -18,9 +18,18 @@
 		<jgit.version>7.4.0.202509020913-r</jgit.version>
 		<spring-vault.version>4.0.3</spring-vault.version>
 		<spring-credhub.version>3.5.1</spring-credhub.version>
+
+		<azure-sdk-bom.version>1.3.8</azure-sdk-bom.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>com.azure</groupId>
+				<artifactId>azure-sdk-bom</artifactId>
+				<version>${azure-sdk-bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-config</artifactId>

--- a/spring-cloud-config-server/pom.xml
+++ b/spring-cloud-config-server/pom.xml
@@ -123,6 +123,17 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-security-keyvault-secrets</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-identity</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/config/EnvironmentRepositoryConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.config.server.config;
 import java.util.List;
 import java.util.Optional;
 
+import com.azure.security.keyvault.secrets.SecretClient;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -49,6 +50,9 @@ import org.springframework.cloud.config.server.environment.AwsS3EnvironmentRepos
 import org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentProperties;
 import org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.AwsSecretsManagerEnvironmentRepositoryFactory;
+import org.springframework.cloud.config.server.environment.AzureKeyVaultEnvironmentProperties;
+import org.springframework.cloud.config.server.environment.AzureKeyVaultEnvironmentRepository;
+import org.springframework.cloud.config.server.environment.AzureKeyVaultEnvironmentRepositoryFactory;
 import org.springframework.cloud.config.server.environment.CompositeEnvironmentRepository;
 import org.springframework.cloud.config.server.environment.ConfigTokenProvider;
 import org.springframework.cloud.config.server.environment.ConfigurableHttpConnectionFactory;
@@ -122,13 +126,15 @@ import org.springframework.vault.core.VaultTemplate;
 		JdbcEnvironmentProperties.class, NativeEnvironmentProperties.class, VaultEnvironmentProperties.class,
 		RedisEnvironmentProperties.class, AwsS3EnvironmentProperties.class,
 		AwsSecretsManagerEnvironmentProperties.class, AwsParameterStoreEnvironmentProperties.class,
-		GoogleSecretManagerEnvironmentProperties.class, MongoDbEnvironmentProperties.class })
+		AzureKeyVaultEnvironmentProperties.class, GoogleSecretManagerEnvironmentProperties.class,
+		MongoDbEnvironmentProperties.class })
 @Import({ CompositeRepositoryConfiguration.class, JdbcRepositoryConfiguration.class, VaultConfiguration.class,
 		SpringVaultRepositoryConfiguration.class, CredhubConfiguration.class, CredhubRepositoryConfiguration.class,
 		SvnRepositoryConfiguration.class, NativeRepositoryConfiguration.class, GitRepositoryConfiguration.class,
 		RedisRepositoryConfiguration.class, GoogleCloudSourceConfiguration.class, AwsS3RepositoryConfiguration.class,
 		AwsSecretsManagerRepositoryConfiguration.class, AwsParameterStoreRepositoryConfiguration.class,
-		GoogleSecretManagerRepositoryConfiguration.class, MongoRepositoryConfiguration.class,
+		AzureKeyVaultRepositoryConfiguration.class, GoogleSecretManagerRepositoryConfiguration.class,
+		MongoRepositoryConfiguration.class,
 		// DefaultRepositoryConfiguration must be last
 		DefaultRepositoryConfiguration.class })
 public class EnvironmentRepositoryConfiguration {
@@ -236,6 +242,18 @@ public class EnvironmentRepositoryConfiguration {
 		public AwsSecretsManagerEnvironmentRepositoryFactory awsSecretsManagerEnvironmentRepositoryFactory(
 				ConfigServerProperties configServerProperties) {
 			return new AwsSecretsManagerEnvironmentRepositoryFactory(configServerProperties);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(SecretClient.class)
+	static class AzureKeyVaultFactoryConfig {
+
+		@Bean
+		public AzureKeyVaultEnvironmentRepositoryFactory azureKeyVaultEnvironmentRepositoryFactory(
+				ConfigServerProperties configServerProperties) {
+			return new AzureKeyVaultEnvironmentRepositoryFactory(configServerProperties);
 		}
 
 	}
@@ -443,6 +461,20 @@ class AwsSecretsManagerRepositoryConfiguration {
 	public AwsSecretsManagerEnvironmentRepository awsSecretsManagerEnvironmentRepository(
 			AwsSecretsManagerEnvironmentRepositoryFactory factory,
 			AwsSecretsManagerEnvironmentProperties environmentProperties) {
+		return factory.build(environmentProperties);
+	}
+
+}
+
+@Configuration(proxyBeanMethods = false)
+@Profile("azurekeyvault")
+class AzureKeyVaultRepositoryConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(AzureKeyVaultEnvironmentRepository.class)
+	public AzureKeyVaultEnvironmentRepository azureKeyVaultEnvironmentRepository(
+			AzureKeyVaultEnvironmentRepositoryFactory factory,
+			AzureKeyVaultEnvironmentProperties environmentProperties) {
 		return factory.build(environmentProperties);
 	}
 

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentProperties.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentProperties.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.config.server.support.EnvironmentRepositoryProperties;
+
+/**
+ * Configuration properties for the Azure Key Vault environment repository.
+ *
+ * @author Yash Chauhan
+ */
+@ConfigurationProperties("spring.cloud.config.server.azure-keyvault")
+public class AzureKeyVaultEnvironmentProperties implements EnvironmentRepositoryProperties {
+
+	private static final String DEFAULT_PROFILE_SEPARATOR = "-";
+
+	private static final String DEFAULT_PROPERTY_SEPARATOR = "--";
+
+	private static final String DEFAULT_ORIGIN = "azure:keyvault:";
+
+	/**
+	 * The URI of the Azure Key Vault.
+	 */
+	@NotBlank
+	private String vaultUri;
+
+	/**
+	 * The prefix used for Azure Key Vault secret names.
+	 */
+	private String prefix = "";
+
+	/**
+	 * String that separates the application, profile, and property name.
+	 */
+	@NotBlank
+	@Pattern(regexp = "[a-zA-Z0-9._-]+")
+	private String profileSeparator = DEFAULT_PROFILE_SEPARATOR;
+
+	/**
+	 * String used to represent dots in property names stored in Azure Key Vault.
+	 */
+	@NotBlank
+	private String propertySeparator = DEFAULT_PROPERTY_SEPARATOR;
+
+	/**
+	 * Prefix indicating the origin of the property.
+	 */
+	@NotNull
+	private String origin = DEFAULT_ORIGIN;
+
+	/**
+	 * The order of the environment repository.
+	 */
+	private int order = DEFAULT_ORDER;
+
+	public String getVaultUri() {
+		return this.vaultUri;
+	}
+
+	public void setVaultUri(String vaultUri) {
+		this.vaultUri = vaultUri;
+	}
+
+	public String getPrefix() {
+		return this.prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String getProfileSeparator() {
+		return this.profileSeparator;
+	}
+
+	public void setProfileSeparator(String profileSeparator) {
+		this.profileSeparator = profileSeparator;
+	}
+
+	public String getPropertySeparator() {
+		return this.propertySeparator;
+	}
+
+	public void setPropertySeparator(String propertySeparator) {
+		this.propertySeparator = propertySeparator;
+	}
+
+	public String getOrigin() {
+		return this.origin;
+	}
+
+	public void setOrigin(String origin) {
+		this.origin = origin;
+	}
+
+	public int getOrder() {
+		return this.order;
+	}
+
+	@Override
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepository.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
+
+/**
+ * Environment repository backed by Azure Key Vault.
+ *
+ * @author Yash Chauhan
+ */
+public class AzureKeyVaultEnvironmentRepository implements EnvironmentRepository, Ordered {
+
+	private final SecretClient secretClient;
+
+	private final ConfigServerProperties configServerProperties;
+
+	private final AzureKeyVaultEnvironmentProperties environmentProperties;
+
+	private final int order;
+
+	public AzureKeyVaultEnvironmentRepository(SecretClient secretClient, ConfigServerProperties configServerProperties,
+			AzureKeyVaultEnvironmentProperties environmentProperties) {
+
+		this.secretClient = secretClient;
+		this.configServerProperties = configServerProperties;
+		this.environmentProperties = environmentProperties;
+		this.order = environmentProperties.getOrder();
+	}
+
+	@Override
+	public Environment findOne(String application, String profile, String label) {
+
+		String defaultApplication = this.configServerProperties.getDefaultApplicationName();
+		String defaultProfile = this.configServerProperties.getDefaultProfile();
+
+		if (!StringUtils.hasLength(application)) {
+			application = defaultApplication;
+		}
+
+		if (!StringUtils.hasLength(profile)) {
+			profile = defaultProfile;
+		}
+
+		String[] profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(profile));
+
+		Environment result = new Environment(application, profiles, label, null, null);
+
+		List<String> reversedProfiles = new ArrayList<>(Arrays.asList(profiles));
+		Collections.reverse(reversedProfiles);
+
+		if (!reversedProfiles.contains(defaultProfile)) {
+			reversedProfiles.add(defaultProfile);
+		}
+
+		List<String> applications = new ArrayList<>(
+				Arrays.asList(StringUtils.commaDelimitedListToStringArray(application)));
+
+		Collections.reverse(applications);
+
+		if (!applications.contains(defaultApplication)) {
+			applications.add(defaultApplication);
+		}
+
+		for (String profileName : reversedProfiles) {
+			for (String applicationName : applications) {
+				addPropertySource(result, applicationName, profileName);
+			}
+		}
+
+		for (String applicationName : applications) {
+			addPropertySource(result, applicationName, null);
+		}
+
+		Map<String, String> overrides = this.configServerProperties.getOverrides();
+
+		if (!overrides.isEmpty()) {
+			result.add(new PropertySource("overrides", overrides));
+		}
+
+		return result;
+	}
+
+	private void addPropertySource(Environment environment, String application, String profile) {
+
+		Map<String, Object> properties = getSecrets(application, profile);
+
+		if (!properties.isEmpty()) {
+
+			String name = this.environmentProperties.getOrigin() + application;
+
+			if (profile != null) {
+				name += this.environmentProperties.getProfileSeparator() + profile;
+			}
+
+			environment.add(new PropertySource(name, properties));
+		}
+	}
+
+	private Map<String, Object> getSecrets(String application, String profile) {
+
+		Map<String, Object> result = new HashMap<>();
+
+		String prefix = this.environmentProperties.getPrefix();
+		String profileSeparator = this.environmentProperties.getProfileSeparator();
+
+		String secretPrefix;
+
+		if (profile == null) {
+			secretPrefix = prefix + application + profileSeparator;
+		}
+		else {
+			secretPrefix = prefix + application + profileSeparator + profile + profileSeparator;
+		}
+
+		PagedIterable<SecretProperties> secrets = this.secretClient.listPropertiesOfSecrets();
+
+		for (SecretProperties secretProperties : secrets) {
+
+			String secretName = secretProperties.getName();
+
+			if (!secretName.startsWith(secretPrefix)) {
+				continue;
+			}
+
+			KeyVaultSecret secret = this.secretClient.getSecret(secretName);
+
+			String propertyName = secretName.substring(secretPrefix.length())
+				.replace(this.environmentProperties.getPropertySeparator(), ".");
+
+			result.put(propertyName, secret.getValue());
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+}

--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepositoryFactory.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepositoryFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+/**
+ * Factory for creating an Azure Key Vault environment repository.
+ *
+ * @author Yash Chauhan
+ */
+public class AzureKeyVaultEnvironmentRepositoryFactory implements
+		EnvironmentRepositoryFactory<AzureKeyVaultEnvironmentRepository, AzureKeyVaultEnvironmentProperties> {
+
+	private final ConfigServerProperties configServerProperties;
+
+	public AzureKeyVaultEnvironmentRepositoryFactory(ConfigServerProperties configServerProperties) {
+		this.configServerProperties = configServerProperties;
+	}
+
+	@Override
+	public AzureKeyVaultEnvironmentRepository build(AzureKeyVaultEnvironmentProperties environmentProperties) {
+
+		SecretClient client = new SecretClientBuilder().vaultUrl(environmentProperties.getVaultUri())
+			.credential(new DefaultAzureCredentialBuilder().build())
+			.buildClient();
+
+		return new AzureKeyVaultEnvironmentRepository(client, this.configServerProperties, environmentProperties);
+	}
+
+}

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/AzureKeyVaultEnvironmentRepositoryTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.config.server.environment;
+
+import java.util.List;
+import java.util.Map;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.config.environment.Environment;
+import org.springframework.cloud.config.environment.PropertySource;
+import org.springframework.cloud.config.server.config.ConfigServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AzureKeyVaultEnvironmentRepositoryTests {
+
+	@Test
+	void shouldLoadSecretsForApplicationAndProfile() {
+		SecretClient secretClient = mock(SecretClient.class);
+
+		AzureKeyVaultEnvironmentProperties properties = new AzureKeyVaultEnvironmentProperties();
+
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+
+		SecretProperties secretProperties = mock(SecretProperties.class);
+
+		when(secretProperties.getName()).thenReturn("foo-default-s3--accessKey");
+
+		@SuppressWarnings("unchecked")
+		PagedIterable<SecretProperties> secrets = mock(PagedIterable.class);
+
+		when(secrets.iterator()).thenReturn(List.of(secretProperties).iterator());
+
+		KeyVaultSecret secret = mock(KeyVaultSecret.class);
+
+		when(secret.getValue()).thenReturn("test-value");
+
+		when(secretClient.listPropertiesOfSecrets()).thenReturn(secrets);
+
+		when(secretClient.getSecret("foo-default-s3--accessKey")).thenReturn(secret);
+
+		AzureKeyVaultEnvironmentRepository repository = new AzureKeyVaultEnvironmentRepository(secretClient,
+				configServerProperties, properties);
+
+		Environment environment = repository.findOne("foo", "default", null);
+
+		assertThat(environment.getPropertySources()).hasSize(1);
+
+		PropertySource propertySource = environment.getPropertySources().get(0);
+
+		assertThat((Map<String, Object>) propertySource.getSource()).containsEntry("s3.accessKey", "test-value");
+	}
+
+	@Test
+	void shouldIgnoreSecretsForDifferentApplicationOrProfile() {
+		SecretClient secretClient = mock(SecretClient.class);
+
+		AzureKeyVaultEnvironmentProperties properties = new AzureKeyVaultEnvironmentProperties();
+
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+
+		SecretProperties matchingSecret = mock(SecretProperties.class);
+
+		SecretProperties nonMatchingSecret = mock(SecretProperties.class);
+
+		when(matchingSecret.getName()).thenReturn("foo-default-s3--accessKey");
+
+		when(nonMatchingSecret.getName()).thenReturn("bar-default-s3--accessKey");
+
+		@SuppressWarnings("unchecked")
+		PagedIterable<SecretProperties> secrets = mock(PagedIterable.class);
+
+		when(secrets.iterator()).thenReturn(List.of(matchingSecret, nonMatchingSecret).iterator());
+
+		KeyVaultSecret secret = mock(KeyVaultSecret.class);
+
+		when(secret.getValue()).thenReturn("test-value");
+
+		when(secretClient.listPropertiesOfSecrets()).thenReturn(secrets);
+
+		when(secretClient.getSecret("foo-default-s3--accessKey")).thenReturn(secret);
+
+		AzureKeyVaultEnvironmentRepository repository = new AzureKeyVaultEnvironmentRepository(secretClient,
+				configServerProperties, properties);
+
+		Environment environment = repository.findOne("foo", "default", null);
+
+		PropertySource propertySource = environment.getPropertySources().get(0);
+
+		assertThat((Map<String, Object>) propertySource.getSource()).hasSize(1)
+			.containsEntry("s3.accessKey", "test-value");
+	}
+
+	@Test
+	void shouldUseConfiguredOrder() {
+		SecretClient secretClient = mock(SecretClient.class);
+
+		AzureKeyVaultEnvironmentProperties properties = new AzureKeyVaultEnvironmentProperties();
+
+		properties.setOrder(42);
+
+		ConfigServerProperties configServerProperties = new ConfigServerProperties();
+
+		AzureKeyVaultEnvironmentRepository repository = new AzureKeyVaultEnvironmentRepository(secretClient,
+				configServerProperties, properties);
+
+		assertThat(repository.getOrder()).isEqualTo(42);
+	}
+
+}


### PR DESCRIPTION
## Description

Adds Azure Key Vault support as an environment repository for Spring Cloud Config Server.

### Changes

- Added `AzureKeyVaultEnvironmentRepository`
- Added Azure Key Vault configuration properties
- Added repository factory and auto-configuration support
- Added Azure SDK dependencies and BOM management
- Added support for application and profile-based secret resolution
- Added property name conversion and configurable separators
- Added repository ordering support
- Added Azure Key Vault backend documentation and navigation entry
- Added unit tests for the Azure Key Vault environment repository

## Testing

- `.\mvnw.cmd -pl spring-cloud-config-server -Dtest=AzureKeyVaultEnvironmentRepositoryTests test`
- `.\mvnw.cmd -pl spring-cloud-config-server -DskipTests compile`
- `git diff --check`

All targeted Azure Key Vault tests pass successfully.

## Full Test Suite

The full `spring-cloud-config-server` test suite was also attempted, but on Windows it encounters JGit cleanup failures where `.git/objects/pack/*.pack` files cannot be deleted. These failures affect unrelated JGit-based tests.

## Related Issue

Fixes #2645