### PR TITLE
Restore empty YAML arrays in JSON and YAML config responses

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/EnvironmentController.java
@@ -20,10 +20,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
@@ -340,6 +342,28 @@ public class EnvironmentController {
 
 	private void postProcessProperties(Map<String, Object> propertiesMap) {
 		propertiesMap.keySet().removeIf(key -> key.equals("spring.profiles"));
+		restoreEmptyCollections(propertiesMap);
+	}
+
+	/**
+	 * Flattened YAML properties represent empty collections as an empty string (see
+	 * {@code YamlProcessor#buildFlattenedMap}). When rebuilding nested YAML/JSON, restore
+	 * those markers to empty lists unless indexed entries exist for the same prefix.
+	 */
+	private void restoreEmptyCollections(Map<String, Object> propertiesMap) {
+		Set<String> arrayPrefixes = new HashSet<>();
+		for (String key : propertiesMap.keySet()) {
+			int indexOfBracket = key.indexOf('[');
+			if (indexOfBracket > 0) {
+				arrayPrefixes.add(key.substring(0, indexOfBracket));
+			}
+		}
+		for (Entry<String, Object> entry : propertiesMap.entrySet()) {
+			String key = entry.getKey();
+			if (!key.contains("[") && "".equals(entry.getValue()) && !arrayPrefixes.contains(key)) {
+				entry.setValue(Collections.emptyList());
+			}
+		}
 	}
 
 	/**

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/EnvironmentControllerTests.java
@@ -184,6 +184,26 @@ class EnvironmentControllerTests {
 	}
 
 	@Test
+	public void emptyArrayInJson() throws Exception {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("network.urls", "");
+		this.environment.add(new PropertySource("one", map));
+		when(this.repository.findOne("foo", "bar", null, false)).thenReturn(this.environment);
+		String json = this.controller.jsonProperties("foo", "bar", false).getBody();
+		JSONAssert.assertEquals("{\"network\":{\"urls\":[]}}", json, JSONCompareMode.STRICT);
+	}
+
+	@Test
+	public void emptyArrayInYaml() throws Exception {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("network.urls", "");
+		this.environment.add(new PropertySource("one", map));
+		when(this.repository.findOne("foo", "bar", null, false)).thenReturn(this.environment);
+		String yaml = this.controller.yaml("foo", "bar", false).getBody();
+		assertThat(yaml).isEqualTo("network:\n  urls: []\n");
+	}
+
+	@Test
 	public void yamlWithBrackets() throws Exception {
 		Map<String, Object> map = new LinkedHashMap<String, Object>();
 		map.put("a.test", "e");

--- a/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
+++ b/spring-cloud-config-server/src/test/java/org/springframework/cloud/config/server/environment/NativeEnvironmentRepositoryTests.java
@@ -23,6 +23,8 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -30,6 +32,7 @@ import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
 import org.springframework.cloud.config.server.environment.SearchPathLocator.Locations;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -110,6 +113,26 @@ public class NativeEnvironmentRepositoryTests {
 		// gh-1778 property sources has the same name.
 		assertThat(environment.getPropertySources().get(0).getName())
 			.isNotEqualTo(environment.getPropertySources().get(1).getName());
+	}
+
+	@Test
+	public void emptyYamlArrayInJsonOutput() throws Exception {
+		this.repository.setSearchLocations("classpath:/test/empty-array");
+		Environment environment = this.repository.findOne("application", "default", "master");
+		EnvironmentRepository repository = new EnvironmentRepository() {
+			@Override
+			public Environment findOne(String application, String profile, String label) {
+				return environment;
+			}
+
+			@Override
+			public Environment findOne(String application, String profile, String label, boolean includeOrigin) {
+				return environment;
+			}
+		};
+		EnvironmentController controller = new EnvironmentController(repository);
+		ResponseEntity<String> json = controller.labelledJsonProperties("application", "default", "master", false);
+		JSONAssert.assertEquals("{\"network\":{\"urls\":[]}}", json.getBody(), JSONCompareMode.STRICT);
 	}
 
 	@Test

--- a/spring-cloud-config-server/src/test/resources/test/empty-array/application.yml
+++ b/spring-cloud-config-server/src/test/resources/test/empty-array/application.yml
@@ -1,0 +1,2 @@
+network:
+  urls: []


### PR DESCRIPTION
## Summary

- When config is loaded from YAML, Spring's flattened property representation stores empty collections as an empty string (`network.urls=`).
- Rebuilding nested JSON/YAML in `EnvironmentController` treated those values as literal empty strings, so `network.urls: []` was served as `"urls": ""`.
- After merging property sources, restore standalone empty-string entries (with no indexed `[n]` keys for the same prefix) back to empty lists before building nested JSON/YAML.

Fixes gh-2746

## Test plan

- [x] `./mvnw -pl spring-cloud-config-server test -Dtest=EnvironmentControllerTests,NativeEnvironmentRepositoryTests`
- [x] Added fixture `classpath:/test/empty-array/application.yml` with `network.urls: []`
- [x] Unit tests: `emptyArrayInJson`, `emptyArrayInYaml`
- [x] Integration-style test: `emptyYamlArrayInJsonOutput`

## Notes

Properties format cannot distinguish an intentional empty string scalar from an empty collection (both flatten to `key=`). This change follows the same convention Spring uses when flattening YAML (empty collection → empty string) and reverses it for structured JSON/YAML endpoints (and the shared flatten path used by `.properties`).